### PR TITLE
chore(ci): remove bors

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -1,3 +1,0 @@
-status = ["Check", "Test", "Rustfmt", "Clippy", "Miri", "Rustdoc", "Bench"]
-delete_merged_branches = true
-timeout_sec = 600

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
-      - trying
-      - staging
   pull_request:
+
+permissions:
+  actions: write
+  contents: read
 
 jobs:
   run:
@@ -14,6 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-bench-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo bench --bench narrow -- --output-format=bencher | tee output.txt
       - uses: actions/upload-artifact@v3
@@ -25,10 +39,13 @@ jobs:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [run]
+    needs: run
     environment:
       name: benchmark-results
       url: https://mbrobbel.github.io/narrow-benchmark-results/
+    permissions:
+      deployments: write
+      contents: write
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,8 @@ name: Docs
 on: [push, pull_request]
 
 permissions:
+  actions: write
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   rustdoc:
@@ -13,6 +12,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-docs-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo doc --no-deps
       - run: chmod -c -R +rX "target/doc"
@@ -27,13 +38,17 @@ jobs:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [rustdoc]
+    needs: rustdoc
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}/narrow
     concurrency:
       group: github-pages
       cancel-in-progress: true
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,28 @@ name: Test
 
 on: [push, pull_request]
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   msrv:
     name: Minimum supported Rust version
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-msrv-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@1.65.0
       - run: cargo check --all
 
@@ -16,6 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-check-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo check --all
 
@@ -24,6 +52,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@nightly
       - uses: dtolnay/rust-toolchain@stable
       - uses: dtolnay/install@master
@@ -47,6 +87,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -57,6 +109,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-miri-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@miri
       - run: cargo miri setup
       - run: cargo miri test
@@ -69,6 +133,18 @@ jobs:
       RUSTDOCFLAGS: "-C instrument-coverage"
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview


### PR DESCRIPTION
Bors is being deprecated so removing its config in this PR and preparing to automate releases via [cargo-smart-release](https://crates.io/crates/cargo-smart-release) + [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).