### PR TITLE
feat: `LogicalArray` to support logical types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ dependencies = [
  "narrow-derive",
  "parquet",
  "rand",
+ "uuid",
 ]
 
 [[package]]
@@ -1063,6 +1064,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "uuid"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,14 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 arrow-rs = ["dep:arrow-array", "dep:arrow-buffer", "dep:arrow-schema", "narrow-derive?/arrow-rs"]
 derive = ["dep:narrow-derive"]
+uuid = ["dep:uuid"]
 
 [dependencies]
 arrow-array = { git = "https://github.com/apache/arrow-rs", rev = "7fd2d42", optional = true }
 arrow-buffer = { git = "https://github.com/apache/arrow-rs", rev = "7fd2d42", optional = true }
 arrow-schema = { git = "https://github.com/apache/arrow-rs", rev = "7fd2d42", optional = true }
 narrow-derive = { path = "narrow-derive", version = "^0.3.4", optional = true }
+uuid = { version = "1.7.0", optional = true }
 
 [dev-dependencies]
 arrow-cast = { git = "https://github.com/apache/arrow-rs", rev = "7fd2d42", default-features = false, features = ["prettyprint"] }
@@ -48,6 +50,7 @@ bytes = "1.5.0"
 criterion = { version = "0.5.1", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 parquet = { git = "https://github.com/apache/arrow-rs", rev = "7fd2d42", default-features = false, features = ["arrow"] }
+uuid = "1.7.0"
 
 [profile.bench]
 lto = true

--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -8,6 +8,7 @@ fn main() {
         ArrayType,
     };
     use parquet::arrow::{arrow_reader::ParquetRecordBatchReader, ArrowWriter};
+    use uuid::Uuid;
 
     #[derive(ArrayType, Default)]
     struct Bar(Option<bool>);
@@ -21,6 +22,7 @@ fn main() {
         e: Option<Vec<Option<bool>>>,
         f: Bar,
         g: [u8; 8],
+        h: Uuid,
     }
     let input = [
         Foo {
@@ -31,6 +33,7 @@ fn main() {
             e: Some(vec![Some(true), None]),
             f: Bar(Some(true)),
             g: [1, 2, 3, 4, 5, 6, 7, 8],
+            h: Uuid::from_u128(1234),
         },
         Foo {
             a: 42,
@@ -40,6 +43,7 @@ fn main() {
             e: None,
             f: Bar(None),
             g: [9, 10, 11, 12, 13, 14, 15, 16],
+            h: Uuid::from_u128(42),
         },
     ];
 

--- a/src/array/boolean.rs
+++ b/src/array/boolean.rs
@@ -5,7 +5,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferRef, BufferRefMut, BufferType, VecBuffer},
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
     Index, Length,
 };
 
@@ -18,9 +18,12 @@ pub struct BooleanArray<const NULLABLE: bool = false, Buffer: BufferType = VecBu
 where
     Bitmap<Buffer>: Validity<NULLABLE>;
 
-impl<const NULLABLE: bool, Buffer: BufferType> Array for BooleanArray<NULLABLE, Buffer> where
-    Bitmap<Buffer>: Validity<NULLABLE>
+impl<const NULLABLE: bool, Buffer: BufferType> Array for BooleanArray<NULLABLE, Buffer>
+where
+    Bitmap<Buffer>: Validity<NULLABLE>,
+    bool: Nullability<NULLABLE>,
 {
+    type Item = <bool as Nullability<NULLABLE>>::Item;
 }
 
 impl<const NULLABLE: bool, Buffer: BufferType> BufferRef<u8> for BooleanArray<NULLABLE, Buffer>

--- a/src/array/fixed_size_list.rs
+++ b/src/array/fixed_size_list.rs
@@ -9,7 +9,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferMut, BufferType, VecBuffer},
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
     Index, Length,
 };
 
@@ -29,7 +29,9 @@ impl<const N: usize, T: Array, const NULLABLE: bool, Buffer: BufferType> Array
     for FixedSizeListArray<N, T, NULLABLE, Buffer>
 where
     T: Validity<NULLABLE>,
+    [<T as Array>::Item; N]: Nullability<NULLABLE>,
 {
+    type Item = <[<T as Array>::Item; N] as Nullability<NULLABLE>>::Item;
 }
 
 impl<const N: usize, T: Array, Buffer: BufferType> BitmapRef

