### PR TITLE
feat: add `arrow-rs` buffer interop via optional `arrow-buffer` feature

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-bench-
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - run: cargo bench --bench narrow -- --output-format=bencher | tee output.txt
+      - run: cargo bench --bench narrow --all-features -- --output-format=bencher | tee output.txt
       - uses: actions/upload-artifact@v3
         with:
           name: benchmark-results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
       - run: cargo install cargo-smart-release@0.20.0 --locked || true
-      - run: cargo check --all
+      - run: cargo check --all --all-features
       - id: changelog
         run: cargo changelog --no-preview narrow narrow-derive || echo "skip=true" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-msrv-
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - run: cargo check --all
+      - run: cargo check --all --all-features
 
   check:
     name: Check
@@ -49,7 +49,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-check-
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - run: cargo check --all
+      - run: cargo check --all --all-features
 
   test:
     name: Test
@@ -75,8 +75,8 @@ jobs:
       - uses: dtolnay/install@master
         with:
           crate: cargo-expand
-      - run: cargo test --all
-      - run: cargo test --benches
+      - run: cargo test --all --all-features
+      - run: cargo test --benches --all-features
 
   rustfmt:
     name: Rustfmt
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-clippy-
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
-      - run: cargo clippy --all -- -Dwarnings
+      - run: cargo clippy --all --all-features -- -Dwarnings
 
   miri:
     name: Miri
@@ -133,7 +133,7 @@ jobs:
             ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
             ${{ runner.os }}-cargo-
       - run: cargo miri setup
-      - run: cargo miri test
+      - run: cargo miri test --all-features
 
   coverage:
     name: Coverage
@@ -163,8 +163,8 @@ jobs:
       - uses: dtolnay/install@master
         with:
           crate: cargo-expand
-      - run: cargo build --all
-      - run: cargo test --all
+      - run: cargo build --all --all-features
+      - run: cargo test --all --all-features
         env:
           LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"
       - name: Install grcov

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,13 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
-default = ["derive", "unsafe"]
+default = ["arrow-buffer", "derive", "unsafe"]
+arrow-buffer = ["dep:arrow-buffer"]
 derive = ["dep:narrow-derive"]
 unsafe = []
 
 [dependencies]
+arrow-buffer = { version = "44.0.0", default-features = false, optional = true }
 narrow-derive = { path = "narrow-derive", version = "^0.3.4", optional = true }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ derive = ["dep:narrow-derive"]
 unsafe = []
 
 [dependencies]
-arrow-buffer = { version = "44.0.0", default-features = false, optional = true }
+arrow-buffer = { git = "https://github.com/mbrobbel/arrow-rs.git", branch = "arrow-native-type", optional = true }
 narrow-derive = { path = "narrow-derive", version = "^0.3.4", optional = true }
 
 [dev-dependencies]

--- a/src/array/fixed_size_primitive.rs
+++ b/src/array/fixed_size_primitive.rs
@@ -209,16 +209,17 @@ mod tests {
     #[test]
     #[cfg(feature = "arrow-buffer")]
     fn arrow_buffer() {
-        use crate::buffer::{ArrowBuffer, ArrowMutableBuffer};
+        use crate::buffer::ArrowBuffer;
 
         let input = [1, 2, 3, 4];
-        let array = input.into_iter().collect::<Int8Array<false, ArrowBuffer>>();
-        // TODO(mbrobbel): nr of bytes
+        let mut array = input.into_iter().collect::<Int8Array<false, ArrowBuffer>>();
         assert_eq!(array.len(), 4);
+        // Use arrow_buffer
+        array.0.append_n(5, 5);
+        assert_eq!(array.0.as_slice(), &[1, 2, 3, 4, 5, 5, 5, 5, 5]);
 
         let input = [Some(1), None, Some(3), Some(4)];
-        let array = input
-            .into_iter()
-            .collect::<Int8Array<true, ArrowMutableBuffer>>();
+        let array = input.into_iter().collect::<Int8Array<true, ArrowBuffer>>();
+        assert_eq!(array.len(), 4);
     }
 }

--- a/src/array/fixed_size_primitive.rs
+++ b/src/array/fixed_size_primitive.rs
@@ -205,4 +205,20 @@ mod tests {
             mem::size_of::<Int8Array>() + mem::size_of::<Bitmap>()
         );
     }
