### PR TITLE
fix: use fully qualified syntax for `VARIANTS` const in `ArrayType` impl

### DIFF
--- a/narrow-derive/src/enum.rs
+++ b/narrow-derive/src/enum.rs
@@ -616,9 +616,10 @@ impl<'a> Enum<'a> {
         let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
         let ident = self.ident;
+        let variants = Literal::usize_unsuffixed(self.variants.len());
         let tokens = quote! {
             impl #impl_generics #narrow::array::ArrayType for #ident #ty_generics #where_clause {
-                type Array<Buffer: #narrow::buffer::BufferType, OffsetItem: #narrow::offset::OffsetElement, UnionLayout: #narrow::array::UnionType> = #narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+                type Array<Buffer: #narrow::buffer::BufferType, OffsetItem: #narrow::offset::OffsetElement, UnionLayout: #narrow::array::UnionType> = #narrow::array::UnionArray<Self, { <Self as #narrow::array::UnionArrayType<#variants>>::VARIANTS }, UnionLayout, Buffer>;
             }
         };
         parse2(tokens).expect("array_type_impl")

--- a/narrow-derive/tests/expand/enum/named/generic.expanded.rs
+++ b/narrow-derive/tests/expand/enum/named/generic.expanded.rs
@@ -259,7 +259,12 @@ impl<T: narrow::array::ArrayType> narrow::array::ArrayType for Foo<T> {
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<3>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }
 #[automatically_derived]
 impl<T: ::core::clone::Clone> ::core::clone::Clone for Foo<T> {

--- a/narrow-derive/tests/expand/enum/named/simple.expanded.rs
+++ b/narrow-derive/tests/expand/enum/named/simple.expanded.rs
@@ -317,5 +317,10 @@ impl narrow::array::ArrayType for FooBar {
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<4>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }

--- a/narrow-derive/tests/expand/enum/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unit/const_generic.expanded.rs
@@ -173,5 +173,10 @@ impl<const X: bool> narrow::array::ArrayType for FooBar<X> {
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<2>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }

--- a/narrow-derive/tests/expand/enum/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unit/simple.expanded.rs
@@ -274,5 +274,10 @@ impl narrow::array::ArrayType for FooBar {
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<4>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }

--- a/narrow-derive/tests/expand/enum/unnamed/generic.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unnamed/generic.expanded.rs
@@ -266,5 +266,10 @@ impl<T: Default + narrow::array::ArrayType> narrow::array::ArrayType for FooBar<
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<3>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }

--- a/narrow-derive/tests/expand/enum/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unnamed/simple.expanded.rs
@@ -172,5 +172,10 @@ impl narrow::array::ArrayType for FooBar {
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<2>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }

--- a/narrow-derive/tests/expand/enum/unnamed/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unnamed/where_clause.expanded.rs
@@ -313,5 +313,10 @@ where
         Buffer: narrow::buffer::BufferType,
         OffsetItem: narrow::offset::OffsetElement,
         UnionLayout: narrow::array::UnionType,
-    > = narrow::array::UnionArray<Self, { Self::VARIANTS }, UnionLayout, Buffer>;
+    > = narrow::array::UnionArray<
+        Self,
+        { <Self as narrow::array::UnionArrayType<3>>::VARIANTS },
+        UnionLayout,
+        Buffer,
+    >;
 }

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -4,7 +4,7 @@ mod tests {
         mod r#enum {
             mod unit {
                 use narrow::{
-                    array::{DenseLayout, SparseLayout, UnionArray, UnionArrayType},
+                    array::{DenseLayout, SparseLayout, UnionArray},
                     ArrayType, Length,
                 };
 
@@ -30,7 +30,7 @@ mod tests {
             }
             mod unnamed {
                 use narrow::{
-                    array::{DenseLayout, SparseLayout, UnionArray, UnionArrayType},
+                    array::{DenseLayout, SparseLayout, UnionArray},
                     ArrayType, Length,
                 };
 
@@ -56,7 +56,7 @@ mod tests {
             }
             mod named {
                 use narrow::{
-                    array::{DenseLayout, SparseLayout, UnionArray, UnionArrayType},
+                    array::{DenseLayout, SparseLayout, UnionArray},
                     ArrayType, Length,
                 };
 


### PR DESCRIPTION
This prevents users from having to bring the trait in scope when using the derive macro.