### PR TITLE
chore(ci): fix Rust cache keys

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -24,11 +26,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-bench-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-bench-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-bench-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-bench-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
       - run: cargo bench --bench narrow -- --output-format=bencher | tee output.txt
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -20,11 +22,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-docs-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-docs-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-docs-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-docs-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
       - run: cargo doc --no-deps
       - run: chmod -c -R +rX "target/doc"
       - run: echo "<meta http-equiv=refresh content=0;url=narrow>" > target/doc/index.html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -24,11 +26,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-smart-release@0.20.0 --locked || true
       - run: cargo check --all
       - id: changelog
@@ -48,6 +50,8 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PAT }}
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -56,11 +60,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-release-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
       - run: cargo install cargo-smart-release@0.20.0 --locked || true
       - run: |
           git config user.name github-actions[bot]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,51 +36,51 @@ jobs:
       - id: changelog
         run: cargo changelog --no-preview narrow narrow-derive || echo "skip=true" >> "$GITHUB_OUTPUT"
 
-  release:
-    name: Release
-    needs: changelog
-    runs-on: ubuntu-latest
-    concurrency: release
-    if: needs.changelog.outputs.skip != 'true'
-    environment:
-      name: crates.io
-      url: https://crates.io/crates/narrow/${{ steps.version.outputs.version }}
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.PAT }}
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
-            ${{ runner.os }}-cargo-
-      - run: cargo install cargo-smart-release@0.20.0 --locked || true
-      - run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          GH_TOKEN: ${{ secrets.PAT }}
-        run: |
-          cargo smart-release \
-            --update-crates-index \
-            --allow-fully-generated-changelogs \
-            --no-changelog-preview \
-            --verbose \
-            --execute \
-            narrow
-      - id: version
-        env:
-          GH_TOKEN: ${{ secrets.PAT }}
-        run: echo "version=$(gh release view --json tagName -t '{{ slice .tagName 1 }}')" >> "$GITHUB_OUTPUT"
+  # release:
+  #   name: Release
+  #   needs: changelog
+  #   runs-on: ubuntu-latest
+  #   concurrency: release
+  #   if: needs.changelog.outputs.skip != 'true'
+  #   environment:
+  #     name: crates.io
+  #     url: https://crates.io/crates/narrow/${{ steps.version.outputs.version }}
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #         token: ${{ secrets.PAT }}
+  #     - uses: dtolnay/rust-toolchain@stable
+  #       id: rust-toolchain
+  #     - uses: actions/cache@v3
+  #       with:
+  #         path: |
+  #           ~/.cargo/bin/
+  #           ~/.cargo/registry/index/
+  #           ~/.cargo/registry/cache/
+  #           ~/.cargo/git/db/
+  #           target/
+  #         key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.toml') }}
+  #         restore-keys: |
+  #           ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
+  #           ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
+  #           ${{ runner.os }}-cargo-
+  #     - run: cargo install cargo-smart-release@0.20.0 --locked || true
+  #     - run: |
+  #         git config user.name github-actions[bot]
+  #         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+  #     - env:
+  #         CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+  #         GH_TOKEN: ${{ secrets.PAT }}
+  #       run: |
+  #         cargo smart-release \
+  #           --update-crates-index \
+  #           --allow-fully-generated-changelogs \
+  #           --no-changelog-preview \
+  #           --verbose \
+  #           --execute \
+  #           narrow
+  #     - id: version
+  #       env:
+  #         GH_TOKEN: ${{ secrets.PAT }}
+  #       run: echo "version=$(gh release view --json tagName -t '{{ slice .tagName 1 }}')" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@1.65.0
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -20,11 +22,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-msrv-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-msrv-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-msrv-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@1.65.0
       - run: cargo check --all
 
   check:
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -40,11 +44,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-check-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-check-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-check-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-check-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
       - run: cargo check --all
 
   test:
@@ -52,6 +56,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -60,12 +66,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-test-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-test-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-test-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: dtolnay/rust-toolchain@stable
       - uses: dtolnay/install@master
         with:
           crate: cargo-expand
@@ -87,6 +93,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+        with:
+          components: clippy
       - uses: actions/cache@v3
         with:
           path: |
@@ -95,13 +105,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-clippy-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-clippy-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-clippy-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
       - run: cargo clippy --all -- -Dwarnings
 
   miri:
@@ -109,6 +117,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@miri
+        id: rust-toolchain
       - uses: actions/cache@v3
         with:
           path: |
@@ -117,11 +127,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-miri-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-miri-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-miri-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-miri-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@miri
       - run: cargo miri setup
       - run: cargo miri test
 
@@ -133,6 +143,10 @@ jobs:
       RUSTDOCFLAGS: "-C instrument-coverage"
     steps:
       - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        id: rust-toolchain
+        with:
+          components: llvm-tools-preview
       - uses: actions/cache@v3
         with:
           path: |
@@ -141,13 +155,11 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-coverage-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-coverage-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-coverage-
+            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: llvm-tools-preview
       - uses: dtolnay/install@master
         with:
           crate: cargo-expand


### PR DESCRIPTION
The rustc version should be part of the cache key.