### PR TITLE
chore(deps): revert codecov/codecov-action from 4 to 3

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,6 +1,1 @@
 comment: false
-coverage:
-  status:
-    project:
-      default:
-        informational: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,4 @@ jobs:
         run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: grcov
         run: ./grcov --branch --binary-path ./target/debug/ --source-dir . --output-type lcov --output-path lcov.info .
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+      - uses: codecov/codecov-action@v3


### PR DESCRIPTION
It seems the tag was removed?

```console
Error: Unable to resolve action `codecov/codecov-action@v4`, unable to find version `v4`
```

Reverting.