### PR TITLE
chore(ci): update release workflow to use `cargo-smart-release`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,31 +2,48 @@ name: Release
 
 on:
   push:
-    tags:
-      - "**"
+    branches:
+      - main
+
+permissions:
+  actions: write
+  contents: write
 
 jobs:
-  github:
-    name: GitHub
+  release:
+    name: Release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - run: hub release create -m ${{ github.ref_name }} ${{ github.ref_name }}
-
-  crates:
-    name: Crates.io
-    runs-on: ubuntu-latest
-    environment:
-      name: crates.io
-      url: https://crates.io/crates/narrow/${{ github.ref_name }}
+    concurrency: release
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-smart-release --locked
+      - run: cargo check --all
+      - run: cargo changelog --execute narrow
       - run: |
-          cargo publish -p narrow-derive
-          cargo publish -p narrow
-        env:
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - env:
+          GH_TOKEN: ${{ github.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+        run: |
+          cargo smart-release \
+            --update-crates-index \
+            --allow-fully-generated-changelogs \
+            --execute \
+            --no-changelog-preview \
+            --allow-dirty \
+            --verbose \
+            narrow

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,6 +148,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
+      - uses: dtolnay/install@master
+        with:
+          crate: cargo-expand
       - run: cargo build --all
       - run: cargo test --all
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,8 +148,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
-      - run: cargo build
-      - run: cargo test
+      - run: cargo build --all
+      - run: cargo test --all
         env:
           LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"
       - name: Install grcov


### PR DESCRIPTION
Replace the current release workflow that was based on pushing tags with one that uses [cargo-smart-release](https://crates.io/crates/cargo-smart-release) on pushes to main.