### PR TITLE
feat!: add `OffsetElement` and `UnionType` to the `Array` GAT of `ArrayType`

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,1 +1,9 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/narrow-derive/src/struct.rs
+++ b/narrow-derive/src/struct.rs
@@ -145,14 +145,14 @@ impl Struct<'_> {
         let ident = self.ident;
         let non_nullable = quote! {
             impl #impl_generics #narrow::array::ArrayType for #ident #ty_generics #where_clause {
-                type Array<Buffer: #narrow::buffer::BufferType> = #narrow::array::StructArray<#ident #ty_generics, false, Buffer>;
+                type Array<Buffer: #narrow::buffer::BufferType, OffsetItem: #narrow::offset::OffsetElement, UnionLayout: #narrow::array::UnionType> = #narrow::array::StructArray<#ident #ty_generics, false, Buffer>;
             }
         };
         let non_nullable: ItemImpl = parse2(non_nullable).expect("array_type_impl");
 
         let nullable = quote! {
             impl #impl_generics #narrow::array::ArrayType<#ident #ty_generics> for ::std::option::Option<#ident #ty_generics> #where_clause {
-                type Array<Buffer: #narrow::buffer::BufferType> = #narrow::array::StructArray<#ident #ty_generics, true, Buffer>;
+                type Array<Buffer: #narrow::buffer::BufferType, OffsetItem: #narrow::offset::OffsetElement, UnionLayout: #narrow::array::UnionType> = #narrow::array::StructArray<#ident #ty_generics, true, Buffer>;
             }
         };
         let nullable: ItemImpl = parse2(nullable).expect("array_type_impl");
@@ -207,7 +207,7 @@ impl Struct<'_> {
                 let field_ty = self.field_types();
                 quote!(
                     #(
-                        #field_ident: <#field_ty as #narrow::array::ArrayType>::Array<Buffer>,
+                        #field_ident: <#field_ty as #narrow::array::ArrayType>::Array<Buffer, #narrow::offset::NA, #narrow::array::union::NA>,
                     )*
                 )
             }
@@ -215,7 +215,7 @@ impl Struct<'_> {
                 let field_ty = self.field_types();
                 quote!(
                     #(
-                        <#field_ty as #narrow::array::ArrayType>::Array<Buffer>,
+                        <#field_ty as #narrow::array::ArrayType>::Array<Buffer, #narrow::offset::NA, #narrow::array::union::NA>,
                     )*
                 )
             }
