### PR TITLE
Add `Index` trait

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.66.0
+      - uses: dtolnay/rust-toolchain@1.67.0
         id: rust-toolchain
       - uses: actions/cache@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.67.0"
 description = "An implementation of Apache Arrow"
 readme = "README.md"
 repository = "https://github.com/mbrobbel/narrow"
@@ -35,8 +35,8 @@ derive = ["dep:narrow-derive"]
 narrow-derive = { path = "narrow-derive", version = "^0.3.4", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.5", default-features = false }
-rand = { version = "0.8", default-features = false, features = ["small_rng"] }
+criterion = { version = "0.5.1", default-features = false }
+rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 
 [profile.bench]
 lto = true

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -188,13 +188,13 @@ mod tests {
             .map(ToOwned::to_owned)
             .collect::<Utf8Array>();
         assert_eq!(array.len(), 4);
-        assert_eq!(array.0 .0 .0.data.0, b"1234567890");
+        assert_eq!(array.0 .0.data.0, b"1234567890");
 
         let input_string = vec!["a".to_owned(), "sd".to_owned(), "f".to_owned()];
         let array_string = input_string.into_iter().collect::<StringArray>();
         assert_eq!(array_string.len(), 3);
-        assert_eq!(array_string.0 .0 .0.data.0, &[97, 115, 100, 102]);
-        assert_eq!(array_string.0 .0 .0.offsets, &[0, 1, 3, 4]);
+        assert_eq!(array_string.0 .0.data.0, &[97, 115, 100, 102]);
+        assert_eq!(array_string.0 .0.offsets, &[0, 1, 3, 4]);
     }
 
     #[test]
@@ -214,8 +214,8 @@ mod tests {
         assert_eq!(array.is_valid(3), Some(true));
         assert_eq!(array.is_valid(4), Some(false));
         assert_eq!(array.is_valid(5), None);
-        assert_eq!(array.0 .0 .0.data.0, "asdf".as_bytes());
-        assert_eq!(array.0 .0 .0.offsets.as_ref(), &[0, 1, 1, 3, 4, 4]);
+        assert_eq!(array.0 .0.data.0, "asdf".as_bytes());
+        assert_eq!(array.0 .0.offsets.as_ref(), &[0, 1, 1, 3, 4, 4]);
         assert_eq!(
             array.bitmap_ref().into_iter().collect::<Vec<_>>(),
             &[true, false, true, true, false]

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -308,11 +308,11 @@ mod tests {
             &[0, 1, 3, 4, 4]
         );
         assert_eq!(
-            array.0.g.0 .0 .0.data.into_iter().collect::<Vec<_>>(),
+            array.0.g.0 .0.data.into_iter().collect::<Vec<_>>(),
             &[97, 115, 100, 102] // a s d f
         );
         assert_eq!(
-            array.0.g.0 .0 .0.offsets.into_iter().collect::<Vec<_>>(),
+            array.0.g.0 .0.offsets.into_iter().collect::<Vec<_>>(),
             &[0, 1, 2, 3, 4]
         );
 

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -3,10 +3,10 @@
 use super::{Array, FixedSizePrimitiveArray, StringArray, VariableSizeListArray};
 use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
-    buffer::{BufferType, VecBuffer},
-    offset::OffsetElement,
+    buffer::{Buffer, BufferType, VecBuffer},
+    offset::{Offset, OffsetElement},
     validity::Validity,
-    Length,
+    Index, Length,
 };
 
 /// Variable-size binary elements.
@@ -14,14 +14,7 @@ pub struct VariableSizeBinaryArray<
     const NULLABLE: bool = false,
     OffsetItem: OffsetElement = i32,
     Buffer: BufferType = VecBuffer,
->(
-    pub  VariableSizeListArray<
-        FixedSizePrimitiveArray<u8, false, Buffer>,
-        NULLABLE,
-        OffsetItem,
-        Buffer,
-    >,
-)
+>(pub Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>)
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>;
 
@@ -44,11 +37,10 @@ impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Defaul
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
-    VariableSizeListArray<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>:
-        Default,
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>: Default,
 {
     fn default() -> Self {
-        Self(VariableSizeListArray::default())
+        Self(Offset::default())
     }
 }
 
@@ -56,8 +48,7 @@ impl<T, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Ext
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
-    VariableSizeListArray<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>:
-        Extend<T>,
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>: Extend<T>,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.0.extend(iter);
@@ -84,7 +75,7 @@ where
             Buffer,
         >,
     ) -> Self {
-        Self(value)
+        Self(value.0)
     }
 }
 
