### PR TITLE
fix: add missing `BitmapRef`, `BitmapRefMut` and `ValidityBitmap` implementations

### DIFF
--- a/src/array/boolean.rs
+++ b/src/array/boolean.rs
@@ -2,7 +2,7 @@
 
 use super::Array;
 use crate::{
-    bitmap::Bitmap,
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     validity::Validity,
     Length,
@@ -92,6 +92,22 @@ where
     }
 }
 
+impl<Buffer: BufferType> BitmapRef for BooleanArray<true, Buffer> {
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.0.bitmap_ref()
+    }
+}
+
+impl<Buffer: BufferType> BitmapRefMut for BooleanArray<true, Buffer> {
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.0.bitmap_ref_mut()
+    }
+}
+
+impl<Buffer: BufferType> ValidityBitmap for BooleanArray<true, Buffer> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -116,10 +132,10 @@ mod tests {
         assert_eq!(array.0.data.is_null(1), Some(true));
         assert_eq!(array.0.data.is_valid(2), Some(true));
         assert_eq!(array.0.data.is_valid(3), Some(false));
-        assert_eq!(array.0.validity.is_valid(0), Some(true));
-        assert_eq!(array.0.validity.is_null(1), Some(true));
-        assert_eq!(array.0.validity.is_valid(2), Some(true));
-        assert_eq!(array.0.validity.is_valid(3), Some(true));
+        assert_eq!(array.is_valid(0), Some(true));
+        assert_eq!(array.is_null(1), Some(true));
+        assert_eq!(array.is_valid(2), Some(true));
+        assert_eq!(array.is_valid(3), Some(true));
         assert!(array.0.data.is_valid(4).is_none());
         assert_eq!(array.0.data.bitmap_ref().len(), array.len());
     }

--- a/src/array/fixed_size_primitive.rs
+++ b/src/array/fixed_size_primitive.rs
@@ -1,5 +1,6 @@
 use super::Array;
 use crate::{
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     validity::Validity,
     FixedSize, Length,
@@ -119,6 +120,22 @@ where
     }
 }
 
+impl<T: FixedSize, Buffer: BufferType> BitmapRef for FixedSizePrimitiveArray<T, true, Buffer> {
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.0.bitmap_ref()
+    }
+}
+
+impl<T: FixedSize, Buffer: BufferType> BitmapRefMut for FixedSizePrimitiveArray<T, true, Buffer> {
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.0.bitmap_ref_mut()
+    }
+}
+
+impl<T: FixedSize, Buffer: BufferType> ValidityBitmap for FixedSizePrimitiveArray<T, true, Buffer> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -143,6 +160,11 @@ mod tests {
         let input = [Some(1u64), None, Some(3), Some(4)];
         let array = input.iter().collect::<FixedSizePrimitiveArray<_, true>>();
         assert_eq!(array.0.buffer_ref().as_slice(), &[1, u64::default(), 3, 4]);
+        assert_eq!(array.is_valid(0), Some(true));
+        assert_eq!(array.is_null(1), Some(true));
+        assert_eq!(array.is_valid(2), Some(true));
+        assert_eq!(array.is_valid(3), Some(true));
+        assert_eq!(array.is_valid(4), None);
     }
 
     #[test]

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -1,7 +1,9 @@
 use super::{Array, ArrayType};
 use crate::{
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     validity::Validity,
+    Length,
 };
 
 /// Struct array types.
