### PR TITLE
chore: remove workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace.package]
-version = "0.2.2"
 authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
 edition = "2021"
 rust-version = "1.65.0"


### PR DESCRIPTION
This is not supported with `cargo smart-release`.