--- a/src/array/fixed_size_primitive.rs
+++ b/src/array/fixed_size_primitive.rs
@@ -5,7 +5,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{Buffer, BufferType, VecBuffer},
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
     FixedSize, Index, Length,
 };
 use std::{ops, slice::SliceIndex};
@@ -53,7 +53,9 @@ impl<T: FixedSize, const NULLABLE: bool, Buffer: BufferType> Array
     for FixedSizePrimitiveArray<T, NULLABLE, Buffer>
 where
     <Buffer as BufferType>::Buffer<T>: Validity<NULLABLE>,
+    T: Nullability<NULLABLE>,
 {
+    type Item = <T as Nullability<NULLABLE>>::Item;
 }
 
 // todo(mbrobbel): buffer_ref traits?

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -34,7 +34,10 @@ mod variable_size_list;
 pub use variable_size_list::*;
 
 /// Types that store their data in Arrow arrays.
-pub trait Array {}
+pub trait Array {
+    /// The items stored in this array.
+    type Item;
+}
 
 /// Types that can be stored in Arrow arrays.
 // Note: the generic `T` is required to allow impls on foreign wrappers e.g.

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -5,7 +5,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
     Index, Length,
 };
 use std::{
@@ -44,9 +44,12 @@ pub struct NullArray<T: Unit = (), const NULLABLE: bool = false, Buffer: BufferT
 where
     Nulls<T>: Validity<NULLABLE>;
 
-impl<T: Unit, const NULLABLE: bool, Buffer: BufferType> Array for NullArray<T, NULLABLE, Buffer> where
-    Nulls<T>: Validity<NULLABLE>
+impl<T: Unit, const NULLABLE: bool, Buffer: BufferType> Array for NullArray<T, NULLABLE, Buffer>
+where
+    Nulls<T>: Validity<NULLABLE>,
+    T: Nullability<NULLABLE>,
 {
+    type Item = <T as Nullability<NULLABLE>>::Item;
 }
 
 impl<T: Unit, const NULLABLE: bool, Buffer: BufferType> Default for NullArray<T, NULLABLE, Buffer>

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -7,7 +7,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     offset::OffsetElement,
-    validity::Validity,
+    validity::{Nullability, Validity},
     Index, Length,
 };
 
@@ -32,7 +32,9 @@ impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Array
     for StringArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    String: Nullability<NULLABLE>,
 {
+    type Item = <String as Nullability<NULLABLE>>::Item;
 }
 
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Default

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -5,7 +5,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
     Length,
 };
 
@@ -30,7 +30,9 @@ impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Array
     for StructArray<T, NULLABLE, Buffer>
 where
     <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    T: Nullability<NULLABLE>,
 {
+    type Item = <T as Nullability<NULLABLE>>::Item;
 }
 
 impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Default

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -5,7 +5,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{Buffer, BufferType, VecBuffer},
     offset::{Offset, OffsetElement},
-    validity::Validity,
+    validity::{Nullability, Validity},
     Index, Length,
 };
 
@@ -30,7 +30,9 @@ impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Array
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Vec<u8>: Nullability<NULLABLE>,
 {
+    type Item = <Vec<u8> as Nullability<NULLABLE>>::Item;
 }
 
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Default

--- a/src/array/variable_size_list.rs
+++ b/src/array/variable_size_list.rs
@@ -5,7 +5,7 @@ use crate::{
     bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
     buffer::{BufferType, VecBuffer},
     offset::{Offset, OffsetElement},
-    validity::Validity,
+    validity::{Nullability, Validity},
     Index, Length,
 };
 use std::fmt::{Debug, Formatter, Result};
@@ -24,7 +24,9 @@ impl<T: Array, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferTy
     for VariableSizeListArray<T, NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Vec<T>: Nullability<NULLABLE>,
 {
+    type Item = <Vec<T> as Nullability<NULLABLE>>::Item;
 }
 
 impl<T: Array, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Debug

--- a/src/arrow/array/boolean.rs
+++ b/src/arrow/array/boolean.rs
@@ -3,8 +3,12 @@
 use std::sync::Arc;
 
 use crate::{
-    array::BooleanArray, arrow::ArrowArray, bitmap::Bitmap, buffer::BufferType, nullable::Nullable,
-    validity::Validity,
+    array::BooleanArray,
+    arrow::ArrowArray,
+    bitmap::Bitmap,
+    buffer::BufferType,
+    nullable::Nullable,
+    validity::{Nullability, Validity},
 };
 use arrow_buffer::{BooleanBuffer, NullBuffer};
 use arrow_schema::{DataType, Field};