@@ -92,15 +83,8 @@ impl<OffsetItem: OffsetElement, Buffer: BufferType>
     From<VariableSizeBinaryArray<false, OffsetItem, Buffer>>
     for VariableSizeBinaryArray<true, OffsetItem, Buffer>
 where
-    VariableSizeListArray<FixedSizePrimitiveArray<u8, false, Buffer>, false, OffsetItem, Buffer>:
-        Into<
-            VariableSizeListArray<
-                FixedSizePrimitiveArray<u8, false, Buffer>,
-                true,
-                OffsetItem,
-                Buffer,
-            >,
-        >,
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, false, OffsetItem, Buffer>:
+        Into<Offset<FixedSizePrimitiveArray<u8, false, Buffer>, true, OffsetItem, Buffer>>,
 {
     fn from(value: VariableSizeBinaryArray<false, OffsetItem, Buffer>) -> Self {
         Self(value.0.into())
@@ -122,7 +106,7 @@ impl<T, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Fro
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
-    VariableSizeListArray<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>:
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>:
         FromIterator<T>,
 {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
@@ -130,12 +114,41 @@ where
     }
 }
 
+impl<OffsetItem: OffsetElement, Buffer: BufferType> Index
+    for VariableSizeBinaryArray<false, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Index,
+{
+    type Item<'a> = &'a [u8]
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        let start: usize = self
+            .0
+            .offsets
+            .as_slice()
+            .index_unchecked(index)
+            .to_owned()
+            .try_into()
+            .expect("convert fail");
+        let end: usize = self
+            .0
+            .offsets
+            .as_slice()
+            .index_unchecked(index + 1)
+            .to_owned()
+            .try_into()
+            .expect("convert fail");
+        &self.0.data.0.as_slice()[start..end]
+    }
+}
+
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Length
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
-    VariableSizeListArray<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>:
-        Length,
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>: Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -182,14 +195,14 @@ mod tests {
             .map(<[u8]>::to_vec)
             .collect::<VariableSizeBinaryArray>();
         assert_eq!(array.len(), 4);
-        assert_eq!(array.0 .0.data.0, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
-        assert_eq!(array.0 .0.offsets, &[0, 1, 3, 6, 10]);
+        assert_eq!(array.0.data.0, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+        assert_eq!(array.0.offsets, &[0, 1, 3, 6, 10]);
 
         let input_vec = vec![vec![1], vec![], vec![2, 3], vec![4]];
         let array_vec = input_vec.into_iter().collect::<VariableSizeBinaryArray>();
         assert_eq!(array_vec.len(), 4);
-        assert_eq!(array_vec.0 .0.data.0, &[1, 2, 3, 4]);
-        assert_eq!(array_vec.0 .0.offsets, &[0, 1, 1, 3, 4]);
+        assert_eq!(array_vec.0.data.0, &[1, 2, 3, 4]);
+        assert_eq!(array_vec.0.offsets, &[0, 1, 1, 3, 4]);
     }
 
     #[test]
@@ -200,27 +213,40 @@ mod tests {
             .map(|x| x.map(<[u8]>::to_vec))
             .collect::<VariableSizeBinaryArray<true>>();
         assert_eq!(array.len(), 4);
-        assert_eq!(array.0 .0.data.0, &[1, 4, 5, 6, 7, 8, 9, 0]);
-        assert_eq!(array.0 .0.offsets.as_ref(), &[0, 1, 1, 4, 8]);
-        assert_eq!(array.0 .0.offsets.bitmap_ref().buffer_ref(), &[0b000_01101]);
+        assert_eq!(array.0.data.0, &[1, 4, 5, 6, 7, 8, 9, 0]);
+        assert_eq!(array.0.offsets.as_ref(), &[0, 1, 1, 4, 8]);
+        assert_eq!(array.0.offsets.bitmap_ref().buffer_ref(), &[0b000_01101]);
 
         let input_vec = vec![Some(vec![1]), None, Some(vec![2, 3]), Some(vec![4])];
         let array_vec = input_vec
             .into_iter()
             .collect::<VariableSizeBinaryArray<true>>();
         assert_eq!(array_vec.len(), 4);
-        assert_eq!(array_vec.0 .0.data.0, &[1, 2, 3, 4]);
-        assert_eq!(array_vec.0 .0.offsets.as_ref(), &[0, 1, 1, 3, 4]);
+        assert_eq!(array_vec.0.data.0, &[1, 2, 3, 4]);
+        assert_eq!(array_vec.0.offsets.as_ref(), &[0, 1, 1, 3, 4]);
         assert_eq!(
             array_vec
                 .0
-                 .0
                 .offsets
                 .bitmap_ref()
                 .into_iter()
                 .collect::<Vec<_>>(),
             &[true, false, true, true]
         );
+    }
+
+    #[test]
+    fn index() {
+        let input: [&[u8]; 4] = [&[1], &[2, 3], &[4, 5, 6], &[7, 8, 9, 0]];
+        let array = input
+            .into_iter()
+            .map(<[u8]>::to_vec)
+            .collect::<VariableSizeBinaryArray>();
+        assert_eq!(array.index_checked(0), &[1]);
+        assert_eq!(array.index_checked(1), &[2, 3]);
+        assert_eq!(array.index_checked(2), &[4, 5, 6]);
+        assert_eq!(array.index_checked(3), &[7, 8, 9, 0]);
+        assert!(array.index(4).is_none());
     }
 
     #[test]

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -2,13 +2,13 @@
 
 use crate::{
     buffer::{Buffer, BufferMut, BufferRef, BufferRefMut, BufferType, VecBuffer},
-    Length,
+    Index, Length,
 };
 use std::{
     any,
     borrow::Borrow,
     fmt::{Debug, Formatter, Result},
-    ops::Index,
+    ops,
 };
 
 mod iter;
@@ -246,7 +246,17 @@ where
     }
 }
 
