### PR TITLE
feat: add `arrow-rs` interop support for `FixedSizeListArray`

### DIFF
--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -16,6 +16,7 @@ fn main() {
         d: String,
         e: Option<Vec<Option<bool>>>,
         f: Bar,
+        g: [u8; 8],
     }
     let input = [
         Foo {
@@ -25,6 +26,7 @@ fn main() {
             d: "hello world!".to_string(),
             e: Some(vec![Some(true), None]),
             f: Bar(Some(true)),
+            g: [1, 2, 3, 4, 5, 6, 7, 8],
         },
         Foo {
             a: 42,
@@ -33,6 +35,7 @@ fn main() {
             d: "narrow".to_string(),
             e: None,
             f: Bar(None),
+            g: [9, 10, 11, 12, 13, 14, 15, 16],
         },
     ];
 

--- a/src/array/fixed_size_list.rs
+++ b/src/array/fixed_size_list.rs
@@ -21,7 +21,7 @@ pub struct FixedSizeListArray<
     T: Array,
     const NULLABLE: bool = false,
     Buffer: BufferType = VecBuffer,
->(<T as Validity<NULLABLE>>::Storage<Buffer>)
+>(pub(crate) <T as Validity<NULLABLE>>::Storage<Buffer>)
 where
     T: Validity<NULLABLE>;
 

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -184,6 +184,53 @@ impl<OffsetItem: OffsetElement, Buffer: BufferType> Index
     }
 }
 
+/// An iterator over strings in a [`StringArray`].
+pub struct StringIter<'a, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+{
+    /// Reference to the array.
+    array: &'a StringArray<NULLABLE, OffsetItem, Buffer>,
+    /// Current index.
+    index: usize,
+}
+
+impl<'a, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Iterator
+    for StringIter<'a, NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    StringArray<NULLABLE, OffsetItem, Buffer>: Length + Index,
+{
+    type Item = <StringArray<NULLABLE, OffsetItem, Buffer> as Index>::Item<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.array
+            .index(self.index)
+            .into_iter()
+            .inspect(|_| {
+                self.index += 1;
+            })
+            .next()
+    }
+}
+
+impl<'a, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> IntoIterator
+    for &'a StringArray<NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    StringArray<NULLABLE, OffsetItem, Buffer>: Index + Length,
+{
+    type Item = <StringArray<NULLABLE, OffsetItem, Buffer> as Index>::Item<'a>;
+    type IntoIter = StringIter<'a, NULLABLE, OffsetItem, Buffer>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        StringIter {
+            array: self,
+            index: 0,
+        }
+    }
+}
+
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Length
     for StringArray<NULLABLE, OffsetItem, Buffer>
 where