@@ -345,7 +345,7 @@ impl Struct<'_> {
             .predicates
             .extend(
                 self.field_types()
-                    .map::<WherePredicate, _>(move |ty| parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<#ty>))
+                    .map::<WherePredicate, _>(move |ty| parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer, #narrow::offset::NA, #narrow::array::union::NA>: ::std::iter::Extend<#ty>))
             );
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
@@ -409,7 +409,7 @@ impl Struct<'_> {
             .predicates
             .extend(
                 self.field_types()
-                    .map::<WherePredicate, _>(move |ty| parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default + ::std::iter::Extend<#ty>))
+                    .map::<WherePredicate, _>(move |ty| parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer, #narrow::offset::NA, #narrow::array::union::NA>: ::std::default::Default + ::std::iter::Extend<#ty>))
             );
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
@@ -465,7 +465,7 @@ impl Struct<'_> {
     ) -> impl Iterator<Item = WherePredicate> + '_ {
         let narrow = util::narrow();
         self.field_types()
-            .map(move |ty| parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer>: #bound))
+            .map(move |ty| parse_quote!(<#ty as #narrow::array::ArrayType>::Array<Buffer, #narrow::offset::NA, #narrow::array::union::NA>: #bound))
     }
 }
 

--- a/narrow-derive/tests/expand/struct/named/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic.expanded.rs
@@ -8,22 +8,22 @@ impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType for Foo<'a, T>
 where
     T: Copy,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<'a, T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<'a, T>, false, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType<Foo<'a, T>>
 for ::std::option::Option<Foo<'a, T>>
 where
     T: Copy,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<'a, T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<'a, T>, true, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType> narrow::array::StructArrayType for Foo<'a, T>
 where
@@ -35,7 +35,11 @@ struct FooArray<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferT
 where
     T: Copy,
 {
-    a: <&'a T as narrow::array::ArrayType>::Array<Buffer>,
+    a: <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 }
 impl<
     'a,
@@ -44,7 +48,11 @@ impl<
 > ::std::default::Default for FooArray<'a, T, Buffer>
 where
     T: Copy,
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self {
@@ -56,7 +64,11 @@ impl<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow
 for FooArray<'a, T, Buffer>
 where
     T: Copy,
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.a.len()
@@ -69,7 +81,11 @@ impl<
 > ::std::iter::Extend<Foo<'a, T>> for FooArray<'a, T, Buffer>
 where
     T: Copy,
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<&'a T>,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<&'a T>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -87,6 +103,8 @@ where
     T: Copy,
     <&'a T as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<&'a T>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
@@ -4,36 +4,68 @@ struct Bar<T> {
     c: Option<T>,
 }
 impl<T: narrow::array::ArrayType> narrow::array::ArrayType for Bar<T> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar<T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar<T>, false, Buffer>;
 }
 impl<T: narrow::array::ArrayType> narrow::array::ArrayType<Bar<T>>
 for ::std::option::Option<Bar<T>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar<T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar<T>, true, Buffer>;
 }
 impl<T: narrow::array::ArrayType> narrow::array::StructArrayType for Bar<T> {
     type Array<Buffer: narrow::buffer::BufferType> = BarArray<T, Buffer>;
 }
 struct BarArray<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> {
-    a: <u32 as narrow::array::ArrayType>::Array<Buffer>,
-    b: <Option<bool> as narrow::array::ArrayType>::Array<Buffer>,
-    c: <Option<T> as narrow::array::ArrayType>::Array<Buffer>,
+    a: <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    b: <Option<
+        bool,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    c: <Option<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 }
 impl<
     T: narrow::array::ArrayType,
     Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for BarArray<T, Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
-    <Option<bool> as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
-    <Option<T> as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
+    <Option<
+        bool,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
+    <Option<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self {
@@ -46,9 +78,25 @@ where
 impl<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
 for BarArray<T, Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <Option<bool> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <Option<T> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <Option<
+        bool,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <Option<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.a.len()
@@ -59,13 +107,25 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > ::std::iter::Extend<Bar<T>> for BarArray<T, Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u32>,
     <Option<
         bool,
-    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Option<bool>>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<Option<bool>>,
     <Option<
         T,
-    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Option<T>>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<Option<T>>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Bar<T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -83,16 +143,22 @@ impl<
 where
     <u32 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u32>,
     <Option<
         bool,
     > as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<Option<bool>>,
     <Option<
         T,
     > as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<Option<T>>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar<T>>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/named/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/simple.expanded.rs
@@ -4,34 +4,60 @@ struct Foo {
     c: Option<Vec<u8>>,
 }
 impl narrow::array::ArrayType for Foo {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, false, Buffer>;
 }
 impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
 }
 struct FooArray<Buffer: narrow::buffer::BufferType> {
-    a: <u32 as narrow::array::ArrayType>::Array<Buffer>,
-    b: <bool as narrow::array::ArrayType>::Array<Buffer>,
-    c: <Option<Vec<u8>> as narrow::array::ArrayType>::Array<Buffer>,
+    a: <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    b: <bool as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    c: <Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 }
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
-    <bool as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
+    <bool as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
     <Option<
         Vec<u8>,
-    > as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self {
@@ -43,9 +69,23 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> narrow::Length for FooArray<Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <bool as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <Option<Vec<u8>> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <bool as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.a.len()
@@ -53,11 +93,23 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo> for FooArray<Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
-    <bool as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<bool>,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u32>,
+    <bool as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<bool>,
     <Option<
         Vec<u8>,
-    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Option<Vec<u8>>>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<Option<Vec<u8>>>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -73,14 +125,20 @@ for FooArray<Buffer>
 where
     <u32 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u32>,
     <bool as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<bool>,
     <Option<
         Vec<u8>,
     > as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<Option<Vec<u8>>>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -5,18 +5,18 @@ unsafe impl<const N: usize> narrow::array::Unit for Foo<N> {
     type Item = Self;
 }
 impl<const N: usize> narrow::array::ArrayType for Foo<N> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<N>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<N>, false, Buffer>;
 }
 impl<const N: usize> narrow::array::ArrayType<Foo<N>> for ::std::option::Option<Foo<N>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<N>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<N>, true, Buffer>;
 }
 impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -5,18 +5,18 @@ unsafe impl<const N: usize> narrow::array::Unit for Foo<N> {
     type Item = Self;
 }
 impl<const N: usize> narrow::array::ArrayType for Foo<N> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<N>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<N>, false, Buffer>;
 }
 impl<const N: usize> narrow::array::ArrayType<Foo<N>> for ::std::option::Option<Foo<N>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<N>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<N>, true, Buffer>;
 }
 impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;

