### PR TITLE
Add offset to Bitmap for zero-copy slicing on non-byte boundaries

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,10 +1,11 @@
 status = [
     "Check (nightly)",
     "Test (nightly)",
-    "Rustfmt",
+    "Rustfmt (nightly)",
     "Clippy (nightly)",
-    "Miri",
-    "Rustdoc"
+    "Miri (nightly)",
+    "Rustdoc (nightly)",
+    "Bench (nightly)"
 ]
 delete_merged_branches = true
 timeout_sec = 600

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -4,8 +4,7 @@ status = [
     "Rustfmt (nightly)",
     "Clippy (nightly)",
     "Miri (nightly)",
-    "Rustdoc (nightly)",
-    "Bench (nightly)"
+    "Rustdoc (nightly)"
 ]
 delete_merged_branches = true
 timeout_sec = 600

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -8,14 +8,18 @@ on:
 
 jobs:
   run:
-    name: Run
+    name: Bench
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           override: true
       - run: cargo bench --bench narrow -- --output-format=bencher | tee output.txt
       - uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,12 +6,16 @@ jobs:
   rustdoc:
     name: Rustdoc
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           override: true
       - uses: actions-rs/cargo@v1.0.3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
       - uses: katyo/publish-crates@v1
         with:
           registry-token: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,12 +46,16 @@ jobs:
   rustfmt:
     name: Rustfmt
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           components: rustfmt
           override: true
       - uses: actions-rs/cargo@v1.0.3
@@ -82,12 +86,16 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           components: miri
           override: true
       - uses: actions-rs/cargo@v1.0.3
@@ -102,6 +110,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - nightly
     env:
       RUSTFLAGS: "-C instrument-coverage"
       RUSTDOCFLAGS: "-C instrument-coverage"
@@ -110,7 +122,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ matrix.rust }}
           components: llvm-tools-preview
           override: true
       - uses: actions-rs/cargo@v1.0.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,10 @@ categories = ["data-structures"]
 
 [features]
 default = ["nightly"]
-nightly = ["extend_one", "simd"]
+nightly = ["extend_one", "portable_simd", "trusted_len"]
 extend_one = []
-simd = []
+portable_simd = []
+trusted_len = []
 
 [dependencies]
 # narrow-derive = { version = "0.2.0", path = "narrow-derive" }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,9 @@
+format_code_in_doc_comments = true
+format_strings = true
+group_imports = "StdExternalCrate"
+hex_literal_case = "Lower"
+imports_granularity = "Crate"
+normalize_comments = true
+reorder_impl_items = true
+use_field_init_shorthand = true
+wrap_comments = true

--- a/src/bitmap/fmt.rs
+++ b/src/bitmap/fmt.rs
@@ -1,5 +1,6 @@
-use crate::buffer::Buffer;
 use std::fmt::{Display, Formatter, Result};
+
+use crate::buffer::Buffer;
 
 /// A slice wrapper with a [Display] implementation to format bytes as bits.
 pub(crate) struct BitsDisplay<'a>(&'a [u8]);

--- a/src/bitmap/iter.rs
+++ b/src/bitmap/iter.rs
@@ -1,10 +1,14 @@
-use std::{borrow::Borrow, iter::Take, slice};
+use std::{
+    borrow::Borrow,
+    iter::{Skip, Take},
+    slice,
+};
 
 /// An iterator over the bits in a Bitmap.
 ///
 /// This iterator returns boolean values that represent the bits stored in a
 /// Bitmap.
-pub type BitmapIter<'a> = Take<BitUnpacked<slice::Iter<'a, u8>, &'a u8>>;
+pub type BitmapIter<'a> = Take<Skip<BitUnpacked<slice::Iter<'a, u8>, &'a u8>>>;
 
 /// An iterator that packs boolean values as bits in bytes using
 /// least-significant bit (LSB) numbering.
@@ -57,6 +61,8 @@ where
         // One item is returned per 8 items in the inner iterator.
         (bytes_for_bits(lower), upper.map(bytes_for_bits))
     }
+
+    // todo(mb): advance_by, nth
 }
 
 // If the inner iterator is ExactSizeIterator, the bounds reported by
@@ -137,8 +143,11 @@ where
             upper.and_then(|upper| upper.checked_mul(8)),
         )
     }
+
+    // todo(mb): advance_by, nth
 }
 
+/// An [Iterator] extension trait for [BitUnpacked].
 pub trait BitUnpackedExt<T>
 where
     Self: Iterator<Item = T>,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,10 +1,11 @@
 //! Traits for memory buffers.
 
-use crate::Primitive;
 use std::{
     borrow::{Borrow, BorrowMut},
     mem, slice,
 };
+
+use crate::Primitive;
 
 /// A contiguous immutable memory buffer for data.
 ///