+
+    #[test]
+    #[cfg(feature = "arrow-buffer")]
+    fn arrow_buffer() {
+        use crate::buffer::{ArrowBuffer, ArrowMutableBuffer};
+
+        let input = [1, 2, 3, 4];
+        let array = input.into_iter().collect::<Int8Array<false, ArrowBuffer>>();
+        // TODO(mbrobbel): nr of bytes
+        assert_eq!(array.len(), 4);
+
+        let input = [Some(1), None, Some(3), Some(4)];
+        let array = input
+            .into_iter()
+            .collect::<Int8Array<true, ArrowMutableBuffer>>();
+    }
 }

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -475,14 +475,14 @@ mod tests {
     #[test]
     #[cfg(feature = "arrow-buffer")]
     fn arrow_buffer() {
-        use crate::buffer::{ArrowBuffer, ArrowMutableBuffer};
+        use crate::buffer::ArrowBuffer;
 
         let input = vec![true, false, true];
         let bitmap = input.into_iter().collect::<Bitmap<ArrowBuffer>>();
         assert_eq!(bitmap.len(), 3);
 
         let input = vec![true, false, true];
-        let bitmap = input.into_iter().collect::<Bitmap<ArrowMutableBuffer>>();
+        let bitmap = input.into_iter().collect::<Bitmap<ArrowBuffer>>();
         assert_eq!(bitmap.len(), 3);
         assert_eq!(bitmap.into_iter().collect::<Vec<_>>(), [true, false, true]);
     }

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -471,4 +471,19 @@ mod tests {
             mem::size_of::<Box<[u8]>>() + 2 * mem::size_of::<usize>()
         );
     }
+
+    #[test]
+    #[cfg(feature = "arrow-buffer")]
+    fn arrow_buffer() {
+        use crate::buffer::{ArrowBuffer, ArrowMutableBuffer};
+
+        let input = vec![true, false, true];
+        let bitmap = input.into_iter().collect::<Bitmap<ArrowBuffer>>();
+        assert_eq!(bitmap.len(), 3);
+
+        let input = vec![true, false, true];
+        let bitmap = input.into_iter().collect::<Bitmap<ArrowMutableBuffer>>();
+        assert_eq!(bitmap.len(), 3);
+        assert_eq!(bitmap.into_iter().collect::<Vec<_>>(), [true, false, true]);
+    }
 }

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -387,7 +387,7 @@ pub struct ArrowMutableBuffer;
 
 #[cfg(feature = "arrow-buffer")]
 impl BufferType for ArrowMutableBuffer {
-    type Buffer<T: FixedSize> = arrow_buffer::Buffer;
+    type Buffer<T: FixedSize> = arrow_buffer::MutableBuffer;
 }
 
 #[cfg(feature = "arrow-buffer")]

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -359,64 +359,33 @@ impl<T: FixedSize> BufferMut<T> for Rc<[T]> {
 }
 
 #[cfg(feature = "arrow-buffer")]