--- a/narrow-derive/tests/expand/struct/unit/self.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/self.expanded.rs
@@ -13,21 +13,21 @@ impl narrow::array::ArrayType for Foo
 where
     Self: Debug,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, false, Buffer>;
 }
 impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo>
 where
     Self: Debug,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo
 where

--- a/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
@@ -5,18 +5,18 @@ unsafe impl narrow::array::Unit for Foo {
     type Item = Self;
 }
 impl narrow::array::ArrayType for Foo {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, false, Buffer>;
 }
 impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -16,22 +16,22 @@ where
     Self: Sized,
     (): From<Self>,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<N>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<N>, false, Buffer>;
 }
 impl<const N: bool> narrow::array::ArrayType<Foo<N>> for ::std::option::Option<Foo<N>>
 where
     Self: Sized,
     (): From<Self>,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<N>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<N>, true, Buffer>;
 }
 impl<const N: bool> narrow::array::StructArrayType for Foo<N>
 where

--- a/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
@@ -9,11 +9,11 @@ where
     Self: Sized,
     <T as Add<Self>>::Output: Debug,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<'a, T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<'a, T>, false, Buffer>;
 }
 impl<'a, T: Add<Self> + narrow::array::ArrayType> narrow::array::ArrayType<Foo<'a, T>>
 for ::std::option::Option<Foo<'a, T>>
@@ -21,11 +21,11 @@ where
     Self: Sized,
     <T as Add<Self>>::Output: Debug,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<'a, T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<'a, T>, true, Buffer>;
 }
 impl<'a, T: Add<Self> + narrow::array::ArrayType> narrow::array::StructArrayType
 for Foo<'a, T>
@@ -40,7 +40,11 @@ struct FooArray<
     T: Add<Foo<'a, T>> + narrow::array::ArrayType,
     Buffer: narrow::buffer::BufferType,
 >(
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 )
 where
     Foo<'a, T>: Sized,
@@ -53,7 +57,11 @@ impl<
 where
     Foo<'a, T>: Sized,
     <T as Add<Foo<'a, T>>>::Output: Debug,
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -67,7 +75,11 @@ impl<
 where
     Foo<'a, T>: Sized,
     <T as Add<Foo<'a, T>>>::Output: Debug,
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -81,7 +93,11 @@ impl<
 where
     Self: Sized,
     <T as Add<Self>>::Output: Debug,
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<&'a T>,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<&'a T>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -100,6 +116,8 @@ where
     <T as Add<Self>>::Output: Debug,
     <&'a T as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<&'a T>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(iter: _I) -> Self {
@@ -109,32 +127,40 @@ where
 }
 struct FooBar<T>(T);
 impl<T: narrow::array::ArrayType> narrow::array::ArrayType for FooBar<T> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        FooBar<T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<FooBar<T>, false, Buffer>;
 }
 impl<T: narrow::array::ArrayType> narrow::array::ArrayType<FooBar<T>>
 for ::std::option::Option<FooBar<T>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        FooBar<T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<FooBar<T>, true, Buffer>;
 }
 impl<T: narrow::array::ArrayType> narrow::array::StructArrayType for FooBar<T> {
     type Array<Buffer: narrow::buffer::BufferType> = FooBarArray<T, Buffer>;
 }
 struct FooBarArray<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
-    <T as narrow::array::ArrayType>::Array<Buffer>,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<
     T: narrow::array::ArrayType,
     Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooBarArray<T, Buffer>
 where
-    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -143,7 +169,11 @@ where
 impl<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
 for FooBarArray<T, Buffer>
 where
