### PR TITLE
Keep benchmark data when deploying docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,3 +36,4 @@ jobs:
       - uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          keep_files: true


### PR DESCRIPTION
Currently the doc deploy [removes the bench data](https://github.com/mbrobbel/narrow/commit/271063ad76ba1ec888c8cd3c43554c9b44ce5fb3#diff-3089b146cea15f1c76bbdc5e356539ecf051e7e052c03083da42ff2c7151a718). By setting `keep_files: true` this should no longer happen. An uninteded side-effect is that outdated doc output is not removed, but we can always add a workaround when that becomes a problem.