@@ -12,6 +16,7 @@ use arrow_schema::{DataType, Field};
 impl<const NULLABLE: bool, Buffer: BufferType> ArrowArray for BooleanArray<NULLABLE, Buffer>
 where
     Bitmap<Buffer>: Validity<NULLABLE>,
+    bool: Nullability<NULLABLE>,
 {
     type Array = arrow_array::BooleanArray;
 

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -11,13 +11,14 @@ use crate::{
     bitmap::Bitmap,
     buffer::BufferType,
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
 };
 
 impl<const N: usize, T: ArrowArray, const NULLABLE: bool, Buffer: BufferType> ArrowArray
     for FixedSizeListArray<N, T, NULLABLE, Buffer>
 where
     T: Validity<NULLABLE>,
+    [<T as Array>::Item; N]: Nullability<NULLABLE>,
 {
     type Array = arrow_array::FixedSizeListArray;
 

--- a/src/arrow/array/fixed_size_primitive.rs
+++ b/src/arrow/array/fixed_size_primitive.rs
@@ -10,8 +10,13 @@ use arrow_buffer::{NullBuffer, ScalarBuffer};
 use arrow_schema::{DataType, Field};
 
 use crate::{
-    array::FixedSizePrimitiveArray, arrow::ArrowArray, bitmap::Bitmap, buffer::BufferType,
-    nullable::Nullable, validity::Validity, FixedSize,
+    array::FixedSizePrimitiveArray,
+    arrow::ArrowArray,
+    bitmap::Bitmap,
+    buffer::BufferType,
+    nullable::Nullable,
+    validity::{Nullability, Validity},
+    FixedSize,
 };
 
 /// Create the `ArrowArray` impl and required conversions.
@@ -21,6 +26,7 @@ macro_rules! arrow_array_convert {
             for FixedSizePrimitiveArray<$ty, NULLABLE, Buffer>
         where
             <Buffer as BufferType>::Buffer<$ty>: Validity<NULLABLE>,
+            $ty: Nullability<NULLABLE>,
         {
             type Array = arrow_array::PrimitiveArray<$primitive_type>;
 

--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -1,3 +1,5 @@
+//! Interop with [`arrow-rs`] arrays for logical arrays.
+
 use std::sync::Arc;
 
 use crate::{

--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use crate::{
+    array::UnionType,
+    arrow::ArrowArray,
+    buffer::BufferType,
+    logical::{LogicalArray, LogicalArrayType},
+    offset::OffsetElement,
+    validity::{Nullability, Validity},
+};
+
+impl<
+        T: LogicalArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > ArrowArray for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
+where
+    <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>:
+        Validity<NULLABLE> + ArrowArray,
+    T: Nullability<NULLABLE>,
+{
+    type Array =
+        <<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as ArrowArray>::Array;
+
+    fn as_field(name: &str) -> arrow_schema::Field {
+        <<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as ArrowArray>::as_field(
+            name,
+        )
+    }
+}
+
+impl<
+        T: LogicalArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<Arc<dyn arrow_array::Array>>
+    for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
+where
+    <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    <<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Validity<NULLABLE>>::Storage<Buffer>: From<Arc<dyn arrow_array::Array>>,
+{
+    fn from(value: Arc<dyn arrow_array::Array>) -> Self {
+        Self(value.into())
+    }
+}
+
+impl<
+        T: LogicalArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>>
+    for arrow_array::FixedSizeListArray
+where
+    <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    arrow_array::FixedSizeListArray:
+        From<
+            <<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Validity<
+                NULLABLE,
+            >>::Storage<Buffer>,
+        >,
+{
+    fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
+        value.0.into()
+    }
+}

--- a/src/arrow/array/mod.rs
+++ b/src/arrow/array/mod.rs
@@ -6,4 +6,5 @@ mod fixed_size_primitive;
 mod string;
 mod r#struct;
 pub use r#struct::StructArrayTypeFields;
+mod logical;
 mod variable_size_list;

--- a/src/arrow/array/string.rs
+++ b/src/arrow/array/string.rs
@@ -13,13 +13,14 @@ use crate::{
     buffer::BufferType,
     nullable::Nullable,
     offset::{Offset, OffsetElement},
-    validity::Validity,
+    validity::{Nullability, Validity},
 };
 
 impl<const NULLABLE: bool, OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
     ArrowArray for StringArray<NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    String: Nullability<NULLABLE>,
 {
     type Array = arrow_array::GenericStringArray<OffsetItem>;
 

--- a/src/arrow/array/struct.rs
+++ b/src/arrow/array/struct.rs
@@ -11,7 +11,7 @@ use crate::{
     bitmap::Bitmap,
     buffer::BufferType,
     nullable::Nullable,
-    validity::Validity,
+    validity::{Nullability, Validity},
 };
 
 /// Arrow schema interop trait for the fields of a struct array type.
@@ -24,6 +24,7 @@ impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> ArrowArray
     for StructArray<T, NULLABLE, Buffer>
 where
     <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE> + StructArrayTypeFields,
+    T: Nullability<NULLABLE>,
 {
     type Array = arrow_array::StructArray;
 

--- a/src/arrow/array/variable_size_list.rs
+++ b/src/arrow/array/variable_size_list.rs
@@ -13,7 +13,7 @@ use crate::{
     buffer::BufferType,
     nullable::Nullable,
     offset::{Offset, OffsetElement},
-    validity::Validity,
+    validity::{Nullability, Validity},
 };
 
 impl<
@@ -24,6 +24,7 @@ impl<
     > ArrowArray for VariableSizeListArray<T, NULLABLE, OffsetItem, Buffer>
 where
     <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Vec<T>: Nullability<NULLABLE>,
 {
     type Array = arrow_array::GenericListArray<OffsetItem>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,8 @@ pub(crate) mod validity;
 
 pub mod array;
 
+pub mod logical;
+
 #[cfg(feature = "arrow-rs")]
 pub mod arrow;
 

--- a/src/logical/mod.rs
+++ b/src/logical/mod.rs
@@ -1,0 +1,95 @@
+//! Logical array support.
+
+use crate::{
+    array::{Array, ArrayType, UnionType},
+    buffer::BufferType,
+    offset::OffsetElement,
+    validity::{Nullability, Validity},
+};
+
+/// Types that can be stored in Arrow arrays, but require mapping via
+/// [`LogicalArray`].
+pub trait LogicalArrayType: ArrayType {
+    /// The Arrow [`Array`] used inside [`LogicalArray`] to store these types.
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>: Array;
+
+    /// Convert an item into the item type of the associated array.
+    fn convert<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>(
+        self,
+    ) -> <<Self as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Array>::Item;
+}
+
+/// An array for [`LogicalArrayType`] items, that are stored in Arrow arrays,
+/// but convertable from and to theirself via this array wrapper.
+pub struct LogicalArray<
+    T: LogicalArrayType,
+    const NULLABLE: bool,
+    Buffer: BufferType,
+    OffsetItem: OffsetElement,
+    UnionLayout: UnionType,
+>(<<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Validity<NULLABLE>>::Storage<Buffer>
+) where <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>;
+
+impl<
+        T: LogicalArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > Array for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
+where
+    <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    T: Nullability<NULLABLE>,
+{
+    type Item = <T as Nullability<NULLABLE>>::Item;
+}
+
+impl<
+        T: LogicalArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > FromIterator<T>
+    for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
+where
+    <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    <<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Validity<NULLABLE>>::Storage<Buffer>: FromIterator<<<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Array>::Item>
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self(iter.into_iter().map(LogicalArrayType::convert).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{array::union, buffer::VecBuffer, offset};
+
+    use super::*;
+
+    struct Foo(u8);
+    impl ArrayType for Foo {
+        type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+            LogicalArray<Foo, false, Buffer, OffsetItem, UnionLayout>;
+    }
+    impl LogicalArrayType for Foo {
+        type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+            <u8 as ArrayType>::Array<Buffer, OffsetItem, UnionLayout>;
+
+        fn convert<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>(
+            self,
+        ) -> <<Self as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Array>::Item
+        {
+            self.0
+        }
+    }
+    type FooArray<const NULLABLE: bool = false, Buffer = VecBuffer> =
+        LogicalArray<Foo, NULLABLE, Buffer, offset::NA, union::NA>;
+
+    #[test]
+    fn from_iter() {
+        let input = [Foo(1), Foo(2), Foo(3), Foo(4)];
+        let array = input.into_iter().collect::<FooArray>();
+        assert_eq!(array.0 .0, [1, 2, 3, 4]);
+    }
+}

--- a/src/logical/uuid.rs
+++ b/src/logical/uuid.rs
@@ -1,0 +1,70 @@
+use uuid::Uuid;
+
+use crate::{
+    array::{Array, ArrayType, FixedSizeListArray, FixedSizePrimitiveArray, UnionType},
+    buffer::BufferType,
+    offset::OffsetElement,
+};
+
+use super::{LogicalArray, LogicalArrayType};
+
+impl ArrayType for Uuid {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<Uuid, false, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl ArrayType for Option<Uuid> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<Uuid, true, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl LogicalArrayType for Uuid {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        FixedSizeListArray<16, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>;
+
+    fn convert<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>(
+        self,
+    ) -> <<Self as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Array>::Item {
+        self.into_bytes()
+    }
+}
+
+impl LogicalArrayType for Option<Uuid> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        FixedSizeListArray<16, FixedSizePrimitiveArray<u8, false, Buffer>, true, Buffer>;
+
+    fn convert<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>(
+        self,
+    ) -> <<Self as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Array>::Item {
+        self.map(Uuid::into_bytes)
+    }
+}
+
+impl<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>
+    From<LogicalArray<Uuid, false, Buffer, OffsetItem, UnionLayout>>
+    for FixedSizeListArray<16, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>
+{
+    fn from(value: LogicalArray<Uuid, false, Buffer, OffsetItem, UnionLayout>) -> Self {
+        value.0
+    }
+}
+
+/// An array for Uuid items.
+#[allow(unused)]
+pub type UuidArray<const NULLABLE: bool = false, Buffer = crate::buffer::VecBuffer> =
+    LogicalArray<Uuid, NULLABLE, Buffer, crate::offset::NA, crate::array::union::NA>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Length;
+
+    #[test]
+    fn from_iter() {
+        let array = [Uuid::from_u128(1), Uuid::from_u128(42)]
+            .into_iter()
+            .collect::<UuidArray>();
+        assert_eq!(array.len(), 2);
+        assert_eq!(array.0.len(), 2);
+    }
+}

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -23,3 +23,18 @@ impl<T> Validity<false> for T {
 impl<T> Validity<true> for T {
     type Storage<Buffer: BufferType> = Nullable<T, Buffer>;
 }
+
+/// Nullability trait for nullable and non-nullable items.
+pub trait Nullability<const NULLABLE: bool> {
+    /// The item, `T` when `NULLABLE` is false, `Option<Item>` when
+    /// `NULLABLE` is true.
+    type Item;
+}
+
+impl<T> Nullability<false> for T {
+    type Item = T;
+}
+
+impl<T> Nullability<true> for T {
+    type Item = Option<T>;
+}


### PR DESCRIPTION
Introduces a `LogicalArray` to support storing logical (and extension) types in Arrow arrays.

It also adds a `uuid` feature that adds logical array support for `uuid::Uuid`.

```
cargo r --example parquet --features="arrow-rs derive uuid"
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `target/debug/examples/parquet`
From narrow StructArray to Arrow RecordBatch
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
| a  | b | c     | d            | e        | f          | g                               | h                                                  |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
| 1  | 2 | true  | hello world! | [true, ] | {_0: true} | [1, 2, 3, 4, 5, 6, 7, 8]        | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 210] |
| 42 |   | false | narrow       |          | {_0: }     | [9, 10, 11, 12, 13, 14, 15, 16] | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42]  |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
From Arrow RecordBatch to Parquet and back to Arrow RecordBatch
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
| a  | b | c     | d            | e        | f          | g                               | h                                                  |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
| 1  | 2 | true  | hello world! | [true, ] | {_0: true} | [1, 2, 3, 4, 5, 6, 7, 8]        | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 210] |
| 42 |   | false | narrow       |          | {_0: }     | [9, 10, 11, 12, 13, 14, 15, 16] | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42]  |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
From Arrow RecordBatch (via Parquet) to narrow StructArray and back to Arrow RecordBatch
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
| a  | b | c     | d            | e        | f          | g                               | h                                                  |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
| 1  | 2 | true  | hello world! | [true, ] | {_0: true} | [1, 2, 3, 4, 5, 6, 7, 8]        | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4, 210] |
| 42 |   | false | narrow       |          | {_0: }     | [9, 10, 11, 12, 13, 14, 15, 16] | [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 42]  |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------------------------+
```