@@ -232,7 +279,6 @@ mod tests {
         let input = ["1", "23", "456", "7890"];
         let array = input
             .into_iter()
-            .map(ToOwned::to_owned)
             .collect::<<String as ArrayType>::Array<VecBuffer, i64, union::NA>>();
         assert_eq!(array.len(), 4);
         assert_eq!(array.0 .0.data.0, b"1234567890");
@@ -246,13 +292,7 @@ mod tests {
 
     #[test]
     fn from_iter_nullable() {
-        let input = vec![
-            Some("a".to_owned()),
-            None,
-            Some("sd".to_owned()),
-            Some("f".to_owned()),
-            None,
-        ];
+        let input = vec![Some("a"), None, Some("sd"), Some("f"), None];
         let array = input.into_iter().collect::<StringArray<true>>();
         assert_eq!(array.len(), 5);
         assert_eq!(array.is_valid(0), Some(true));
@@ -266,6 +306,23 @@ mod tests {
         assert_eq!(
             array.bitmap_ref().into_iter().collect::<Vec<_>>(),
             &[true, false, true, true, false]
+        );
+    }
+
+    #[test]
+    fn into_iter() {
+        let input = ["1", "23", "456", "7890"];
+        let array = input.clone().into_iter().collect::<StringArray>();
+        assert_eq!(array.into_iter().collect::<Vec<_>>(), input);
+
+        let input_nullable = vec![Some("a"), None, Some("sd"), Some("f"), None];
+        let array_nullable = input_nullable
+            .clone()
+            .into_iter()
+            .collect::<StringArray<true>>();
+        assert_eq!(
+            array_nullable.into_iter().collect::<Vec<_>>(),
+            input_nullable
         );
     }
 

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -1,0 +1,242 @@
+//! Interop with `arrow-rs` fixed-sized list array.
+
+use std::sync::Arc;
+
+use arrow_buffer::NullBuffer;
+use arrow_schema::{DataType, Field};
+
+use crate::{
+    array::{Array, FixedSizeListArray},
+    arrow::ArrowArray,
+    bitmap::Bitmap,
+    buffer::BufferType,
+    nullable::Nullable,
+    validity::Validity,
+};
+
+impl<const N: usize, T: ArrowArray, const NULLABLE: bool, Buffer: BufferType> ArrowArray
+    for FixedSizeListArray<N, T, NULLABLE, Buffer>
+where
+    T: Validity<NULLABLE>,
+{
+    type Array = arrow_array::FixedSizeListArray;
+
+    fn as_field(name: &str) -> Field {
+        // todo(mbrobbel): const_assert
+        assert!(N <= 0x7FFF_FFFF); // i32::MAX
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+        Field::new(
+            name,
+            DataType::FixedSizeList(Arc::new(T::as_field("item")), N as i32),
+            NULLABLE,
+        )
+    }
+}
+
+impl<const N: usize, T: Array, const NULLABLE: bool, Buffer: BufferType>
+    From<Arc<dyn arrow_array::Array>> for FixedSizeListArray<N, T, NULLABLE, Buffer>
+where
+    T: Validity<NULLABLE>,
+    Self: From<arrow_array::FixedSizeListArray>,
+{
+    fn from(value: Arc<dyn arrow_array::Array>) -> Self {
+        Self::from(arrow_array::FixedSizeListArray::from(value.to_data()))
+    }
+}
+
+impl<const N: usize, T: ArrowArray, Buffer: BufferType>
+    From<FixedSizeListArray<N, T, false, Buffer>> for arrow_array::FixedSizeListArray
+where
+    <T as ArrowArray>::Array: From<T> + 'static,
+{
+    fn from(value: FixedSizeListArray<N, T, false, Buffer>) -> Self {
+        // todo(mbrobbel): const_assert
+        assert!(N <= 0x7FFF_FFFF); // i32::MAX
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+        arrow_array::FixedSizeListArray::new(
+            Arc::new(T::as_field("item")),
+            N as i32,
+            Arc::<<T as ArrowArray>::Array>::new(value.0.into()),
+            None,
+        )
+    }
+}
+
+impl<const N: usize, T: ArrowArray, Buffer: BufferType> From<FixedSizeListArray<N, T, true, Buffer>>
+    for arrow_array::FixedSizeListArray
+where
+    <T as ArrowArray>::Array: From<T> + 'static,
+    Bitmap<Buffer>: Into<NullBuffer>,
+{
+    fn from(value: FixedSizeListArray<N, T, true, Buffer>) -> Self {
+        // todo(mbrobbel): const_assert
+        assert!(N <= 0x7FFF_FFFF); // i32::MAX
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+        arrow_array::FixedSizeListArray::new(
+            Arc::new(T::as_field("item")),
+            N as i32,
+            Arc::<<T as ArrowArray>::Array>::new(value.0.data.into()),
+            Some(value.0.validity.into()),
+        )
+    }
+}
+
+/// Panics when there are nulls
+impl<const N: usize, T: ArrowArray, Buffer: BufferType> From<arrow_array::FixedSizeListArray>
+    for FixedSizeListArray<N, T, false, Buffer>
+where
+    T: From<Arc<dyn arrow_array::Array>>,
+{
+    fn from(value: arrow_array::FixedSizeListArray) -> Self {
+        let (_field, size, values, nulls_opt) = value.into_parts();
+        let n = usize::try_from(size).expect("size to cast to usize");
+        assert_eq!(N, n);
+        match nulls_opt {
+            Some(_) => panic!("expected array without a null buffer"),
+            None => FixedSizeListArray(values.into()),
+        }
+    }
+}
+
+/// Panics when there are no nulls
+impl<const N: usize, T: ArrowArray, Buffer: BufferType> From<arrow_array::FixedSizeListArray>
+    for FixedSizeListArray<N, T, true, Buffer>
+where
+    T: From<Arc<dyn arrow_array::Array>>,
+    Bitmap<Buffer>: From<NullBuffer>,
+{
+    fn from(value: arrow_array::FixedSizeListArray) -> Self {
+        let (_field, size, values, nulls_opt) = value.into_parts();
+        let n = usize::try_from(size).expect("size to cast to usize");
+        assert_eq!(N, n);
+        match nulls_opt {
+            Some(null_buffer) => FixedSizeListArray(Nullable {
+                data: values.into(),
+                validity: null_buffer.into(),
+            }),
+            None => panic!("expected array with a null buffer"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        array::{StringArray, Uint32Array},
+        arrow::scalar_buffer::ArrowScalarBuffer,
+    };
+
+    use super::*;
+
+    const INPUT: [[u32; 2]; 3] = [[1, 2], [3, 4], [5, 6]];
+    const INPUT_NULLABLE: [Option<[&str; 2]>; 3] =
+        [Some(["hello", " "]), None, Some(["world", "!"])];
+
+    #[test]
+    fn from() {
+        let fixed_size_list_array = INPUT
+            .into_iter()
+            .collect::<FixedSizeListArray<2, Uint32Array>>();
+        assert_eq!(
+            arrow_array::FixedSizeListArray::from(fixed_size_list_array)
+                .iter()
+                .flatten()
+                .flat_map(|dyn_array| {
+                    let array: Uint32Array<false, ArrowScalarBuffer> = dyn_array.into();
+                    array.into_iter().copied().collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+            INPUT.into_iter().flatten().collect::<Vec<_>>()
+        );
+
+        let fixed_size_list_array_nullable = INPUT_NULLABLE
+            .into_iter()
+            .collect::<FixedSizeListArray<2, StringArray, true>>();
+        assert_eq!(
+            arrow_array::FixedSizeListArray::from(fixed_size_list_array_nullable)
+                .iter()
+                .flatten()
+                .flat_map(|dyn_array| {
+                    let array: StringArray<false, i32, ArrowScalarBuffer> = dyn_array.into();
+                    array.into_iter().map(ToOwned::to_owned).collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>(),
+            INPUT_NULLABLE
+                .into_iter()
+                .flatten()
+                .flatten()
+                .collect::<Vec<_>>()
+        );
+    }
+
+    // #[test]
+    // #[should_panic(expected = "expected array with a null buffer")]
+    // fn into_nullable() {
+    //     let primitive_array = INPUT
+    //         .into_iter()
+    //         .collect::<arrow_array::PrimitiveArray<UInt32Type>>();
+    //     let _ = FixedSizePrimitiveArray::<
+    //         u32,
+    //         true,
+    //         crate::arrow::buffer::scalar_buffer::ArrowScalarBuffer,
+    //     >::from(primitive_array);
+    // }
+
+    // #[test]
+    // #[should_panic(expected = "expected array without a null buffer")]
+    // fn into_non_nullable() {
+    //     let primitive_array_nullable = INPUT_NULLABLE
+    //         .into_iter()
+    //         .collect::<arrow_array::PrimitiveArray<UInt16Type>>();
+    //     let _ = FixedSizePrimitiveArray::<
+    //         u16,
+    //         false,
+    //         crate::arrow::buffer::scalar_buffer::ArrowScalarBuffer,
+    //     >::from(primitive_array_nullable);
+    // }
+
+    #[test]
+    fn into() {
+        // let primitive_array = INPUT
+        //     .into_iter()
+        //     .collect::<arrow_array::PrimitiveArray<UInt32Type>>();
+        // assert_eq!(
+        //     FixedSizePrimitiveArray::<
+        //         u32,
+        //         false,
+        //         crate::arrow::buffer::scalar_buffer::ArrowScalarBuffer,
+        //     >::from(primitive_array)
+        //     .into_iter()
+        //     .copied()
+        //     .collect::<Vec<_>>(),
+        //     INPUT
+        // );
+
+        // let primitive_array_nullable = INPUT_NULLABLE
+        //     .into_iter()
+        //     .collect::<arrow_array::PrimitiveArray<UInt16Type>>();
+        // assert_eq!(
+        //     FixedSizePrimitiveArray::<
+        //         u16,
+        //         true,
+        //         crate::arrow::buffer::scalar_buffer::ArrowScalarBuffer,
+        //     >::from(primitive_array_nullable)
+        //     .into_iter()
+        //     .map(|opt| opt.copied())
+        //     .collect::<Vec<_>>(),
+        //     INPUT_NULLABLE
+        // );
+    }
+}

--- a/src/arrow/array/mod.rs
+++ b/src/arrow/array/mod.rs
@@ -1,6 +1,7 @@
 //! Interop with [`arrow-array`].
 
 mod boolean;
+mod fixed_size_list;
 mod fixed_size_primitive;
 mod string;
 mod r#struct;


### PR DESCRIPTION
Adds support for interop between `narrow::array::FixedSizeListArray` and `arrow_array::FixedSizeListArray`.