-/// A [BufferType] implementation for [arrow_buffer::Buffer].
-pub struct ArrowBuffer;
+mod arrow {
+    use super::{Buffer, BufferMut, BufferType};
+    use crate::FixedSize;
+    use arrow_buffer::{ArrowNativeType, BufferBuilder};
 
-#[cfg(feature = "arrow-buffer")]
-impl BufferType for ArrowBuffer {
-    type Buffer<T: FixedSize> = arrow_buffer::Buffer;
-}
+    /// A [BufferType] implementation for [arrow_buffer::BufferBuilder].
+    pub struct ArrowBuffer;
 
-#[cfg(feature = "arrow-buffer")]
-impl<T: FixedSize> Buffer<T> for arrow_buffer::Buffer {
-    fn as_slice(&self) -> &[T] {
-        // This only works if FixedSize: arrow_buffer::ArrowNativeType, however that forces us to remove some FixedSize impls.
-        // self.typed_data()
+    impl BufferType for ArrowBuffer {
+        type Buffer<T: FixedSize> = BufferBuilder<T>;
+    }
 
-        // Instead we copy the logic here and rely on our trait for safety.
-        // https://github.com/apache/arrow-rs/blob/5724cf21c23aa9d5a3ef06b6381cf267903746ee/arrow-buffer/src/buffer/immutable.rs#L228-L235
-        let (prefix, offsets, suffix) = unsafe { self.as_slice().align_to::<T>() };
-        assert!(prefix.is_empty() && suffix.is_empty());
-        offsets
+    impl<T: FixedSize + ArrowNativeType> Buffer<T> for BufferBuilder<T> {
+        fn as_slice(&self) -> &[T] {
+            BufferBuilder::as_slice(self)
+        }
+    }
+
+    impl<T: FixedSize + ArrowNativeType> BufferMut<T> for BufferBuilder<T> {
+        fn as_mut_slice(&mut self) -> &mut [T] {
+            BufferBuilder::as_slice_mut(self)
+        }
     }
 }
 
 #[cfg(feature = "arrow-buffer")]
-/// A [BufferType] implementation for [arrow_buffer::Buffer].
-pub struct ArrowMutableBuffer;
-
-#[cfg(feature = "arrow-buffer")]
-impl BufferType for ArrowMutableBuffer {
-    type Buffer<T: FixedSize> = arrow_buffer::MutableBuffer;
-}
-
-#[cfg(feature = "arrow-buffer")]
-impl<T: FixedSize> Buffer<T> for arrow_buffer::MutableBuffer {
-    fn as_slice(&self) -> &[T] {
-        // This only works if FixedSize: arrow_buffer::ArrowNativeType, however that forces us to remove some FixedSize impls.
-        // self.typed_data()
-
-        // Instead we copy the logic here and rely on our trait for safety.
-        // https://github.com/apache/arrow-rs/blob/5724cf21c23aa9d5a3ef06b6381cf267903746ee/arrow-buffer/src/buffer/immutable.rs#L228-L235
-        let (prefix, offsets, suffix) = unsafe { self.as_slice().align_to::<T>() };
-        assert!(prefix.is_empty() && suffix.is_empty());
-        offsets
-    }
-}
-
-#[cfg(feature = "arrow-buffer")]
-impl<T: FixedSize> BufferMut<T> for arrow_buffer::MutableBuffer {
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        // This only works if FixedSize: arrow_buffer::ArrowNativeType, however that forces us to remove some FixedSize impls.
-        // self.typed_data()
-
-        // Instead we copy the logic here and rely on our trait for safety.
-        // https://github.com/apache/arrow-rs/blob/5724cf21c23aa9d5a3ef06b6381cf267903746ee/arrow-buffer/src/buffer/mutable.rs#L351-L359
-        let (prefix, offsets, suffix) = unsafe { self.as_slice_mut().align_to_mut::<T>() };
-        assert!(prefix.is_empty() && suffix.is_empty());
-        offsets
-    }
-}
+pub use arrow::*;
 
 #[cfg(test)]
 mod tests {
@@ -486,10 +455,10 @@ mod tests {
     #[test]
     #[cfg(feature = "arrow-buffer")]
     fn arrow() {
-        let buffer = arrow_buffer::Buffer::from_vec(vec![1, 2, 3, 4]);
+        let buffer = arrow_buffer::BufferBuilder::from_iter([1, 2, 3, 4]);
         assert_eq!(<_ as Buffer<u32>>::as_slice(&buffer), &[1, 2, 3, 4]);
 
-        let mut buffer = arrow_buffer::MutableBuffer::from_vec(vec![1u64, 2, 3, 4]);
+        let mut buffer = arrow_buffer::BufferBuilder::from_iter([1u64, 2, 3, 4]);
         assert_eq!(
             <_ as BufferMut<u64>>::as_mut_slice(&mut buffer),
             &[1, 2, 3, 4]

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -10,7 +10,16 @@ use std::fmt::Debug;
 /// fixed-size types.
 ///
 /// This trait is sealed to prevent downstream implementations.
+#[cfg(not(feature = "arrow-buffer"))]
 pub trait FixedSize: ArrayType + Copy + Debug + Sized + sealed::Sealed + 'static {
+    /// The fixed-size of this type in bytes.
+    const SIZE: usize = std::mem::size_of::<Self>();
+}
+
+#[cfg(feature = "arrow-buffer")]
+pub trait FixedSize:
+    arrow_buffer::ArrowNativeType + ArrayType + Copy + Debug + Sized + sealed::Sealed + 'static
+{
     /// The fixed-size of this type in bytes.
     const SIZE: usize = std::mem::size_of::<Self>();
 }
@@ -47,7 +56,7 @@ mod sealed {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::FixedSize;
 
     #[test]
     fn size() {

--- a/src/length.rs
+++ b/src/length.rs
@@ -92,15 +92,13 @@ impl<T: Length> Length for Option<T> {
 }
 
 #[cfg(feature = "arrow-buffer")]
-impl Length for arrow_buffer::Buffer {
-    fn len(&self) -> usize {
-        arrow_buffer::Buffer::len(self)
-    }
-}
+mod arrow {
+    use crate::Length;
+    use arrow_buffer::{ArrowNativeType, BufferBuilder};
 
-#[cfg(feature = "arrow-buffer")]
-impl Length for arrow_buffer::MutableBuffer {
-    fn len(&self) -> usize {
-        arrow_buffer::MutableBuffer::len(self)
+    impl<T: ArrowNativeType> Length for BufferBuilder<T> {
+        fn len(&self) -> usize {
+            BufferBuilder::len(self)
+        }
     }
 }

--- a/src/length.rs
+++ b/src/length.rs
@@ -90,3 +90,17 @@ impl<T: Length> Length for Option<T> {
         }
     }
 }
+
+#[cfg(feature = "arrow-buffer")]
+impl Length for arrow_buffer::Buffer {
+    fn len(&self) -> usize {
+        arrow_buffer::Buffer::len(self)
+    }
+}
+
+#[cfg(feature = "arrow-buffer")]
+impl Length for arrow_buffer::MutableBuffer {
+    fn len(&self) -> usize {
+        arrow_buffer::MutableBuffer::len(self)
+    }
+}


### PR DESCRIPTION
Closes #94. 

- [x] Wait on upstream PR for `Default` impl for `MutableBuffer`
- [ ] Switch to `BufferBuilder` for mutable buffers
- [ ] Fix `Length` impl issue (bytes len vs items len) -> should be fixed after switching to `BufferBuilder`
- [ ] Remove from default features