### PR TITLE
feat: add `arrow` `NullArray` interop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ahash"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
+checksum = "77c3a9648d43b9cd48db467b3f87fdd6e146bcc88ab0180006cef2179fe11d01"
 dependencies = [
  "cfg-if",
  "const-random",
@@ -623,7 +623,7 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "narrow"
-version = "0.4.3"
+version = "0.4.2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "narrow-derive"
-version = "0.4.3"
+version = "0.4.2"
 dependencies = [
  "macrotest",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,7 +623,7 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "narrow"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -639,7 +639,7 @@ dependencies = [
 
 [[package]]
 name = "narrow-derive"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "macrotest",
  "once_cell",

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -183,6 +183,7 @@ pub struct Nulls<T: Unit> {
 }
 
 impl<T: Unit> Nulls<T> {
+    #[cfg(feature = "arrow-rs")]
     /// Constructs a Nulls from a given length.
     pub(crate) fn new(len: usize) -> Self {
         Self {

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -39,7 +39,7 @@ unsafe impl Unit for () {
 
 /// A sequence of nulls.
 pub struct NullArray<T: Unit = (), const NULLABLE: bool = false, Buffer: BufferType = VecBuffer>(
-    pub <Nulls<T> as Validity<NULLABLE>>::Storage<Buffer>,
+    pub(crate) <Nulls<T> as Validity<NULLABLE>>::Storage<Buffer>,
 )
 where
     Nulls<T>: Validity<NULLABLE>;
@@ -180,6 +180,16 @@ pub struct Nulls<T: Unit> {
 
     /// Covariant over `T`
     _ty: PhantomData<fn() -> T>,
+}
+
+impl<T: Unit> Nulls<T> {
+    /// Constructs a Nulls from a given length.
+    pub(crate) fn new(len: usize) -> Self {
+        Self {
+            len,
+            _ty: PhantomData,
+        }
+    }
 }
 
 impl<T: Unit> FromIterator<T> for Nulls<T> {

--- a/src/arrow/array/mod.rs
+++ b/src/arrow/array/mod.rs
@@ -7,4 +7,5 @@ mod string;
 mod r#struct;
 pub use r#struct::StructArrayTypeFields;
 mod logical;
+mod null;
 mod variable_size_list;

--- a/src/arrow/array/null.rs
+++ b/src/arrow/array/null.rs
@@ -1,0 +1,86 @@
+//! Interop with `arrow-rs` boolean array.
+
+use std::sync::Arc;
+
+use crate::{
+    array::{NullArray, Nulls, Unit},
+    arrow::ArrowArray,
+    buffer::BufferType,
+    validity::{Nullability, Validity},
+    Length,
+};
+use arrow_array::Array;
+use arrow_schema::{DataType, Field};
+
+impl<T: Unit, const NULLABLE: bool, Buffer: BufferType> ArrowArray
+    for NullArray<T, NULLABLE, Buffer>
+where
+    T: Nullability<NULLABLE>,
+    Nulls<T>: Validity<NULLABLE>,
+{
+    type Array = arrow_array::NullArray;
+
+    fn as_field(name: &str) -> arrow_schema::Field {
+        Field::new(name, DataType::Null, NULLABLE)
+    }
+}
+
+impl<T: Unit, Buffer: BufferType> From<Arc<dyn arrow_array::Array>> for NullArray<T, false, Buffer>
+where
+    Self: From<arrow_array::NullArray>,
+{
+    fn from(value: Arc<dyn arrow_array::Array>) -> Self {
+        Self::from(arrow_array::NullArray::from(value.to_data()))
+    }
+}
+
+impl<T: Unit, Buffer: BufferType> From<NullArray<T, false, Buffer>> for arrow_array::NullArray {
+    fn from(value: NullArray<T, false, Buffer>) -> Self {
+        arrow_array::NullArray::new(value.len())
+    }
+}
+
+/// Panics when there are nulls
+impl<T: Unit, Buffer: BufferType> From<arrow_array::NullArray> for NullArray<T, false, Buffer> {
+    fn from(value: arrow_array::NullArray) -> Self {
+        NullArray(Nulls::new(value.len()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{array::NullArray, buffer::ArcBuffer, Length};
+    use arrow_array::Array;
+
+    const INPUT: [(); 4] = [(), (), (), ()];
+
+    #[test]
+    fn from() {
+        let null_array = INPUT.into_iter().collect::<NullArray>();
+        assert_eq!(
+            arrow_array::NullArray::new(null_array.len()).len(),
+            INPUT.len()
+        );
+
+        let null_array_arc = INPUT
+            .into_iter()
+            .collect::<NullArray<_, false, ArcBuffer>>();
+        assert_eq!(
+            arrow_array::NullArray::new(null_array_arc.len()).len(),
+            INPUT.len()
+        );
+    }
+
+    #[test]
+    fn into() {
+        let null_array = arrow_array::NullArray::new(INPUT.len());
+        assert_eq!(
+            NullArray::<(), false, crate::arrow::buffer::scalar_buffer::ArrowScalarBuffer>::from(
+                null_array
+            )
+            .into_iter()
+            .collect::<Vec<_>>(),
+            INPUT
+        );
+    }
+}


### PR DESCRIPTION
Note that there is no support for nullable null arrays in `arrow-rs`.