@@ -13,29 +15,55 @@ pub trait StructArrayType: ArrayType {
 pub struct StructArray<
     T: StructArrayType,
     const NULLABLE: bool = false,
-    BitmapBuffer: BufferType = VecBuffer,
->(<<T as StructArrayType>::Array<BitmapBuffer> as Validity<NULLABLE>>::Storage<BitmapBuffer>)
+    Buffer: BufferType = VecBuffer,
+>(<<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>)
 where
-    <T as StructArrayType>::Array<BitmapBuffer>: Validity<NULLABLE>;
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>;
 
-impl<T: StructArrayType, const NULLABLE: bool, BitmapBuffer: BufferType> Array
-    for StructArray<T, NULLABLE, BitmapBuffer>
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Array
+    for StructArray<T, NULLABLE, Buffer>
 where
-    <T as StructArrayType>::Array<BitmapBuffer>: Validity<NULLABLE>,
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
 {
 }
 
-impl<T: StructArrayType, U, const NULLABLE: bool, BitmapBuffer: BufferType> FromIterator<U>
-    for StructArray<T, NULLABLE, BitmapBuffer>
+impl<T: StructArrayType, U, const NULLABLE: bool, Buffer: BufferType> FromIterator<U>
+    for StructArray<T, NULLABLE, Buffer>
 where
-    <T as StructArrayType>::Array<BitmapBuffer>: Validity<NULLABLE>,
-    <<T as StructArrayType>::Array<BitmapBuffer> as Validity<NULLABLE>>::Storage<BitmapBuffer>:
-        FromIterator<U>,
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>: FromIterator<U>,
 {
     fn from_iter<I: IntoIterator<Item = U>>(iter: I) -> Self {
         Self(iter.into_iter().collect())
     }
 }
+
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Length
+    for StructArray<T, NULLABLE, Buffer>
+where
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>: Length,
+{
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<T: StructArrayType, Buffer: BufferType> BitmapRef for StructArray<T, true, Buffer> {
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.0.bitmap_ref()
+    }
+}
+
+impl<T: StructArrayType, Buffer: BufferType> BitmapRefMut for StructArray<T, true, Buffer> {
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.0.bitmap_ref_mut()
+    }
+}
+
+impl<T: StructArrayType, Buffer: BufferType> ValidityBitmap for StructArray<T, true, Buffer> {}
 
 #[cfg(test)]
 mod tests {
@@ -44,7 +72,7 @@ mod tests {
     #[test]
     fn from_iter() {
         // Definition
-        // #[derive(Array)]
+        #[derive(Default)]
         struct Foo<'a> {
             a: u32,
             b: Option<()>,
@@ -58,6 +86,7 @@ mod tests {
         impl<'a> ArrayType for Foo<'a> {
             type Array<Buffer: BufferType> = StructArray<Foo<'a>, false, Buffer>;
         }
+
         struct FooArray<'a, Buffer: BufferType> {
             a: <u32 as ArrayType>::Array<Buffer>,
             b: <Option<()> as ArrayType>::Array<Buffer>,
@@ -67,6 +96,63 @@ mod tests {
             f: <&'a [u8] as ArrayType>::Array<Buffer>,
             g: <String as ArrayType>::Array<Buffer>,
         }
+
+        impl<'a, Buffer: BufferType> Default for FooArray<'a, Buffer>
+        where
+            <u32 as ArrayType>::Array<Buffer>: Default,
+            <Option<()> as ArrayType>::Array<Buffer>: Default,
+            <() as ArrayType>::Array<Buffer>: Default,
+            <Option<[u128; 2]> as ArrayType>::Array<Buffer>: Default,
+            <bool as ArrayType>::Array<Buffer>: Default,
+            <&'a [u8] as ArrayType>::Array<Buffer>: Default,
+            <String as ArrayType>::Array<Buffer>: Default,
+        {
+            fn default() -> Self {
+                Self {
+                    a: <u32 as ArrayType>::Array::<Buffer>::default(),
+                    b: <Option<()> as ArrayType>::Array::<Buffer>::default(),
+                    c: <() as ArrayType>::Array::<Buffer>::default(),
+                    d: <Option<[u128; 2]> as ArrayType>::Array::<Buffer>::default(),
+                    e: <bool as ArrayType>::Array::<Buffer>::default(),
+                    f: <&'a [u8] as ArrayType>::Array::<Buffer>::default(),
+                    g: <String as ArrayType>::Array::<Buffer>::default(),
+                }
+            }
+        }
+
+        impl<'a, Buffer: BufferType> Extend<Foo<'a>> for FooArray<'a, Buffer>
+        where
+            <u32 as ArrayType>::Array<Buffer>: Extend<u32>,
+            <Option<()> as ArrayType>::Array<Buffer>: Extend<Option<()>>,
+            <() as ArrayType>::Array<Buffer>: Extend<()>,
+            <Option<[u128; 2]> as ArrayType>::Array<Buffer>: Extend<Option<[u128; 2]>>,
+            <bool as ArrayType>::Array<Buffer>: Extend<bool>,
+            <&'a [u8] as ArrayType>::Array<Buffer>: Extend<&'a [u8]>,
+            <String as ArrayType>::Array<Buffer>: Extend<String>,
+        {
+            fn extend<I: IntoIterator<Item = Foo<'a>>>(&mut self, iter: I) {
+                iter.into_iter().for_each(
+                    |Foo {
+                         a,
+                         b,
+                         c,
+                         d,
+                         e,
+                         f,
+                         g,
+                     }| {
+                        self.a.extend(std::iter::once(a));
+                        self.b.extend(std::iter::once(b));
+                        self.c.extend(std::iter::once(c));
+                        self.d.extend(std::iter::once(d));
+                        self.e.extend(std::iter::once(e));
+                        self.f.extend(std::iter::once(f));
+                        self.g.extend(std::iter::once(g));
+                    },
+                )
+            }
+        }
+
         impl<'a, Buffer: BufferType> FromIterator<Foo<'a>> for FooArray<'a, Buffer>
         where
             <u32 as ArrayType>::Array<Buffer>: Default + Extend<u32>,
@@ -177,5 +263,23 @@ mod tests {
             array.0.g.0 .0 .0.offsets.into_iter().collect::<Vec<_>>(),
             &[0, 1, 2, 3, 4]
         );
+
+        let input = [
+            None,
+            Some(Foo {
+                a: 1,
+                b: None,
+                c: (),
+                d: Some([1, 2]),
+                e: false,
+                f: &[1],
+                g: "a".to_string(),
+            }),
+        ];
+        let array = input.into_iter().collect::<StructArray<Foo, true>>();
+        assert_eq!(array.len(), 2);
+        assert_eq!(array.is_null(0), Some(true));
+        assert_eq!(array.is_valid(1), Some(true));
+        assert_eq!(array.is_valid(2), None);
     }
 }

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -2,6 +2,7 @@
 
 use super::{Array, FixedSizePrimitiveArray, StringArray, VariableSizeListArray};
 use crate::{
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     offset::OffsetElement,
     validity::Validity,
@@ -118,6 +119,29 @@ where
     fn len(&self) -> usize {
         self.0.len()
     }
+}
+
+impl<OffsetItem: OffsetElement, Buffer: BufferType> BitmapRef
+    for VariableSizeBinaryArray<true, OffsetItem, Buffer>
+{
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.0.bitmap_ref()
+    }
+}
+
+impl<OffsetItem: OffsetElement, Buffer: BufferType> BitmapRefMut
+    for VariableSizeBinaryArray<true, OffsetItem, Buffer>
+{
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.0.bitmap_ref_mut()
+    }
+}
+
+impl<OffsetItem: OffsetElement, Buffer: BufferType> ValidityBitmap
+    for VariableSizeBinaryArray<true, OffsetItem, Buffer>
+{
 }
 
 #[cfg(test)]