-    <T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -154,7 +184,11 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > ::std::iter::Extend<FooBar<T>> for FooBarArray<T, Buffer>
 where
-    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<T>,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<T>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = FooBar<T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -170,6 +204,8 @@ impl<
 where
     <T as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<T>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = FooBar<T>>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
@@ -1,24 +1,28 @@
 struct Foo<'a, T>(&'a T);
 impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType for Foo<'a, T> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<'a, T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<'a, T>, false, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType<Foo<'a, T>>
 for ::std::option::Option<Foo<'a, T>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<'a, T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<'a, T>, true, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType> narrow::array::StructArrayType for Foo<'a, T> {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<'a, T, Buffer>;
 }
 struct FooArray<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<
     'a,
@@ -26,7 +30,11 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<'a, T, Buffer>
 where
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -35,7 +43,11 @@ where
 impl<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
 for FooArray<'a, T, Buffer>
 where
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -47,7 +59,11 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > ::std::iter::Extend<Foo<'a, T>> for FooArray<'a, T, Buffer>
 where
-    <&'a T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<&'a T>,
+    <&'a T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<&'a T>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -64,6 +80,8 @@ impl<
 where
     <&'a T as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<&'a T>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<'a, T>>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
@@ -1,33 +1,65 @@
 struct Bar(u8, u16, u32, u64);
 impl narrow::array::ArrayType for Bar {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar, false, Buffer>;
 }
 impl narrow::array::ArrayType<Bar> for ::std::option::Option<Bar> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Bar {
     type Array<Buffer: narrow::buffer::BufferType> = BarArray<Buffer>;
 }
 struct BarArray<Buffer: narrow::buffer::BufferType>(
-    <u8 as narrow::array::ArrayType>::Array<Buffer>,
-    <u16 as narrow::array::ArrayType>::Array<Buffer>,
-    <u32 as narrow::array::ArrayType>::Array<Buffer>,
-    <u64 as narrow::array::ArrayType>::Array<Buffer>,
+    <u8 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    <u16 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
+    <u64 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for BarArray<Buffer>
 where
-    <u8 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
-    <u16 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
-    <u64 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u8 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
+    <u16 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
+    <u64 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(
@@ -40,10 +72,26 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> narrow::Length for BarArray<Buffer>
 where
-    <u8 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <u16 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
-    <u64 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <u8 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <u16 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
+    <u64 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -51,10 +99,26 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Bar> for BarArray<Buffer>
 where
-    <u8 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u8>,
-    <u16 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u16>,
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
-    <u64 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u64>,
+    <u8 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u8>,
+    <u16 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u16>,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u32>,
+    <u64 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u64>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Bar>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -71,15 +135,23 @@ for BarArray<Buffer>
 where
     <u8 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u8>,
     <u16 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u16>,
     <u32 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u32>,
     <u64 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u64>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
@@ -1,27 +1,35 @@
 struct Foo(u32);
 impl narrow::array::ArrayType for Foo {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, false, Buffer>;
 }
 impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
 }
 struct FooArray<Buffer: narrow::buffer::BufferType>(
-    <u32 as narrow::array::ArrayType>::Array<Buffer>,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -29,7 +37,11 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> narrow::Length for FooArray<Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -37,7 +49,11 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Foo> for FooArray<Buffer>
 where
-    <u32 as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<u32>,
+    <u32 as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u32>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -51,6 +67,8 @@ for FooArray<Buffer>
 where
     <u32 as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<u32>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo>>(iter: _I) -> Self {
@@ -60,28 +78,36 @@ where
 }
 struct Bar(Foo);
 impl narrow::array::ArrayType for Bar {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar, false, Buffer>;
 }
 impl narrow::array::ArrayType<Bar> for ::std::option::Option<Bar> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Bar {
     type Array<Buffer: narrow::buffer::BufferType> = BarArray<Buffer>;
 }
 struct BarArray<Buffer: narrow::buffer::BufferType>(
-    <Foo as narrow::array::ArrayType>::Array<Buffer>,
+    <Foo as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for BarArray<Buffer>
 where
-    <Foo as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <Foo as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -89,7 +115,11 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> narrow::Length for BarArray<Buffer>
 where
-    <Foo as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <Foo as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -97,7 +127,11 @@ where
 }
 impl<Buffer: narrow::buffer::BufferType> ::std::iter::Extend<Bar> for BarArray<Buffer>
 where
-    <Foo as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Foo>,
+    <Foo as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<Foo>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Bar>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -111,6 +145,8 @@ for BarArray<Buffer>
 where
     <Foo as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<Foo>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
@@ -7,22 +7,22 @@ impl<T: narrow::array::ArrayType> narrow::array::ArrayType for Foo<T>
 where
     T: Copy,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<T>, false, Buffer>;
 }
 impl<T: narrow::array::ArrayType> narrow::array::ArrayType<Foo<T>>
 for ::std::option::Option<Foo<T>>
 where
     T: Copy,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<T>, true, Buffer>;
 }
 impl<T: narrow::array::ArrayType> narrow::array::StructArrayType for Foo<T>
 where
