### PR TITLE
Ignore `dtolnay/rust-toolchain` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
bors r+