--- a/src/array/variable_size_list.rs
+++ b/src/array/variable_size_list.rs
@@ -1,5 +1,6 @@
 use super::Array;
 use crate::{
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     offset::{Offset, OffsetElement},
     validity::Validity,
@@ -65,6 +66,29 @@ where
     fn len(&self) -> usize {
         self.0.len()
     }
+}
+
+impl<T: Array, OffsetItem: OffsetElement, Buffer: BufferType> BitmapRef
+    for VariableSizeListArray<T, true, OffsetItem, Buffer>
+{
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.0.bitmap_ref()
+    }
+}
+
+impl<T: Array, OffsetItem: OffsetElement, Buffer: BufferType> BitmapRefMut
+    for VariableSizeListArray<T, true, OffsetItem, Buffer>
+{
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.0.bitmap_ref_mut()
+    }
+}
+
+impl<T: Array, OffsetItem: OffsetElement, Buffer: BufferType> ValidityBitmap
+    for VariableSizeListArray<T, true, OffsetItem, Buffer>
+{
 }
 
 #[cfg(test)]

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -1,6 +1,7 @@
 //! Offsets for variable-sized arrays.
 
 use crate::{
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{Buffer, BufferType, VecBuffer},
     validity::Validity,
     FixedSize, Length,
@@ -179,6 +180,29 @@ impl<T, OffsetItem: OffsetElement, Buffer: BufferType> Length
         // The offsets contains a bitmap that uses the number of bits as length
         self.offsets.len()
     }
+}
+
+impl<T, OffsetItem: OffsetElement, Buffer: BufferType> BitmapRef
+    for Offset<T, true, OffsetItem, Buffer>
+{
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.offsets.bitmap_ref()
+    }
+}
+
+impl<T, OffsetItem: OffsetElement, Buffer: BufferType> BitmapRefMut
+    for Offset<T, true, OffsetItem, Buffer>
+{
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.offsets.bitmap_ref_mut()
+    }
+}
+
+impl<T, OffsetItem: OffsetElement, Buffer: BufferType> ValidityBitmap
+    for Offset<T, true, OffsetItem, Buffer>
+{
 }
 
 #[cfg(test)]


### PR DESCRIPTION
When arrays are nullable they should provide access to the validity bitmap and the methods of the `ValidityBitmap` trait to get nullability information.