@@ -31,7 +31,11 @@ where
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<T, Buffer>;
 }
 struct FooArray<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
-    <T as narrow::array::ArrayType>::Array<Buffer>,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 )
 where
     T: Copy;
@@ -41,7 +45,11 @@ impl<
 > ::std::default::Default for FooArray<T, Buffer>
 where
     T: Copy,
-    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -51,7 +59,11 @@ impl<T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Le
 for FooArray<T, Buffer>
 where
     T: Copy,
-    <T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -63,7 +75,11 @@ impl<
 > ::std::iter::Extend<Foo<T>> for FooArray<T, Buffer>
 where
     T: Copy,
-    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<T>,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<T>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -80,6 +96,8 @@ where
     T: Copy,
     <T as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<T>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(iter: _I) -> Self {
@@ -89,25 +107,31 @@ where
 }
 struct Bar<'a, T>(&'a Foo<T>);
 impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType for Bar<'a, T> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar<'a, T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar<'a, T>, false, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType> narrow::array::ArrayType<Bar<'a, T>>
 for ::std::option::Option<Bar<'a, T>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Bar<'a, T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Bar<'a, T>, true, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType> narrow::array::StructArrayType for Bar<'a, T> {
     type Array<Buffer: narrow::buffer::BufferType> = BarArray<'a, T, Buffer>;
 }
 struct BarArray<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
-    <&'a Foo<T> as narrow::array::ArrayType>::Array<Buffer>,
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<
     'a,
@@ -115,7 +139,13 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for BarArray<'a, T, Buffer>
 where
-    <&'a Foo<T> as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -124,7 +154,13 @@ where
 impl<'a, T: narrow::array::ArrayType, Buffer: narrow::buffer::BufferType> narrow::Length
 for BarArray<'a, T, Buffer>
 where
-    <&'a Foo<T> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -138,7 +174,11 @@ impl<
 where
     <&'a Foo<
         T,
-    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<&'a Foo<T>>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<&'a Foo<T>>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Bar<'a, T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -157,6 +197,8 @@ where
         T,
     > as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<&'a Foo<T>>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar<'a, T>>>(iter: _I) -> Self {
@@ -166,29 +208,43 @@ where
 }
 struct FooBar<'a>(Bar<'a, u32>);
 impl<'a> narrow::array::ArrayType for FooBar<'a> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        FooBar<'a>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<FooBar<'a>, false, Buffer>;
 }
 impl<'a> narrow::array::ArrayType<FooBar<'a>> for ::std::option::Option<FooBar<'a>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        FooBar<'a>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<FooBar<'a>, true, Buffer>;
 }
 impl<'a> narrow::array::StructArrayType for FooBar<'a> {
     type Array<Buffer: narrow::buffer::BufferType> = FooBarArray<'a, Buffer>;
 }
 struct FooBarArray<'a, Buffer: narrow::buffer::BufferType>(
-    <Bar<'a, u32> as narrow::array::ArrayType>::Array<Buffer>,
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<'a, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooBarArray<'a, Buffer>
 where
-    <Bar<'a, u32> as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -196,7 +252,14 @@ where
 }
 impl<'a, Buffer: narrow::buffer::BufferType> narrow::Length for FooBarArray<'a, Buffer>
 where
-    <Bar<'a, u32> as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -208,7 +271,11 @@ where
     <Bar<
         'a,
         u32,
