### PR TITLE
fix(derive): `ArrayType` derive for tuple structs

### DIFF
--- a/narrow-derive/src/struct/mod.rs
+++ b/narrow-derive/src/struct/mod.rs
@@ -1,14 +1,46 @@
 use crate::util;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{DeriveInput, Fields, Generics, Ident};
+use std::ops::Deref;
+use syn::{
+    parse_quote, DeriveInput, Field, Fields, FieldsNamed, FieldsUnnamed, Generics, Ident, Index,
+};
 
 mod unit;
+mod unnamed;
 
 pub(super) fn derive(input: &DeriveInput, fields: &Fields) -> TokenStream {
-    match fields {
+    let array_impl = match fields {
         Fields::Unit => unit::derive(input),
-        _ => todo!("non unit structs derive"),
+        Fields::Unnamed(FieldsUnnamed {
+            unnamed: fields, ..
+        }) => unnamed::derive(input, fields),
+        Fields::Named(FieldsNamed { named: _fields, .. }) => {
+            todo!("derive for structs with named fields")
+        }
+    };
+
+    let DeriveInput {
+        ident, generics, ..
+    } = input;
+
+    // Generate the ArrayType implementation.
+    let array_type_impl = array_type_impl(ident, generics);
+
+    // Generate the StructArrayType implementation.
+    let struct_array_type_impl = struct_array_type_impl(ident, generics);
+
+    // Generate the Length implementation.
+    let length_impl = length_impl(ident, generics, fields.iter().next());
+
+    quote! {
+        #array_type_impl
+
+        #struct_array_type_impl
+
+        #array_impl
+
+        #length_impl
     }
 }
 
@@ -19,7 +51,9 @@ fn array_type_ident(ident: &Ident) -> Ident {
 fn array_type_impl(ident: &Ident, generics: &Generics) -> TokenStream {
     let narrow = util::narrow();
 
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (_, ty_generics, _) = generics.split_for_impl();
+    let array_type_bound_generics = ArrayTypeBound::from(generics);
+    let (impl_generics, _, where_clause) = array_type_bound_generics.split_for_impl();
 
     quote! {
         impl #impl_generics #narrow::array::ArrayType for #ident #ty_generics #where_clause {
@@ -29,5 +63,114 @@ fn array_type_impl(ident: &Ident, generics: &Generics) -> TokenStream {
         impl #impl_generics #narrow::array::ArrayType<#ident #ty_generics> for ::std::option::Option<#ident #ty_generics> #where_clause {
             type Array<Buffer: #narrow::buffer::BufferType> = #narrow::array::StructArray<#ident #ty_generics, true, Buffer>;
         }
+    }
+}
+
+fn struct_array_type_impl(ident: &Ident, generics: &Generics) -> TokenStream {
+    let narrow = util::narrow();
+    let array_type_ident = array_type_ident(ident);
+
+    let generics = ArrayTypeBound::from(generics);
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+    let generics = BufferTypeGeneric::from(&*generics);
+    let (_, ty_generics_with_buffer, _) = generics.split_for_impl();
+
+    quote! {
+        impl #impl_generics #narrow::array::StructArrayType for #ident #ty_generics #where_clause {
+            type Array<Buffer: #narrow::buffer::BufferType> = #array_type_ident #ty_generics_with_buffer;
+        }
+    }
+}
+
+fn length_impl(ident: &Ident, generics: &Generics, field: Option<&Field>) -> TokenStream {
+    let narrow = util::narrow();
+
+    let array_type_ident = array_type_ident(ident);
+
+    let generics = ArrayTypeBound::from(generics);
+    let (_, _ty_generics, _where_clause) = generics.split_for_impl();
+
+    let array_generics = BufferTypeGeneric::from(&*generics);
+    let (impl_generics_with_buffer, ty_generics_with_buffer, _) = array_generics.split_for_impl();
+
+    // If there is a field we need to add a length bound in the where_clause
+    let mut generics = generics.clone();
+    let where_clause = match field {
+        Some(Field { ty, .. }) => {
+            generics.make_where_clause().predicates.push(
+                parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: #narrow::Length),
+            );
+            generics.where_clause
+        }
+        None => generics.where_clause,
+    };
+
+    // If there is named field we need to use the ident otherwise we use an index (0)
+    let method = match field {
+        Some(Field {
+            ident: Some(ident), ..
+        }) => {
+            quote!(self.#ident.len())
+        }
+        None | Some(Field { ident: None, .. }) => {
+            let ident = Index::from(0);
+            quote!(self.#ident.len())
+        }
+    };
+
+    quote! {
+        impl #impl_generics_with_buffer #narrow::Length for #array_type_ident #ty_generics_with_buffer #where_clause {
+            #[inline]
+            fn len(&self) -> usize {
+                #method
+            }
+        }
+    }
+}
+
+/// Adds an `#narrow::array::ArrayType` bound to all type generics.
+struct ArrayTypeBound(Generics);
+
+impl Deref for ArrayTypeBound {
+    type Target = Generics;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<&Generics> for ArrayTypeBound {
+    fn from(value: &Generics) -> Self {
+        let narrow = util::narrow();
+        let mut generics = value.clone();
+        generics.type_params_mut().for_each(|type_param| {
+            type_param
+                .bounds
+                .push(parse_quote!(#narrow::array::ArrayType));
+        });
+        Self(generics)
+    }
+}
+
+/// Adds a `Buffer` generic with a `BufferType` bound.
+struct BufferTypeGeneric(Generics);
+
+impl Deref for BufferTypeGeneric {
+    type Target = Generics;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<&Generics> for BufferTypeGeneric {
+    fn from(value: &Generics) -> Self {
+        let narrow = util::narrow();
+        let mut generics = value.clone();
+        generics
+            .params
+            .push(parse_quote!(Buffer: #narrow::buffer::BufferType = #narrow::buffer::VecBuffer));
+        Self(generics)
     }
 }

--- a/narrow-derive/src/struct/unit.rs
+++ b/narrow-derive/src/struct/unit.rs
@@ -1,12 +1,10 @@
 use crate::{
-    r#struct::{array_type_ident, array_type_impl},
+    r#struct::{array_type_ident, BufferTypeGeneric},
     util,
 };
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{
-    parse_quote, DeriveInput, Generics, Ident, ImplGenerics, TypeGenerics, Visibility, WhereClause,
-};
+use syn::{DeriveInput, Generics, Ident, Visibility};
 
 pub(super) fn derive(input: &DeriveInput) -> TokenStream {
     let DeriveInput {
@@ -16,20 +14,11 @@ pub(super) fn derive(input: &DeriveInput) -> TokenStream {
         ..
     } = input;
 
-    // Generate the ArrayType implementation.
-    let array_type_impl = array_type_impl(ident, generics);
-
-    // Generate the StructArrayType implementation.
-    let struct_array_type_impl = struct_array_type_impl(ident, generics);
-
     // Generate the Unit implementation.
     let unit_impl = unit_impl(ident, generics);
 
     // Generate the array type definition.
     let array_type_def = array_type_def(vis, ident, generics);
-
-    // Generate the length impl.
-    let length_impl = length_impl(ident, generics);
 
     // Generate the FromIterator impl.
     let from_iterator_impl = from_iterator_impl(ident, generics);
@@ -41,17 +30,11 @@ pub(super) fn derive(input: &DeriveInput) -> TokenStream {
     let default_impl = default_impl(ident, generics);
 
     quote! {
-      #array_type_impl
-
-      #struct_array_type_impl
-
       #unit_impl
 
       #array_type_def
 
       #from_iterator_impl
-
-      #length_impl
 
       #extend_impl
 
@@ -71,23 +54,6 @@ fn unit_impl(ident: &Ident, generics: &Generics) -> TokenStream {
     }
 }
 
-fn struct_array_type_impl(ident: &Ident, generics: &Generics) -> TokenStream {
-    let narrow = util::narrow();
-
-    let array_type_ident = array_type_ident(ident);
-
-    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-
-    let array_generics = NullArrayGenerics::new(generics);
-    let (_, ty_generics_with_buffer, _) = array_generics.split_for_impl();
-
-    quote! {
-        impl #impl_generics #narrow::array::StructArrayType for #ident #ty_generics #where_clause {
-            type Array<Buffer: #narrow::buffer::BufferType> = #array_type_ident #ty_generics_with_buffer;
-        }
-    }
-}
-
 fn array_type_def(vis: &Visibility, ident: &Ident, generics: &Generics) -> TokenStream {
     let narrow = util::narrow();
 
@@ -95,7 +61,7 @@ fn array_type_def(vis: &Visibility, ident: &Ident, generics: &Generics) -> Token
 
     let (_, ty_generics, where_clause) = generics.split_for_impl();
 
-    let array_generics = NullArrayGenerics::new(generics);
+    let array_generics = BufferTypeGeneric::from(generics);
     let (impl_generics_with_buffer, _, _) = array_generics.split_for_impl();
 
     quote! {
@@ -110,7 +76,7 @@ fn from_iterator_impl(ident: &Ident, generics: &Generics) -> TokenStream {
 
     let (_, ty_generics, where_clause) = generics.split_for_impl();
 
-    let array_generics = NullArrayGenerics::new(generics);
+    let array_generics = BufferTypeGeneric::from(generics);
     let (impl_generics_with_buffer, ty_generics_with_buffer, _) = array_generics.split_for_impl();
 
     quote! {
@@ -122,32 +88,12 @@ fn from_iterator_impl(ident: &Ident, generics: &Generics) -> TokenStream {
     }
 }
 
-fn length_impl(ident: &Ident, generics: &Generics) -> TokenStream {
-    let narrow = util::narrow();
-
-    let array_type_ident = array_type_ident(ident);
-
-    let (_, _ty_generics, where_clause) = generics.split_for_impl();
-
-    let array_generics = NullArrayGenerics::new(generics);
-    let (impl_generics_with_buffer, ty_generics_with_buffer, _) = array_generics.split_for_impl();
-
-    quote! {
-        impl #impl_generics_with_buffer #narrow::Length for #array_type_ident #ty_generics_with_buffer #where_clause {
-            #[inline]
-            fn len(&self) -> usize {
-                self.0.len()
-            }
-        }
-    }
-}
-
 fn extend_impl(ident: &Ident, generics: &Generics) -> TokenStream {
     let array_type_ident = array_type_ident(ident);
 
     let (_, ty_generics, where_clause) = generics.split_for_impl();
 
-    let array_generics = NullArrayGenerics::new(generics);
+    let array_generics = BufferTypeGeneric::from(generics);
     let (impl_generics_with_buffer, ty_generics_with_buffer, _) = array_generics.split_for_impl();
 
     quote! {
@@ -164,7 +110,7 @@ fn default_impl(ident: &Ident, generics: &Generics) -> TokenStream {
 
     let (_, _, where_clause) = generics.split_for_impl();
 
-    let array_generics = NullArrayGenerics::new(generics);
+    let array_generics = BufferTypeGeneric::from(generics);
     let (impl_generics_with_buffer, ty_generics_with_buffer, _) = array_generics.split_for_impl();
 
     quote! {
@@ -173,22 +119,5 @@ fn default_impl(ident: &Ident, generics: &Generics) -> TokenStream {
                 Self(::std::default::Default::default())
             }
         }
-    }
-}
-
-struct NullArrayGenerics(Generics);
-
-impl NullArrayGenerics {
-    fn new(generics: &Generics) -> Self {
-        let narrow = util::narrow();
-
-        let mut generics_with_buffer = generics.clone();
-        generics_with_buffer
-            .params
-            .push(parse_quote!(Buffer: #narrow::buffer::BufferType = #narrow::buffer::VecBuffer));
-        Self(generics_with_buffer)
-    }
-    fn split_for_impl(&self) -> (ImplGenerics, TypeGenerics, Option<&WhereClause>) {
-        self.0.split_for_impl()
     }
 }

--- a/narrow-derive/src/struct/unnamed.rs
+++ b/narrow-derive/src/struct/unnamed.rs
@@ -1,0 +1,212 @@
+use crate::{
+    r#struct::{array_type_ident, ArrayTypeBound, BufferTypeGeneric},
+    util,
+};
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote, ToTokens};
+use syn::{
+    parse_quote, punctuated::Punctuated, DeriveInput, Field, Generics, Ident, Index, Token,
+    Visibility, WherePredicate,
+};
+
+pub(super) fn derive(input: &DeriveInput, fields: &Punctuated<Field, Token![,]>) -> TokenStream {
+    let DeriveInput {
+        vis,
+        ident,
+        generics,
+        ..
+    } = input;
+
+    // Generate the array type definition.
+    let array_type_def = array_type_def(vis, ident, generics, fields);
+
+    // Generate the FromIterator impl.
+    let from_iterator_impl = from_iterator_impl(ident, generics, fields);
+
+    // Generate the Default impl.
+    let default_impl = default_impl(ident, generics, fields);
+
+    // Generate the Extend impl.
+    let extend_impl = extend_impl(ident, generics, fields);
+
+    quote! {
+        #array_type_def
+
+        #from_iterator_impl
+
+        #default_impl
+
+        #extend_impl
+    }
+}
+
+fn array_type_def(
+    vis: &Visibility,
+    ident: &Ident,
+    generics: &Generics,
+    fields: &Punctuated<Field, Token![,]>,
+) -> TokenStream {
+    let narrow = util::narrow();
+
+    let array_type_ident = array_type_ident(ident);
+
+    // Add an ArrayType bound to all generics.
+    let generics = ArrayTypeBound::from(generics);
+    // Add a Buffer generic for the array type.
+    let generics = BufferTypeGeneric::from(&*generics);
+
+    let (impl_generics, _, where_clause) = generics.split_for_impl();
+
+    let field_vis = fields.into_iter().map(|Field { vis, .. }| vis);
+    let field_ty = fields.into_iter().map(|Field { ty, .. }| ty);
+
+    quote! {
+        #vis struct #array_type_ident #impl_generics(
+            #(
+                #field_vis <#field_ty as #narrow::array::ArrayType>::Array<Buffer>,
+            )*
+        ) #where_clause;
+    }
+}
+
+fn from_iterator_impl(
+    ident: &Ident,
+    generics: &Generics,
+    fields: &Punctuated<Field, Token![,]>,
+) -> TokenStream {
+    let narrow = util::narrow();
+
+    let array_type_ident = array_type_ident(ident);
+
+    let (_, ty_generics, _) = generics.split_for_impl();
+
+    // Add an ArrayType bound to all generics.
+    let generics = ArrayTypeBound::from(generics);
+
+    // Add a Buffer generic for the array type.
+    let generics = BufferTypeGeneric::from(&*generics);
+    let (impl_generics, ty_generics_with_buffer, _) = generics.split_for_impl();
+
+    // Add bounds for all field types
+    let mut generics = generics.clone();
+    let where_clause = generics.make_where_clause();
+    where_clause.predicates.extend(
+        fields.into_iter().map::<WherePredicate, _>(|Field { ty, .. }|
+            parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default + ::std::iter::Extend<#ty>)
+        )
+    );
+
+    let field_idx = fields
+        .into_iter()
+        .enumerate()
+        .map(|(idx, _)| format_ident!("_{}", idx))
+        .collect::<Vec<_>>();
+    let mut tuple = field_idx.iter().map(ToTokens::to_token_stream);
+    let initial = tuple.next_back().map(|last| quote!((#last,()))).unwrap();
+    let tuple = tuple.rfold(initial, |acc, x| quote!((#x, #acc)));
+
+    quote! {
+        impl #impl_generics ::std::iter::FromIterator<#ident #ty_generics> for #array_type_ident #ty_generics_with_buffer #where_clause {
+            fn from_iter<_I: ::std::iter::IntoIterator<Item = #ident #ty_generics>>(iter: _I) -> Self {
+                let #tuple = iter.into_iter().map(|#ident (#( #field_idx, )*) | #tuple).unzip();
+                Self(
+                    #(
+                        #field_idx,
+                    )*
+                )
+            }
+        }
+    }
+}
+
+fn default_impl(
+    ident: &Ident,
+    generics: &Generics,
+    fields: &Punctuated<Field, Token![,]>,
+) -> TokenStream {
+    let narrow = util::narrow();
+
+    let array_type_ident = array_type_ident(ident);
+
+    // Add an ArrayType bound to all generics.
+    let generics = ArrayTypeBound::from(generics);
+    // Add a Buffer generic for the array type.
+    let array_generics = BufferTypeGeneric::from(&*generics);
+    let (impl_generics, ty_generics, _) = array_generics.split_for_impl();
+
+    // Add bounds for all field types
+    let mut generics = generics.clone();
+    let where_clause = generics.make_where_clause();
+    where_clause.predicates.extend(
+        fields.into_iter().map::<WherePredicate, _>(|Field { ty, .. }|
+            parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default)
+        )
+    );
+
+    let default_field = fields
+        .into_iter()
+        .map(|_| quote!(::std::default::Default::default()));
+
+    quote!(
+        impl #impl_generics ::std::default::Default for #array_type_ident #ty_generics #where_clause {
+            fn default() -> Self {
+                Self(
+                    #(
+                        #default_field,
+                    )*
+                )
+            }
+        }
+    )
+}
+
+fn extend_impl(
+    ident: &Ident,
+    generics: &Generics,
+    fields: &Punctuated<Field, Token![,]>,
+) -> TokenStream {
+    let narrow = util::narrow();
+
+    let array_type_ident = array_type_ident(ident);
+
+    let (_, ty_generics, _) = generics.split_for_impl();
+
+    // Add an ArrayType bound to all generics.
+    let generics = ArrayTypeBound::from(generics);
+    // Add a Buffer generic for the array type.
+    let generics = BufferTypeGeneric::from(&*generics);
+
+    let (impl_generics, ty_generics_with_buffer, _) = generics.split_for_impl();
+
+    // Add bounds for all field types
+    let mut generics = generics.clone();
+    let where_clause = generics.make_where_clause();
+    where_clause.predicates.extend(
+        fields.into_iter().map::<WherePredicate, _>(|Field { ty, .. }|
+            parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<#ty>)
+        )
+    );
+
+    let field_idx = fields
+        .into_iter()
+        .enumerate()
+        .map(|(idx, _)| Index::from(idx))
+        .collect::<Vec<_>>();
+
+    let field_name = field_idx
+        .iter()
+        .map(|idx| format_ident!("_{}", idx))
+        .collect::<Vec<_>>();
+
+    quote! {
+        impl #impl_generics ::std::iter::Extend<#ident #ty_generics> for #array_type_ident #ty_generics_with_buffer #where_clause {
+            fn extend<_I: ::std::iter::IntoIterator<Item = #ident #ty_generics>>(&mut self, iter: _I) {
+                iter.into_iter().for_each(|#ident (#( #field_name, )*) | {
+                    #(
+                        self.#field_idx.extend(::std::iter::once(#field_name));
+                    )*
+                });
+            }
+        }
+    }
+}

--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -30,13 +30,6 @@ impl<
         Self(iter.into_iter().collect())
     }
 }
-impl<const N: usize, Buffer: narrow::buffer::BufferType> narrow::Length
-for FooArray<N, Buffer> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
 impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo<N>>
 for FooArray<N, Buffer> {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<N>>>(&mut self, iter: _I) {
@@ -47,5 +40,12 @@ impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer> {
     fn default() -> Self {
         Self(::std::default::Default::default())
+    }
+}
+impl<const N: usize, Buffer: narrow::buffer::BufferType> narrow::Length
+for FooArray<N, Buffer> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
     }
 }

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -30,13 +30,6 @@ impl<
         Self(iter.into_iter().collect())
     }
 }
-impl<const N: usize, Buffer: narrow::buffer::BufferType> narrow::Length
-for FooArray<N, Buffer> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
 impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo<N>>
 for FooArray<N, Buffer> {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<N>>>(&mut self, iter: _I) {
@@ -47,5 +40,12 @@ impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer> {
     fn default() -> Self {
         Self(::std::default::Default::default())
+    }
+}
+impl<const N: usize, Buffer: narrow::buffer::BufferType> narrow::Length
+for FooArray<N, Buffer> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
     }
 }

--- a/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
@@ -28,12 +28,6 @@ for FooArray<Buffer> {
         Self(iter.into_iter().collect())
     }
 }
-impl<Buffer: narrow::buffer::BufferType> narrow::Length for FooArray<Buffer> {
-    #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
 impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo> for FooArray<Buffer> {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo>>(&mut self, iter: _I) {
         self.0.extend(iter)
@@ -42,5 +36,11 @@ impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo> for FooArray<B
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer> {
     fn default() -> Self {
         Self(::std::default::Default::default())
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> narrow::Length for FooArray<Buffer> {
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
     }
 }

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -47,16 +47,6 @@ where
         Self(iter.into_iter().collect())
     }
 }
-impl<const N: bool, Buffer: narrow::buffer::BufferType> narrow::Length
-for FooArray<N, Buffer>
-where
-    Self: Sized,
-{
-    #[inline]
-    fn len(&self) -> usize {
-        self.0.len()
-    }
-}
 impl<const N: bool, Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo<N>>
 for FooArray<N, Buffer>
 where
@@ -73,5 +63,15 @@ where
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
+    }
+}
+impl<const N: bool, Buffer: narrow::buffer::BufferType> narrow::Length
+for FooArray<N, Buffer>
+where
+    Self: Sized,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
     }
 }

--- a/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
@@ -1,0 +1,74 @@
+struct Foo<'a, T>(&'a T);
+impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType for Foo<'a, T> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo<'a, T>,
+        false,
+        Buffer,
+    >;
+}
+impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType<Foo<'a, T>>
+for ::std::option::Option<Foo<'a, T>> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo<'a, T>,
+        true,
+        Buffer,
+    >;
+}
+impl<'a, T: narrow::array::ArrayType> narrow::array::StructArrayType for Foo<'a, T> {
+    type Array<Buffer: narrow::buffer::BufferType> = FooArray<'a, T, Buffer>;
+}
+struct FooArray<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
+    <&'a T as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<
+    'a,
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::FromIterator<Foo<'a, T>> for FooArray<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<&'a T>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|Foo(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::default::Default for FooArray<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Extend<Foo<'a, T>> for FooArray<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<&'a T>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Foo(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
+for FooArray<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/lifetime.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/lifetime.rs
@@ -1,0 +1,2 @@
+#[derive(narrow_derive::ArrayType)]
+struct Foo<'a, T>(&'a T);

--- a/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
@@ -1,0 +1,122 @@
+struct Foo(u32);
+impl narrow::array::ArrayType for Foo {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo,
+        false,
+        Buffer,
+    >;
+}
+impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo,
+        true,
+        Buffer,
+    >;
+}
+impl narrow::array::StructArrayType for Foo {
+    type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
+}
+struct FooArray<Buffer: narrow::buffer::BufferType>(
+    <u32 as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::FromIterator<Foo>
+for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<u32>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|Foo(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo> for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Foo>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Foo(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> narrow::Length for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+struct Bar(Foo);
+impl narrow::array::ArrayType for Bar {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Bar,
+        false,
+        Buffer,
+    >;
+}
+impl narrow::array::ArrayType<Bar> for ::std::option::Option<Bar> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Bar,
+        true,
+        Buffer,
+    >;
+}
+impl narrow::array::StructArrayType for Bar {
+    type Array<Buffer: narrow::buffer::BufferType> = BarArray<Buffer>;
+}
+struct BarArray<Buffer: narrow::buffer::BufferType>(
+    <Foo as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::FromIterator<Bar>
+for BarArray<Buffer>
+where
+    <Foo as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<Foo>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|Bar(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for BarArray<Buffer>
+where
+    <Foo as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Bar> for BarArray<Buffer>
+where
+    <Foo as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Foo>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Bar>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Bar(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> narrow::Length for BarArray<Buffer>
+where
+    <Foo as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/nested.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested.rs
@@ -1,0 +1,5 @@
+#[derive(narrow_derive::ArrayType)]
+struct Foo(u32);
+
+#[derive(narrow_derive::ArrayType)]
+struct Bar(Foo);

--- a/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
@@ -1,0 +1,237 @@
+struct Foo<T>(
+    T,
+)
+where
+    T: Copy;
+impl<T: narrow::array::ArrayType> narrow::array::ArrayType for Foo<T>
+where
+    T: Copy,
+{
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo<T>,
+        false,
+        Buffer,
+    >;
+}
+impl<T: narrow::array::ArrayType> narrow::array::ArrayType<Foo<T>>
+for ::std::option::Option<Foo<T>>
+where
+    T: Copy,
+{
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo<T>,
+        true,
+        Buffer,
+    >;
+}
+impl<T: narrow::array::ArrayType> narrow::array::StructArrayType for Foo<T>
+where
+    T: Copy,
+{
+    type Array<Buffer: narrow::buffer::BufferType> = FooArray<T, Buffer>;
+}
+struct FooArray<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
+    <T as narrow::array::ArrayType>::Array<Buffer>,
+)
+where
+    T: Copy;
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::FromIterator<Foo<T>> for FooArray<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<T>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|Foo(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::default::Default for FooArray<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Extend<Foo<T>> for FooArray<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<T>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Foo(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
+for FooArray<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+struct Bar<'a, T>(&'a Foo<T>);
+impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType for Bar<'a, T> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Bar<'a, T>,
+        false,
+        Buffer,
+    >;
+}
+impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType<Bar<'a, T>>
+for ::std::option::Option<Bar<'a, T>> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Bar<'a, T>,
+        true,
+        Buffer,
+    >;
+}
+impl<'a, T: narrow::array::ArrayType> narrow::array::StructArrayType for Bar<'a, T> {
+    type Array<Buffer: narrow::buffer::BufferType> = BarArray<'a, T, Buffer>;
+}
+struct BarArray<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
+    <&'a Foo<T> as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<
+    'a,
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::FromIterator<Bar<'a, T>> for BarArray<'a, T, Buffer>
+where
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<&'a Foo<T>>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar<'a, T>>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|Bar(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::default::Default for BarArray<'a, T, Buffer>
+where
+    <&'a Foo<T> as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Extend<Bar<'a, T>> for BarArray<'a, T, Buffer>
+where
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<&'a Foo<T>>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Bar<'a, T>>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Bar(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
+for BarArray<'a, T, Buffer>
+where
+    <&'a Foo<T> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+struct FooBar<'a>(Bar<'a, u32>);
+impl<'a> narrow::array::ArrayType for FooBar<'a> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        FooBar<'a>,
+        false,
+        Buffer,
+    >;
+}
+impl<'a> narrow::array::ArrayType<FooBar<'a>> for ::std::option::Option<FooBar<'a>> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        FooBar<'a>,
+        true,
+        Buffer,
+    >;
+}
+impl<'a> narrow::array::StructArrayType for FooBar<'a> {
+    type Array<Buffer: narrow::buffer::BufferType> = FooBarArray<'a, Buffer>;
+}
+struct FooBarArray<'a, Buffer: narrow::buffer::BufferType>(
+    <Bar<'a, u32> as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<'a, Buffer: narrow::buffer::BufferType> ::std::iter::FromIterator<FooBar<'a>>
+for FooBarArray<'a, Buffer>
+where
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<Bar<'a, u32>>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = FooBar<'a>>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|FooBar(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<'a, Buffer: narrow::buffer::BufferType> ::std::default::Default
+for FooBarArray<'a, Buffer>
+where
+    <Bar<'a, u32> as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<'a, Buffer: narrow::buffer::BufferType> ::std::iter::Extend<FooBar<'a>>
+for FooBarArray<'a, Buffer>
+where
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Bar<'a, u32>>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = FooBar<'a>>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|FooBar(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<'a, Buffer: narrow::buffer::BufferType> narrow::Length for FooBarArray<'a, Buffer>
+where
+    <Bar<'a, u32> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/nested_generic.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested_generic.rs
@@ -1,0 +1,10 @@
+#[derive(narrow_derive::ArrayType)]
+struct Foo<T>(T)
+where
+    T: Copy;
+
+#[derive(narrow_derive::ArrayType)]
+struct Bar<'a, T>(&'a Foo<T>);
+
+#[derive(narrow_derive::ArrayType)]
+struct FooBar<'a>(Bar<'a, u32>);

--- a/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
@@ -1,0 +1,222 @@
+struct Foo(u32);
+impl narrow::array::ArrayType for Foo {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo,
+        false,
+        Buffer,
+    >;
+}
+impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Foo,
+        true,
+        Buffer,
+    >;
+}
+impl narrow::array::StructArrayType for Foo {
+    type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
+}
+struct FooArray<Buffer: narrow::buffer::BufferType>(
+    <u32 as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::FromIterator<Foo>
+for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<u32>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|Foo(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo> for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Foo>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Foo(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> narrow::Length for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+struct Bar(u8, u16, u32, u64);
+impl narrow::array::ArrayType for Bar {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Bar,
+        false,
+        Buffer,
+    >;
+}
+impl narrow::array::ArrayType<Bar> for ::std::option::Option<Bar> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        Bar,
+        true,
+        Buffer,
+    >;
+}
+impl narrow::array::StructArrayType for Bar {
+    type Array<Buffer: narrow::buffer::BufferType> = BarArray<Buffer>;
+}
+struct BarArray<Buffer: narrow::buffer::BufferType>(
+    <u8 as narrow::array::ArrayType>::Array<Buffer>,
+    <u16 as narrow::array::ArrayType>::Array<Buffer>,
+    <u32 as narrow::array::ArrayType>::Array<Buffer>,
+    <u64 as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::FromIterator<Bar>
+for BarArray<Buffer>
+where
+    <u8 as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<u8>,
+    <u16 as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<u16>,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<u32>,
+    <u64 as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<u64>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar>>(iter: _I) -> Self {
+        let (_0, (_1, (_2, (_3, ())))) = iter
+            .into_iter()
+            .map(|Bar(_0, _1, _2, _3)| (_0, (_1, (_2, (_3, ())))))
+            .unzip();
+        Self(_0, _1, _2, _3)
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for BarArray<Buffer>
+where
+    <u8 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u16 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u64 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(
+            ::std::default::Default::default(),
+            ::std::default::Default::default(),
+            ::std::default::Default::default(),
+            ::std::default::Default::default(),
+        )
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Bar> for BarArray<Buffer>
+where
+    <u8 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u8>,
+    <u16 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u16>,
+    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
+    <u64 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u64>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = Bar>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|Bar(_0, _1, _2, _3)| {
+                self.0.extend(::std::iter::once(_0));
+                self.1.extend(::std::iter::once(_1));
+                self.2.extend(::std::iter::once(_2));
+                self.3.extend(::std::iter::once(_3));
+            });
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> narrow::Length for BarArray<Buffer>
+where
+    <u8 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+struct FooBar<T>(T);
+impl<T: narrow::array::ArrayType> narrow::array::ArrayType for FooBar<T> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        FooBar<T>,
+        false,
+        Buffer,
+    >;
+}
+impl<T: narrow::array::ArrayType> narrow::array::ArrayType<FooBar<T>>
+for ::std::option::Option<FooBar<T>> {
+    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
+        FooBar<T>,
+        true,
+        Buffer,
+    >;
+}
+impl<T: narrow::array::ArrayType> narrow::array::StructArrayType for FooBar<T> {
+    type Array<Buffer: narrow::buffer::BufferType> = FooBarArray<T, Buffer>;
+}
+struct FooBarArray<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
+    <T as narrow::array::ArrayType>::Array<Buffer>,
+);
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::FromIterator<FooBar<T>> for FooBarArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+    >: ::std::default::Default + ::std::iter::Extend<T>,
+{
+    fn from_iter<_I: ::std::iter::IntoIterator<Item = FooBar<T>>>(iter: _I) -> Self {
+        let (_0, ()) = iter.into_iter().map(|FooBar(_0)| (_0, ())).unzip();
+        Self(_0)
+    }
+}
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::default::Default for FooBarArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+{
+    fn default() -> Self {
+        Self(::std::default::Default::default())
+    }
+}
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Extend<FooBar<T>> for FooBarArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<T>,
+{
+    fn extend<_I: ::std::iter::IntoIterator<Item = FooBar<T>>>(&mut self, iter: _I) {
+        iter.into_iter()
+            .for_each(|FooBar(_0)| {
+                self.0.extend(::std::iter::once(_0));
+            });
+    }
+}
+impl<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
+for FooBarArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+{
+    #[inline]
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/simple.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.rs
@@ -1,0 +1,8 @@
+#[derive(narrow_derive::ArrayType)]
+struct Foo(u32);
+
+#[derive(narrow_derive::ArrayType)]
+struct Bar(u8, u16, u32, u64);
+
+#[derive(narrow_derive::ArrayType)]
+struct FooBar<T>(T);

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -27,6 +27,17 @@ where
 {
 }
 
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Default
+    for StructArray<T, NULLABLE, Buffer>
+where
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>: Default,
+{
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
 impl<T: StructArrayType, U, const NULLABLE: bool, Buffer: BufferType> FromIterator<U>
     for StructArray<T, NULLABLE, Buffer>
 where
@@ -35,6 +46,17 @@ where
 {
     fn from_iter<I: IntoIterator<Item = U>>(iter: I) -> Self {
         Self(iter.into_iter().collect())
+    }
+}
+
+impl<T: StructArrayType, U, const NULLABLE: bool, Buffer: BufferType> Extend<U>
+    for StructArray<T, NULLABLE, Buffer>
+where
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>: Extend<U>,
+{
+    fn extend<I: IntoIterator<Item = U>>(&mut self, iter: I) {
+        self.0.extend(iter);
     }
 }
 

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -1,31 +1,131 @@
 #[cfg(feature = "derive")]
 mod tests {
-    use narrow::{array::StructArray, bitmap::ValidityBitmap, ArrayType, Length};
+    mod derive {
+        mod r#struct {
+            mod unit {
+                use narrow::{
+                    array::{StructArray, VariableSizeListArray},
+                    bitmap::ValidityBitmap,
+                    buffer::BoxBuffer,
+                    ArrayType, Length,
+                };
 
-    #[test]
-    fn unit_struct() {
-        #[derive(ArrayType, Copy, Clone, Default)]
-        pub struct Foo;
+                #[derive(ArrayType, Copy, Clone, Default)]
+                struct Foo;
 
-        let input = [Foo; 5];
-        let array = input.into_iter().collect::<StructArray<Foo>>();
-        assert_eq!(array.len(), 5);
+                #[derive(ArrayType, Copy, Clone, Default)]
+                struct Bar<const N: bool = false>
+                where
+                    Self: Sized;
 
-        let input = [Some(Foo); 5];
-        let array = input.into_iter().collect::<StructArray<Foo, true>>();
-        assert_eq!(array.len(), 5);
-        assert!(array.all_valid());
-    }
+                #[test]
+                fn non_nullable() {
+                    let input = [Foo; 5];
+                    let array = input.into_iter().collect::<StructArray<Foo>>();
+                    assert_eq!(array.len(), 5);
+                }
 
-    #[test]
-    fn unit_struct_generic() {
-        #[derive(ArrayType, Copy, Clone, Default)]
-        pub struct Bar<const N: bool = false>
-        where
-            Self: Sized;
+                #[test]
+                fn nullable() {
+                    let input = [Some(Foo); 5];
+                    let array = input.into_iter().collect::<StructArray<Foo, true>>();
+                    assert_eq!(array.len(), 5);
+                    assert!(array.all_valid());
+                }
 
-        let input = [Bar, Bar];
-        let array = input.into_iter().collect::<StructArray<Bar>>();
-        assert_eq!(array.len(), 2);
+                #[test]
+                fn generic() {
+                    let input = [Bar, Bar];
+                    let array = input.into_iter().collect::<StructArray<Bar>>();
+                    assert_eq!(array.len(), 2);
+                }
+
+                #[test]
+                fn nested() {
+                    let input = vec![
+                        Some(vec![Foo; 1]),
+                        None,
+                        Some(vec![Foo; 2]),
+                        Some(vec![Foo; 3]),
+                    ];
+                    let array = input
+                        .into_iter()
+                        .collect::<VariableSizeListArray<StructArray<Foo>, true>>();
+                    assert_eq!(array.len(), 4);
+                }
+
+                #[test]
+                fn buffer() {
+                    let input = [Foo; 5];
+                    let array = input
+                        .into_iter()
+                        .collect::<StructArray<Foo, false, BoxBuffer>>();
+                    assert_eq!(array.len(), 5);
+                }
+            }
+
+            mod unnamed {
+                use narrow::{
+                    array::{StructArray, VariableSizeListArray},
+                    bitmap::ValidityBitmap,
+                    ArrayType, Length,
+                };
+
+                #[derive(ArrayType, Default)]
+                struct Foo(u32, u16);
+
+                #[derive(ArrayType, Default)]
+                struct Bar(Foo);
+
+                #[derive(ArrayType, Default)]
+                struct FooBar<T>(Bar, T);
+
+                #[test]
+                fn non_nullable() {
+                    let input = [Foo(1, 2), Foo(3, 4)];
+                    let array = input.into_iter().collect::<StructArray<Foo>>();
+                    assert_eq!(array.len(), 2);
+
+                    let input = [Bar(Foo(1, 2)), Bar(Foo(3, 4)), Bar(Foo(5, 6))];
+                    let array = input.into_iter().collect::<StructArray<Bar>>();
+                    assert_eq!(array.len(), 3);
+                }
+
+                #[test]
+                fn nullable() {
+                    let input = [Some(Foo(1, 2)), None, Some(Foo(3, 4))];
+                    let array = input.into_iter().collect::<StructArray<Foo, true>>();
+                    assert_eq!(array.len(), 3);
+                    assert_eq!(array.is_valid(0), Some(true));
+                    assert_eq!(array.is_null(1), Some(true));
+                    assert_eq!(array.is_valid(2), Some(true));
+
+                    let input = [Some(Bar(Foo(1, 2))), None];
+                    let array = input.into_iter().collect::<StructArray<Bar, true>>();
+                    assert_eq!(array.len(), 2);
+                }
+
+                #[test]
+                fn generic() {
+                    let input = [FooBar(Bar(Foo(1, 2)), false), FooBar(Bar(Foo(1, 2)), false)];
+                    let array = input.into_iter().collect::<StructArray<FooBar<_>>>();
+                    assert_eq!(array.len(), 2);
+                }
+
+                #[test]
+                fn nested() {
+                    let input = vec![
+                        Some(vec![Some(FooBar(Bar::default(), 1234))]),
+                        None,
+                        Some(vec![None]),
+                        Some(vec![None, None]),
+                    ];
+                    let array = input
+                        .into_iter()
+                        .collect::<VariableSizeListArray<StructArray<FooBar<_>, true>, true>>();
+                    assert_eq!(array.len(), 4);
+                }
+            }
+        }
     }
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -72,42 +72,49 @@ mod tests {
                 };
 
                 #[derive(ArrayType, Default)]
-                struct Foo(u32, u16);
+                struct Foo<'a>(u32, u16, &'a str);
 
                 #[derive(ArrayType, Default)]
-                struct Bar(Foo);
+                struct Bar<'a>(Foo<'a>);
 
                 #[derive(ArrayType, Default)]
-                struct FooBar<T>(Bar, T);
+                struct FooBar<'a, T>(Bar<'a>, T);
 
                 #[test]
                 fn non_nullable() {
-                    let input = [Foo(1, 2), Foo(3, 4)];
+                    let input = [Foo(1, 2, "as"), Foo(3, 4, "df")];
                     let array = input.into_iter().collect::<StructArray<Foo>>();
                     assert_eq!(array.len(), 2);
 
-                    let input = [Bar(Foo(1, 2)), Bar(Foo(3, 4)), Bar(Foo(5, 6))];
+                    let input = [
+                        Bar(Foo(1, 2, "hello")),
+                        Bar(Foo(3, 4, "world")),
+                        Bar(Foo(5, 6, "!")),
+                    ];
                     let array = input.into_iter().collect::<StructArray<Bar>>();
                     assert_eq!(array.len(), 3);
                 }
 
                 #[test]
                 fn nullable() {
-                    let input = [Some(Foo(1, 2)), None, Some(Foo(3, 4))];
+                    let input = [Some(Foo(1, 2, "n")), None, Some(Foo(3, 4, "arrow"))];
                     let array = input.into_iter().collect::<StructArray<Foo, true>>();
                     assert_eq!(array.len(), 3);
                     assert_eq!(array.is_valid(0), Some(true));
                     assert_eq!(array.is_null(1), Some(true));
                     assert_eq!(array.is_valid(2), Some(true));
 
-                    let input = [Some(Bar(Foo(1, 2))), None];
+                    let input = [Some(Bar(Foo(1, 2, "yes"))), None];
                     let array = input.into_iter().collect::<StructArray<Bar, true>>();
                     assert_eq!(array.len(), 2);
                 }
 
                 #[test]
                 fn generic() {
-                    let input = [FooBar(Bar(Foo(1, 2)), false), FooBar(Bar(Foo(1, 2)), false)];
+                    let input = [
+                        FooBar(Bar(Foo(1, 2, "n")), false),
+                        FooBar(Bar(Foo(1, 2, "arrow")), false),
+                    ];
                     let array = input.into_iter().collect::<StructArray<FooBar<_>>>();
                     assert_eq!(array.len(), 2);
                 }
@@ -115,7 +122,7 @@ mod tests {
                 #[test]
                 fn nested() {
                     let input = vec![
-                        Some(vec![Some(FooBar(Bar::default(), 1234))]),
+                        Some(vec![Some(FooBar(Bar(Foo(42, 0, "!")), 1234))]),
                         None,
                         Some(vec![None]),
                         Some(vec![None, None]),


### PR DESCRIPTION
```rust
#[derive(ArrayType, Default)]
struct Foo<'a>(u32, u16, &'a str);

#[derive(ArrayType, Default)]
struct Bar<'a>(Foo<'a>);

#[derive(ArrayType, Default)]
struct FooBar<'a, T>(Bar<'a>, T);

let input = [
    FooBar(Bar(Foo(1, 2, "n")), false),
    FooBar(Bar(Foo(1, 2, "arrow")), false),
];
let array = input.into_iter().collect::<StructArray<FooBar<_>>>();
assert_eq!(array.len(), 2);

let input = vec![
    Some(vec![Some(FooBar(Bar(Foo(42, 0, "!"), 1234))]),
    None,
    Some(vec![None]),
    Some(vec![None, None]),
];
let array = input
    .into_iter()
    .collect::<VariableSizeListArray<StructArray<FooBar<_>, true>, true>>();
assert_eq!(array.len(), 4);
```