@@ -20,9 +21,9 @@ where
 {
     fn as_bytes(&self) -> &[u8] {
         // Safety:
-        // - The pointer returned by slice::as_ptr (via Borrow) points to
-        //   slice::len() consecutive properly initialized values of type T,
-        //   with size_of::<T> bytes per element.
+        // - The pointer returned by slice::as_ptr (via Borrow) points to slice::len()
+        //   consecutive properly initialized values of type T, with size_of::<T> bytes
+        //   per element.
         unsafe {
             slice::from_raw_parts(
                 self.borrow().as_ptr() as *const u8,
@@ -66,10 +67,6 @@ where
     Self: Buffer<T>,
     Self: FromIterator<T>,
 {
-    // type Uninit<U>;
-
-    // fn new_uninit(len: usize) -> &mut [MaybeUninit<T>]; //Self::Container<'_, MaybeUninit<T>>;
-    // think about pre-allocating for specific nr of elements with MaybeUninit
 }
 
 impl<T> BufferAlloc<T> for Vec<T> where T: Primitive {}
@@ -81,13 +78,13 @@ impl<T> BufferAlloc<T> for Box<[T]> where T: Primitive {}
 pub trait BufferExtend<T>
 where
     T: Primitive,
-    Self: Buffer<T> + Extend<T>,
+    Self: BufferMut<T> + Extend<T>,
 {
 }
 
 impl<T, U> BufferExtend<T> for U
 where
     T: Primitive,
-    U: Buffer<T> + Extend<T>,
+    U: BufferMut<T> + Extend<T>,
 {
 }

--- a/src/length.rs
+++ b/src/length.rs
@@ -1,6 +1,7 @@
 /// The length of a collection.
 pub trait Length {
-    /// Returns the number of elements in the collection, also referred to as its length.
+    /// Returns the number of elements in the collection, also referred to as
+    /// its length.
     fn len(&self) -> usize;
 
     /// Returns `true` if there are no elements in the collection.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
 #![deny(warnings)]
 #![feature(generic_associated_types)]
 #![cfg_attr(feature = "extend_one", feature(extend_one))]
-#![cfg_attr(feature = "simd", feature(portable_simd))]
+#![cfg_attr(feature = "portable_simd", feature(portable_simd))]
+#![cfg_attr(feature = "trusted_len", feature(trusted_len))]
 
 mod primitive;
 pub use primitive::Primitive;

--- a/src/null.rs
+++ b/src/null.rs
@@ -1,5 +1,6 @@
-use crate::Length;
 use std::ops::Not;
+
+use crate::Length;
 
 /// Null-ness of elements in a collection.
 pub trait Null: Length {
@@ -8,7 +9,8 @@ pub trait Null: Length {
         self.is_valid(index).map(Not::not)
     }
 
-    /// Returns `true` if the element at position `index` is null, without performing any bounds checking.
+    /// Returns `true` if the element at position `index` is null, without
+    /// performing any bounds checking.
     ///
     /// # Safety
     /// - The `index` must be in bounds.
@@ -28,7 +30,8 @@ pub trait Null: Length {
         (index < self.len()).then(|| unsafe { self.is_valid_unchecked(index) })
     }
 
-    /// Returns `true` if the element at position `index` is valid, without performing any bounds checking.
+    /// Returns `true` if the element at position `index` is valid, without
+    /// performing any bounds checking.
     ///
     /// # Safety
     /// - The `index` must be in bounds.

--- a/src/nullable/mod.rs
+++ b/src/nullable/mod.rs
@@ -70,12 +70,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    // use super::*;
+    use super::*;
 
     #[test]
     fn from_iter() {
-        // let input = [Some(1u32), Some(2), Some(3), Some(4), None, Some(42)];
-        // let nullable = input.into_iter().collect::<Nullable<Vec<_>, Vec<_>>>();
-        // assert_eq!(nullable.data_buffer(), &[1, 2, 3, 4, u32::default(), 42]);
+        let input = [Some(1u32), Some(2), Some(3), Some(4), None, Some(42)];
+        let nullable = input.into_iter().collect::<Nullable<Vec<_>, Vec<_>>>();
+        assert_eq!(nullable.data_buffer(), &[1, 2, 3, 4, u32::default(), 42]);
+        assert_eq!(nullable.validity.data_buffer(), &[0b00101111u8]);
     }
 }

--- a/src/offset/mod.rs
+++ b/src/offset/mod.rs
@@ -1,7 +1,8 @@
 //! Offsets for variable sized arrays.
 
-use crate::Primitive;
 use std::{num::TryFromIntError, ops::AddAssign};
+
+use crate::Primitive;
 
 /// Types representing offset values.
 ///


### PR DESCRIPTION
In addition to the offset field on a Bitmap:
- add a `rustfmt.toml` with some nightly features enabled
- modify some workflows to run with a nightly compiler
- implement Extend for Bitmap.