-    > as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<Bar<'a, u32>>,
+    > as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<Bar<'a, u32>>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = FooBar<'a>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -225,6 +292,8 @@ where
         u32,
     > as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<Bar<'a, u32>>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = FooBar<'a>>>(iter: _I) -> Self {

--- a/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
@@ -1,31 +1,39 @@
 struct Foo<T: Sized>(T);
 impl<T: Sized + narrow::array::ArrayType> narrow::array::ArrayType for Foo<T> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<T>,
-        false,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<T>, false, Buffer>;
 }
 impl<T: Sized + narrow::array::ArrayType> narrow::array::ArrayType<Foo<T>>
 for ::std::option::Option<Foo<T>> {
-    type Array<Buffer: narrow::buffer::BufferType> = narrow::array::StructArray<
-        Foo<T>,
-        true,
-        Buffer,
-    >;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::UnionType,
+    > = narrow::array::StructArray<Foo<T>, true, Buffer>;
 }
 impl<T: Sized + narrow::array::ArrayType> narrow::array::StructArrayType for Foo<T> {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<T, Buffer>;
 }
 struct FooArray<T: Sized + narrow::array::ArrayType, Buffer: narrow::buffer::BufferType>(
-    <T as narrow::array::ArrayType>::Array<Buffer>,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >,
 );
 impl<
     T: Sized + narrow::array::ArrayType,
     Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<T, Buffer>
 where
-    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::default::Default,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
         Self(::std::default::Default::default())
@@ -36,7 +44,11 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > narrow::Length for FooArray<T, Buffer>
 where
