### PR TITLE
chore(ci): cancel release if there is a failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,7 @@ jobs:
             --execute \
             --verbose \
             narrow
+      - if: failure()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh run cancel --repo ${{ github.repository }} ${{ github.run_id }}


### PR DESCRIPTION
If a release is not needed this prevents a failed status check. If the release failed for a different reason this also cancels it.