-impl<Buffer: BufferType> Index<usize> for Bitmap<Buffer> {
+impl<Buffer: BufferType> Index for Bitmap<Buffer> {
+    type Item<'a> = bool
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<Buffer: BufferType> ops::Index<usize> for Bitmap<Buffer> {
     type Output = bool;
 
     fn index(&self, index: usize) -> &Self::Output {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -80,25 +80,13 @@ pub trait BufferMut<T: FixedSize>: Buffer<T> {
     }
 }
 
-// /// A [`BufferType`] for a single item.
-// #[derive(Clone, Copy, Debug)]
-// pub struct SingleBuffer;
+/// A [`BufferType`] for a single item.
+#[derive(Clone, Copy, Debug)]
+pub struct SingleBuffer;
 
-// impl BufferType for SingleBuffer {
-//     type Buffer<T: FixedSize> = T;
-// }
-
-// impl<T: FixedSize> Buffer<T> for T {
-//     fn as_slice(&self) -> &[T] {
-//         slice::from_ref(self)
-//     }
-// }
-
-// impl<T: FixedSize> BufferMut<T> for T {
-//     fn as_mut_slice(&mut self) -> &mut [T] {
-//         slice::from_mut(self)
-//     }
-// }
+impl BufferType for SingleBuffer {
+    type Buffer<T: FixedSize> = <ArrayBuffer<1> as BufferType>::Buffer<T>;
+}
 
 /// A [`BufferType`] implementation for array.
 ///
@@ -358,15 +346,15 @@ impl<T: FixedSize> BufferMut<T> for Rc<[T]> {
 mod tests {
     use super::*;
 
-    // #[test]
-    // fn single() {
-    //     let mut single: <SingleBuffer as BufferType>::Buffer<u16> = 1234;
-    //     assert_eq!(single.as_bytes(), [210, 4]);
-    //     single.as_mut_bytes()[1] = 0;
-    //     assert_eq!(single.as_bytes(), [210, 0]);
-    //     single.as_mut_slice()[0] = 1234;
-    //     assert_eq!(single, 1234);
-    // }
+    #[test]
+    fn single() {
+        let mut single: <SingleBuffer as BufferType>::Buffer<u16> = [1234];
+        assert_eq!(single.as_bytes(), [210, 4]);
+        single.as_mut_bytes()[1] = 0;
+        assert_eq!(single.as_bytes(), [210, 0]);
+        single.as_mut_slice()[0] = 1234;
+        assert_eq!(single, [1234]);
+    }
 
     #[test]
     fn array() {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,6 @@
 //! Traits for memory buffers.
 
-use crate::FixedSize;
+use crate::{FixedSize, Index, Length};
 use std::{marker::PhantomData, mem, rc::Rc, slice, sync::Arc};
 
 /// A memory buffer type constructor for Arrow data.
@@ -41,19 +41,9 @@ pub trait BufferRefMut<T: FixedSize> {
 }
 
 /// A contiguous immutable memory buffer for Arrow data.
-pub trait Buffer<T: FixedSize> {
+pub trait Buffer<T: FixedSize>: Index + Length {
     /// Extracts a slice containing the entire buffer.
     fn as_slice(&self) -> &[T];
-
-    /// Returns the number of items in the buffer.
-    fn len(&self) -> usize {
-        self.as_slice().len()
-    }
-
-    /// Returns `true` if buffer has a length of 0.
-    fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
 
     /// Returns the contents of the entire buffer as a byte slice.
     fn as_bytes(&self) -> &[u8] {
@@ -90,25 +80,25 @@ pub trait BufferMut<T: FixedSize>: Buffer<T> {
     }
 }
 
-/// A [`BufferType`] for a single item.
-#[derive(Clone, Copy, Debug)]
-pub struct SingleBuffer;
+// /// A [`BufferType`] for a single item.
+// #[derive(Clone, Copy, Debug)]
+// pub struct SingleBuffer;
 
-impl BufferType for SingleBuffer {
-    type Buffer<T: FixedSize> = T;
-}
+// impl BufferType for SingleBuffer {
+//     type Buffer<T: FixedSize> = T;
+// }
 
-impl<T: FixedSize> Buffer<T> for T {
-    fn as_slice(&self) -> &[T] {
-        slice::from_ref(self)
-    }
-}
+// impl<T: FixedSize> Buffer<T> for T {
+//     fn as_slice(&self) -> &[T] {
+//         slice::from_ref(self)
+//     }
+// }
 
-impl<T: FixedSize> BufferMut<T> for T {
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        slice::from_mut(self)
-    }
-}
+// impl<T: FixedSize> BufferMut<T> for T {
+//     fn as_mut_slice(&mut self) -> &mut [T] {
+//         slice::from_mut(self)
+//     }
+// }
 
 /// A [`BufferType`] implementation for array.
 ///
@@ -368,15 +358,15 @@ impl<T: FixedSize> BufferMut<T> for Rc<[T]> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn single() {
-        let mut single: <SingleBuffer as BufferType>::Buffer<u16> = 1234;
-        assert_eq!(single.as_bytes(), [210, 4]);
-        single.as_mut_bytes()[1] = 0;
-        assert_eq!(single.as_bytes(), [210, 0]);
-        single.as_mut_slice()[0] = 1234;
-        assert_eq!(single, 1234);
-    }
+    // #[test]
+    // fn single() {
+    //     let mut single: <SingleBuffer as BufferType>::Buffer<u16> = 1234;
+    //     assert_eq!(single.as_bytes(), [210, 4]);
+    //     single.as_mut_bytes()[1] = 0;
+    //     assert_eq!(single.as_bytes(), [210, 0]);
+    //     single.as_mut_slice()[0] = 1234;
+    //     assert_eq!(single, 1234);
+    // }
 
     #[test]
     fn array() {

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,0 +1,147 @@
+//! Indexing operations.
+
+use crate::Length;
+use std::{collections::VecDeque, rc::Rc, sync::Arc};
+
+/// Index operation for shared access to values in a collection.
+pub trait Index: Length {
+    /// The item.
+    type Item<'a>
+    where
+        Self: 'a;
+
+    /// Returns the value at given index. Returns `None` if the index is out of range.
+    fn index(&self, index: usize) -> Option<Self::Item<'_>> {
+        (index < self.len()).then(||
+            // Safety:
+            // - Bounds checked in predicate
+            unsafe { self.index_unchecked(index)})
+    }
+
+    /// Returns the value at given index. Panics if the index is out of bounds.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the index is out of bounds.
+    fn index_checked(&self, index: usize) -> Self::Item<'_> {
+        /// Panic when out of bounds.
+        #[cold]
+        #[inline(never)]
+        fn assert_failed(index: usize, len: usize) -> ! {
+            panic!("index (is {index}) should be < len (is {len})");
+        }
+
+        let len = self.len();
+        if index >= len {
+            assert_failed(index, len);
+        }
+
+        // Safety:
+        // - Bounds checked above.
+        unsafe { self.index_unchecked(index) }
+    }
+
+    /// Returns the value at given index. Skips bound checking.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure index is within bounds.
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_>;
+}
+
+/// Index operation for mutable access to values in a collection.
+pub trait IndexMut: Index {
+    /// Returns a mutable reference to the value at given index.
+    fn index_mut(&mut self, index: usize) -> &mut Self::Item<'_>;
+}
+
+impl<T> Index for Vec<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T, const N: usize> Index for [T; N] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for [T] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for &[T] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for &mut [T] {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for Box<[T]> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for Rc<[T]> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for Arc<[T]> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.get_unchecked(index)
+    }
+}
+
+impl<T> Index for VecDeque<T> {
+    type Item<'a> = &'a T
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        // VecDeque has no unchecked get so this panics for out of bounds access
+        std::ops::Index::index(self, index)
+    }
+}

--- a/src/length.rs
+++ b/src/length.rs
@@ -21,6 +21,13 @@ impl<const N: usize, T> Length for [T; N] {
     }
 }
 
+impl<T> Length for [T] {
+    #[inline]
+    fn len(&self) -> usize {
+        <[T]>::len(self)
+    }
+}
+
 impl<T> Length for &[T] {
     #[inline]
     fn len(&self) -> usize {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@ pub use self::fixed_size::FixedSize;
 mod length;
 pub use self::length::Length;
 
+mod index;
+pub use self::index::Index;
+
 pub mod buffer;
 
 pub mod bitmap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,8 @@ pub mod buffer;
 pub mod bitmap;
 
 pub(crate) mod nullable;
-pub(crate) mod offset;
+// TODO(mbrobbel): pub(crate)
+pub mod offset;
 pub(crate) mod validity;
 
 pub mod array;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -5,9 +5,13 @@ use crate::{
     buffer::{Buffer, BufferType, VecBuffer},
     nullable::Nullable,
     validity::Validity,
-    FixedSize, Length,
+    FixedSize, Index, Length,
 };
-use std::{iter, num::TryFromIntError, ops::AddAssign};
+use std::{
+    iter,
+    num::TryFromIntError,
+    ops::{AddAssign, Range, Sub},
+};
 
 /// Types representing offset values.
 ///
@@ -20,7 +24,9 @@ pub trait OffsetElement:
     + Default
     + TryFrom<usize, Error = TryFromIntError>
     + TryInto<usize, Error = TryFromIntError>
+    + Sub<Output = Self>
     + sealed::Sealed
+    + 'static
 {
     /// The unsigned variant of Self.
     type Unsigned: TryFrom<usize, Error = TryFromIntError>;
@@ -55,6 +61,60 @@ impl OffsetElement for i64 {
     }
     fn checked_add_unsigned(self, rhs: Self::Unsigned) -> Option<Self> {
         i64::checked_add_unsigned(self, rhs)
+    }
+}
+
+/// A reference to a slot in an offset
+pub struct OffsetSlot<'a, OffsetItem: OffsetElement, Buffer: BufferType> {
+    /// The offset buffer
+    offset: &'a <Buffer as BufferType>::Buffer<OffsetItem>,
+    /// The position in the offset
+    index: usize,
+}
+
+impl<'a, OffsetItem: OffsetElement, Buffer: BufferType> OffsetSlot<'a, OffsetItem, Buffer> {
+    fn position(&self) -> usize {
+        self.index
+    }
+    fn start(&self) -> OffsetItem {
+        unsafe {
+            self.offset
+                .as_slice()
+                .index_unchecked(self.index)
+                .to_owned()
+        }
+    }
+    fn start_usize(&self) -> usize {
+        self.start().try_into().expect("convert fail")
+    }
+    fn range(&self) -> Range<OffsetItem> {
+        self.start()..self.end()
+    }
+    fn range_usize(&self) -> Range<usize> {
+        self.start_usize()..self.end_usize()
+    }
+    fn end(&self) -> OffsetItem {
+        unsafe {
+            self.offset
+                .as_slice()
+                .index_unchecked(self.index + 1)
+                .to_owned()
+        }
+    }
+    fn end_usize(&self) -> usize {
+        self.end().try_into().expect("convert fail")
+    }
+    fn len(&self) -> OffsetItem {
+        self.end() - self.start()
+    }
+    fn len_usize(&self) -> usize {
+        self.len().try_into().expect("convert fail")
+    }
+    fn tuple(&self) -> (OffsetItem, OffsetItem) {
+        (self.start(), self.end())
+    }
+    fn tuple_usize(&self) -> (usize, usize) {
+        (self.start_usize(), self.end_usize())
     }
 }
 
@@ -215,6 +275,92 @@ where
     }
 }
 
+/// An iterator over items in an offset.
+pub struct OffsetSlice<'a, T, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+{
+    /// The offset storing the values and offsets
+    offset: &'a Offset<T, NULLABLE, OffsetItem, Buffer>,
+    /// The current position
+    index: usize,
+    /// Then end of this slice
+    end: usize,
+}
+
+impl<'a, T, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Iterator
+    for OffsetSlice<'a, T, NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    T: Index,
+{
+    type Item = <T as Index>::Item<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        (self.index < self.end).then(|| {
+            // Safety:
+            // - Bounds checked above
+            let value = unsafe { self.offset.data.index_unchecked(self.index) };
+            self.index += 1;
+            value
+        })
+    }
+}
+
+impl<T, OffsetItem: OffsetElement, Buffer: BufferType> Index
+    for Offset<T, false, OffsetItem, Buffer>
+{
+    type Item<'a> = OffsetSlice<'a, T, false, OffsetItem, Buffer>
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        OffsetSlice {
+            offset: self,
+            index: (*self.offsets.as_slice().get_unchecked(index))
+                .try_into()
+                .expect("offset value out of range"),
+            end: (*self.offsets.as_slice().get_unchecked(index + 1))
+                .try_into()
+                .expect("offset value out of range"),
+        }
+    }
+}
+
+impl<T, OffsetItem: OffsetElement, Buffer: BufferType> Index
+    for Offset<T, true, OffsetItem, Buffer>
+{
+    type Item<'a> = Option<OffsetSlice<'a, T, true, OffsetItem, Buffer>>
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        // Safety:
+        // - TODO
+        let start = unsafe {
+            (*self.offsets.data.as_slice().get_unchecked(index))
+                .try_into()
+                .expect("out of bounds")
+        };
+        // Safety:
+        // - TODO
+        let end = unsafe {
+            (*self.offsets.data.as_slice().get_unchecked(index + 1))
+                .try_into()
+                .expect("out of bounds")
+        };
+        // Safety:
+        // - TODO
+        unsafe {
+            self.is_valid_unchecked(index).then_some(OffsetSlice {
+                offset: self,
+                index: start,
+                end,
+            })
+        }
+    }
+}
+
 impl<T, OffsetItem: OffsetElement, Buffer: BufferType> Length
     for Offset<T, false, OffsetItem, Buffer>
 {
@@ -328,6 +474,26 @@ mod tests {
         assert_eq!(offset.len(), 4);
         assert_eq!(offset.offsets.as_ref().as_slice(), &[0, 1, 1, 2, 2]);
         assert_eq!(offset.data, "ab");
+    }
+
+    #[test]
+    fn index() {
+        let input = vec![vec![1, 2, 3, 4], vec![5, 6], vec![7, 8, 9]];
+        let offset = input.into_iter().collect::<Offset<Vec<u8>>>();
+        let mut first = offset.index_checked(0);
+        assert_eq!(first.next(), Some(&1));
+        assert_eq!(first.next(), Some(&2));
+        assert_eq!(first.next(), Some(&3));
+        assert_eq!(first.next(), Some(&4));
+        assert_eq!(first.next(), None);
+
+        let input_nullable = vec![Some(vec![1, 2, 3, 4]), None, Some(vec![5, 6, 7, 8])];
+        let offset_nullable = input_nullable
+            .into_iter()
+            .collect::<Offset<Vec<u8>, true>>();
+        let first_opt = offset_nullable.index_checked(0).expect("a value");
+        assert_eq!(first_opt.copied().collect::<Vec<_>>(), [1, 2, 3, 4]);
+        assert!(offset_nullable.index_checked(1).is_none());
     }
 
     #[test]

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -97,7 +97,7 @@ impl<'a, OffsetItem: OffsetElement, Buffer: BufferType> OffsetSlot<'a, OffsetIte
     ///
     /// # Panics
     ///
-    /// This function panics if the conversion of [`OffsetItem`] to [`usize`] fails.
+    /// This function panics if the conversion of [`OffsetElement`] to [`usize`] fails.
     #[must_use]
     pub fn start_usize(&self) -> usize {
         self.start().try_into().expect("convert fail")
@@ -131,7 +131,7 @@ impl<'a, OffsetItem: OffsetElement, Buffer: BufferType> OffsetSlot<'a, OffsetIte
     /// Returns the end index of this offset slot as usize.
     /// # Panics
     ///
-    /// This function panics if the conversion of [`OffsetItem`] to [`usize`] fails.
+    /// This function panics if the conversion of [`OffsetElement`] to [`usize`] fails.
     #[must_use]
     pub fn end_usize(&self) -> usize {
         self.end().try_into().expect("convert fail")
@@ -147,7 +147,7 @@ impl<'a, OffsetItem: OffsetElement, Buffer: BufferType> OffsetSlot<'a, OffsetIte
     ///
     /// # Panics
     ///
-    /// This function panics if the conversion of [`OffsetItem`] to [`usize`] fails.
+    /// This function panics if the conversion of [`OffsetElement`] to [`usize`] fails.
     #[must_use]
     pub fn len_usize(&self) -> usize {
         self.len().try_into().expect("convert fail")

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -88,10 +88,10 @@ mod tests {
                     assert_eq!(array.0 .0 .0, &[1, 3]);
                     assert_eq!(array.0 .1 .0, &[2, 4]);
                     assert_eq!(
-                        array.0 .2 .0 .0 .0.data.0.as_slice(),
+                        array.0 .2 .0 .0.data.0.as_slice(),
                         &[b'a', b's', b'd', b'f']
                     );
-                    assert_eq!(array.0 .2 .0 .0 .0.offsets.as_slice(), &[0, 2, 4]);
+                    assert_eq!(array.0 .2 .0 .0.offsets.as_slice(), &[0, 2, 4]);
 
                     let input = [
                         Bar(Foo(1, 2, "hello")),
@@ -207,10 +207,10 @@ mod tests {
                     assert_eq!(array.len(), 2);
                     assert_eq!(array.0.c.0, &[4, 2]);
                     assert_eq!(
-                        array.0.d.0.data.0 .0 .0.data.0.as_slice(),
+                        array.0.d.0.data.0 .0.data.0.as_slice(),
                         "helloworld".as_bytes()
                     );
-                    assert_eq!(array.0.d.0.data.0 .0 .0.offsets.as_ref(), &[0, 5, 5, 10]);
+                    assert_eq!(array.0.d.0.data.0 .0.offsets.as_ref(), &[0, 5, 5, 10]);
                     assert_eq!(
                         array
                             .0
@@ -218,7 +218,6 @@ mod tests {
                             .0
                             .data
                             .0
-                             .0
                              .0
                             .offsets
                             .bitmap_ref()


### PR DESCRIPTION
Adds an `Index` trait to get items out of collections.

Also closes #57.