-    <T as narrow::array::ArrayType>::Array<Buffer>: narrow::Length,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: narrow::Length,
 {
     fn len(&self) -> usize {
         self.0.len()
@@ -47,7 +59,11 @@ impl<
     Buffer: narrow::buffer::BufferType,
 > ::std::iter::Extend<Foo<T>> for FooArray<T, Buffer>
 where
-    <T as narrow::array::ArrayType>::Array<Buffer>: ::std::iter::Extend<T>,
+    <T as narrow::array::ArrayType>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<T>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(&mut self, iter: _I) {
         iter.into_iter()
@@ -63,6 +79,8 @@ impl<
 where
     <T as narrow::array::ArrayType>::Array<
         Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<T>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(iter: _I) -> Self {

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -227,7 +227,7 @@ impl<T: Unit> Length for Nulls<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::bitmap::Bitmap;
+    use crate::{array::UnionType, bitmap::Bitmap, offset::OffsetElement};
     use std::mem;
 
     #[test]
@@ -240,7 +240,8 @@ mod tests {
             type Item = Self;
         }
         impl ArrayType for Foo {
-            type Array<Buffer: BufferType> = NullArray<Foo, false, Buffer>;
+            type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+                NullArray<Foo, false, Buffer>;
         }
         let input = [Foo; 42];
         let array = input.into_iter().collect::<NullArray<Foo>>();

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -178,7 +178,11 @@ impl<OffsetItem: OffsetElement, Buffer: BufferType> ValidityBitmap
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{bitmap::BitmapRef, buffer::BufferRef};
+    use crate::{
+        array::{union, ArrayType},
+        bitmap::BitmapRef,
+        buffer::BufferRef,
+    };
 
     #[test]
     fn from_iter() {
@@ -186,7 +190,7 @@ mod tests {
         let array = input
             .into_iter()
             .map(ToOwned::to_owned)
-            .collect::<Utf8Array>();
+            .collect::<<String as ArrayType>::Array<VecBuffer, i64, union::NA>>();
         assert_eq!(array.len(), 4);
         assert_eq!(array.0 .0.data.0, b"1234567890");
 

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -106,6 +106,11 @@ impl<T: StructArrayType, Buffer: BufferType> ValidityBitmap for StructArray<T, t
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        array::{union, UnionType},
+        offset::{self, OffsetElement},
+    };
+
     use super::*;
 
     // Definition
@@ -121,54 +126,58 @@ mod tests {
     }
     // These impls below can all be generated.
     impl<'a> ArrayType for Foo<'a> {
-        type Array<Buffer: BufferType> = StructArray<Foo<'a>, false, Buffer>;
+        type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+            StructArray<Foo<'a>, false, Buffer>;
     }
     impl<'a> ArrayType for Option<Foo<'a>> {
-        type Array<Buffer: BufferType> = StructArray<Foo<'a>, true, Buffer>;
+        type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+            StructArray<Foo<'a>, true, Buffer>;
     }
 
     struct FooArray<'a, Buffer: BufferType> {
-        a: <u32 as ArrayType>::Array<Buffer>,
-        b: <Option<()> as ArrayType>::Array<Buffer>,
-        c: <() as ArrayType>::Array<Buffer>,
-        d: <Option<[u128; 2]> as ArrayType>::Array<Buffer>,
-        e: <bool as ArrayType>::Array<Buffer>,
-        f: <&'a [u8] as ArrayType>::Array<Buffer>,
-        g: <String as ArrayType>::Array<Buffer>,
+        a: <u32 as ArrayType>::Array<Buffer, offset::NA, union::NA>,
+        b: <Option<()> as ArrayType>::Array<Buffer, offset::NA, union::NA>,
+        c: <() as ArrayType>::Array<Buffer, offset::NA, union::NA>,
+        d: <Option<[u128; 2]> as ArrayType>::Array<Buffer, offset::NA, union::NA>,
+        e: <bool as ArrayType>::Array<Buffer, offset::NA, union::NA>,
+        f: <&'a [u8] as ArrayType>::Array<Buffer, offset::NA, union::NA>,
+        g: <String as ArrayType>::Array<Buffer, offset::NA, union::NA>,
     }
 
     impl<'a, Buffer: BufferType> Default for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType>::Array<Buffer>: Default,
-        <Option<()> as ArrayType>::Array<Buffer>: Default,
-        <() as ArrayType>::Array<Buffer>: Default,
-        <Option<[u128; 2]> as ArrayType>::Array<Buffer>: Default,
-        <bool as ArrayType>::Array<Buffer>: Default,
-        <&'a [u8] as ArrayType>::Array<Buffer>: Default,
-        <String as ArrayType>::Array<Buffer>: Default,
+        <u32 as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
+        <Option<()> as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
+        <() as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
+        <Option<[u128; 2]> as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
+        <bool as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
+        <&'a [u8] as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
+        <String as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default,
     {
         fn default() -> Self {
             Self {
-                a: <u32 as ArrayType>::Array::<Buffer>::default(),
-                b: <Option<()> as ArrayType>::Array::<Buffer>::default(),
-                c: <() as ArrayType>::Array::<Buffer>::default(),
-                d: <Option<[u128; 2]> as ArrayType>::Array::<Buffer>::default(),
-                e: <bool as ArrayType>::Array::<Buffer>::default(),
-                f: <&'a [u8] as ArrayType>::Array::<Buffer>::default(),
-                g: <String as ArrayType>::Array::<Buffer>::default(),
+                a: <u32 as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(),
+                b: <Option<()> as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(),
+                c: <() as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(),
+                d: <Option<[u128; 2]> as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(
+                ),
+                e: <bool as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(),
+                f: <&'a [u8] as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(),
+                g: <String as ArrayType>::Array::<Buffer, offset::NA, union::NA>::default(),
             }
         }
     }
 
     impl<'a, Buffer: BufferType> Extend<Foo<'a>> for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType>::Array<Buffer>: Extend<u32>,
-        <Option<()> as ArrayType>::Array<Buffer>: Extend<Option<()>>,
-        <() as ArrayType>::Array<Buffer>: Extend<()>,
-        <Option<[u128; 2]> as ArrayType>::Array<Buffer>: Extend<Option<[u128; 2]>>,
-        <bool as ArrayType>::Array<Buffer>: Extend<bool>,
-        <&'a [u8] as ArrayType>::Array<Buffer>: Extend<&'a [u8]>,
-        <String as ArrayType>::Array<Buffer>: Extend<String>,
+        <u32 as ArrayType>::Array<Buffer, offset::NA, union::NA>: Extend<u32>,
+        <Option<()> as ArrayType>::Array<Buffer, offset::NA, union::NA>: Extend<Option<()>>,
+        <() as ArrayType>::Array<Buffer, offset::NA, union::NA>: Extend<()>,
+        <Option<[u128; 2]> as ArrayType>::Array<Buffer, offset::NA, union::NA>:
+            Extend<Option<[u128; 2]>>,
+        <bool as ArrayType>::Array<Buffer, offset::NA, union::NA>: Extend<bool>,
+        <&'a [u8] as ArrayType>::Array<Buffer, offset::NA, union::NA>: Extend<&'a [u8]>,
+        <String as ArrayType>::Array<Buffer, offset::NA, union::NA>: Extend<String>,
     {
         fn extend<I: IntoIterator<Item = Foo<'a>>>(&mut self, iter: I) {
             iter.into_iter().for_each(
@@ -195,13 +204,15 @@ mod tests {
 
     impl<'a, Buffer: BufferType> FromIterator<Foo<'a>> for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType>::Array<Buffer>: Default + Extend<u32>,
-        <Option<()> as ArrayType>::Array<Buffer>: Default + Extend<Option<()>>,
-        <() as ArrayType>::Array<Buffer>: Default + Extend<()>,
-        <Option<[u128; 2]> as ArrayType>::Array<Buffer>: Default + Extend<Option<[u128; 2]>>,
-        <bool as ArrayType>::Array<Buffer>: Default + Extend<bool>,
-        <&'a [u8] as ArrayType>::Array<Buffer>: Default + Extend<&'a [u8]>,
-        <String as ArrayType>::Array<Buffer>: Default + Extend<String>,
+        <u32 as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default + Extend<u32>,
+        <Option<()> as ArrayType>::Array<Buffer, offset::NA, union::NA>:
+            Default + Extend<Option<()>>,
+        <() as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default + Extend<()>,
+        <Option<[u128; 2]> as ArrayType>::Array<Buffer, offset::NA, union::NA>:
+            Default + Extend<Option<[u128; 2]>>,
+        <bool as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default + Extend<bool>,
+        <&'a [u8] as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default + Extend<&'a [u8]>,
+        <String as ArrayType>::Array<Buffer, offset::NA, union::NA>: Default + Extend<String>,
     {
         #[allow(clippy::many_single_char_names)]
         fn from_iter<T: IntoIterator<Item = Foo<'a>>>(iter: T) -> Self {
@@ -236,7 +247,7 @@ mod tests {
 
     impl<'a, Buffer: BufferType> Length for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType>::Array<Buffer>: Length,
+        <u32 as ArrayType>::Array<Buffer, offset::NA, union::NA>: Length,
     {
         fn len(&self) -> usize {
             self.a.len()

--- a/src/array/union.rs
+++ b/src/array/union.rs
@@ -1,0 +1,25 @@
+//! Array for sum types.
+
+/// Different types of union layouts.
+pub trait UnionType {}
+
+/// The dense union layout.
+#[derive(Clone, Copy)]
+pub struct DenseLayout;
+
+impl UnionType for DenseLayout {}
+
+/// The sparse union layout.
+#[derive(Clone, Copy)]
+pub struct SparseLayout;
+
+impl UnionType for SparseLayout {}
+
+/// Indicates that a [`UnionType`] generic is not applicable.
+///
+/// This is used instead to prevent confusion in code because we don't have default
+/// types for generic associated types.
+///
+/// This still shows up as [`DenseLayout`] in documentation but there is no way
+/// to prevent that.
+pub type NA = DenseLayout;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -37,6 +37,15 @@ pub trait OffsetElement:
     fn checked_add_unsigned(self, rhs: Self::Unsigned) -> Option<Self>;
 }
 
+/// Indicates that an [`OffsetElement`] generic is not applicable.
+///
+/// This is used instead to prevent confusion in code because we don't have default
+/// types for generic associated types.
+///
+/// This still shows up as [`i32`] in documentation but there is no way
+/// to prevent that.
+pub type NA = i32;
+
 /// Private module for a seal trait.
 mod sealed {
     /// Sealed trait to seal [`super::OffsetElement`].


### PR DESCRIPTION
This adds generics for offset element type (`i32` or `i64`) and union layout (sparse or dense) to the `Array` type constructor of the `ArrayType` trait.

This is not ideal without default types for the generics in a generic associated type, but the alternatives are worse (making `ArrayType` generic over these types with defaults).