### PR TITLE
feat!: add item associated type to `Unit` trait

### DIFF
--- a/narrow-derive/src/struct.rs
+++ b/narrow-derive/src/struct.rs
@@ -126,7 +126,9 @@ impl Struct<'_> {
         let tokens = quote! {
             /// Safety:
             /// - This is a unit struct.
-            unsafe impl #impl_generics #narrow::array::Unit for #ident #ty_generics #where_clause {}
+            unsafe impl #impl_generics #narrow::array::Unit for #ident #ty_generics #where_clause {
+                type Item = Self;
+            }
         };
         parse2(tokens).expect("unit_impl")
     }

--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -1,7 +1,9 @@
 pub struct Foo<const N: usize>;
 /// Safety:
 /// - This is a unit struct.
-unsafe impl<const N: usize> narrow::array::Unit for Foo<N> {}
+unsafe impl<const N: usize> narrow::array::Unit for Foo<N> {
+    type Item = Self;
+}
 impl<const N: usize> narrow::array::ArrayType for Foo<N> {
     type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
         Foo<N>,

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -1,7 +1,9 @@
 pub struct Foo<const N: usize = 42>;
 /// Safety:
 /// - This is a unit struct.
-unsafe impl<const N: usize> narrow::array::Unit for Foo<N> {}
+unsafe impl<const N: usize> narrow::array::Unit for Foo<N> {
+    type Item = Self;
+}
 impl<const N: usize> narrow::array::ArrayType for Foo<N> {
     type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
         Foo<N>,

--- a/narrow-derive/tests/expand/struct/unit/self.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/self.expanded.rs
@@ -6,7 +6,9 @@ where
 unsafe impl narrow::array::Unit for Foo
 where
     Self: Debug,
-{}
+{
+    type Item = Self;
+}
 impl narrow::array::ArrayType for Foo
 where
     Self: Debug,

--- a/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
@@ -1,7 +1,9 @@
 struct Foo;
 /// Safety:
 /// - This is a unit struct.
-unsafe impl narrow::array::Unit for Foo {}
+unsafe impl narrow::array::Unit for Foo {
+    type Item = Self;
+}
 impl narrow::array::ArrayType for Foo {
     type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
         Foo,

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -8,7 +8,9 @@ unsafe impl<const N: bool> narrow::array::Unit for Foo<N>
 where
     Self: Sized,
     (): From<Self>,
-{}
+{
+    type Item = Self;
+}
 impl<const N: bool> narrow::array::ArrayType for Foo<N>
 where
     Self: Sized,


### PR DESCRIPTION
To support using `NullArray` for unit variants of enums in `UnionArrays`, this adds an `Item` associated type to the `Unit` trait, which converts into the type implementing `Unit`, allowing code generation of types for unit enum variants which implement `Unit` and convert to instances of the variants of the original enum.