### PR TITLE
docs: add `docs.rs` metadata and set `docsrs` for main branch doc deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,25 @@ permissions:
   contents: read
 
 jobs:
+  docs-rs:
+    name: docs.rs
+    runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: -Dwarnings
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo docs-rs
+
   rustdoc:
     name: Rustdoc
     runs-on: ubuntu-latest
+    env:
+      RUSTDOCFLAGS: --cfg docsrs
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@nightly
         id: rust-toolchain
       - uses: actions/cache@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
 [features]
 default = []
 arrow-rs = ["dep:arrow-array", "dep:arrow-buffer", "dep:arrow-schema", "narrow-derive?/arrow-rs"]


### PR DESCRIPTION
To make sure the deployed docs of the main branch render required features.