### PR TITLE
feat!: add parquet write support for `UnionArray`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
             --no-changelog-preview \
             --verbose \
             --execute \
-            narrow
+            narrow narrow-derive
       - id: version
         env:
           GH_TOKEN: ${{ secrets.PAT }}

--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -3,7 +3,7 @@ fn main() {
     use arrow_cast::pretty;
     use bytes::Bytes;
     use narrow::{
-        array::StructArray,
+        array::{DenseLayout, SparseLayout, StructArray},
         arrow::{buffer_builder::ArrowBufferBuilder, scalar_buffer::ArrowScalarBuffer},
         ArrayType,
     };
@@ -12,6 +12,18 @@ fn main() {
 
     #[derive(ArrayType, Default)]
     struct Bar(Option<bool>);
+
+    #[derive(ArrayType, Default)]
+    enum FooBar {
+        #[default]
+        Foo,
+        Bar(bool),
+        Baz {
+            a: u8,
+            b: u16,
+            c: u32,
+        },
+    }
 
     #[derive(ArrayType, Default)]
     struct Foo {
@@ -23,6 +35,7 @@ fn main() {
         f: Bar,
         g: [u8; 8],
         h: Uuid,
+        i: FooBar,
     }
     let input = [
         Foo {
@@ -34,6 +47,7 @@ fn main() {
             f: Bar(Some(true)),
             g: [1, 2, 3, 4, 5, 6, 7, 8],
             h: Uuid::from_u128(1234),
+            i: FooBar::Bar(true),
         },
         Foo {
             a: 42,
@@ -44,6 +58,7 @@ fn main() {
             f: Bar(None),
             g: [9, 10, 11, 12, 13, 14, 15, 16],
             h: Uuid::from_u128(42),
+            i: FooBar::Baz { a: 1, b: 2, c: 42 },
         },
     ];
 

--- a/narrow-derive/src/enum.rs
+++ b/narrow-derive/src/enum.rs
@@ -41,7 +41,7 @@ pub(super) fn derive(
     // Generate the ArrayType impl.
     let array_type_impl = input.array_type_impl();
 
-    quote! {
+    let tokens = quote! {
         #i8_conversion
 
         #variant_struct_defs
@@ -59,7 +59,31 @@ pub(super) fn derive(
         #union_array_type_impl
 
         #array_type_impl
+    };
+
+    #[cfg(feature = "arrow-rs")]
+    {
+        // Generate the union array type fields impl.
+        let union_array_types_fields_impl = input.union_array_types_fields_impl();
+
+        // Generate the conversion to struct array.
+        let union_array_to_struct_array_impl = input.union_array_to_struct_array_impl();
+
+        // Generate the conversion from the variant arrays.
+        let union_array_from_struct_array_impl = input.union_array_from_struct_array_impl();
+
+        quote! {
+            #tokens
+
+            #union_array_types_fields_impl
+
+            #union_array_to_struct_array_impl
+
+            #union_array_from_struct_array_impl
+        }
     }
+    #[cfg(not(feature = "arrow-rs"))]
+    tokens
 }
 
 struct Enum<'a> {
@@ -623,5 +647,135 @@ impl<'a> Enum<'a> {
             }
         };
         parse2(tokens).expect("array_type_impl")
+    }
+
+    #[cfg(feature = "arrow-rs")]
+    fn union_array_types_fields_impl(&self) -> ItemImpl {
+        let narrow = util::narrow();
+
+        let ident = self.array_struct_ident();
+        let mut generics = self.generics.clone();
+        AddTypeParam(parse_quote!(Buffer: #narrow::buffer::BufferType))
+            .visit_generics_mut(&mut generics);
+        AddTypeParam(parse_quote!(OffsetItem: #narrow::offset::OffsetElement))
+            .visit_generics_mut(&mut generics);
+        AddTypeParam(parse_quote!(UnionLayout: #narrow::array::UnionType))
+            .visit_generics_mut(&mut generics);
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+        let self_ident = self.ident;
+        let idx = self.variant_indices();
+        let variant_idx = (0..self.variants.len()).map(|idx| idx.to_string());
+        let tokens = quote! {
+            impl #impl_generics #narrow::arrow::UnionArrayTypeFields for #ident #ty_generics #where_clause {
+                fn fields() -> ::arrow_schema::Fields {
+                    ::arrow_schema::Fields::from(vec![
+                        #(
+                            <<<#self_ident as #narrow::array::union::EnumVariant<#idx>>::Data as #narrow::array::ArrayType>::Array<
+                                Buffer,
+                                OffsetItem,
+                                SparseLayout,
+                            > as #narrow::arrow::ArrowArray>::as_field(#variant_idx),
+                        )*
+                    ])
+                }
+            }
+        };
+        parse2(tokens).expect("union_array_types_fields_impl")
+    }
+
+    #[cfg(feature = "arrow-rs")]
+    fn union_array_to_struct_array_impl(&self) -> ItemImpl {
+        let narrow = util::narrow();
+
+        let ident = self.array_struct_ident();
+        let mut generics = self.generics.clone();
+        AddTypeParam(parse_quote!(Buffer: #narrow::buffer::BufferType))
+            .visit_generics_mut(&mut generics);
+        AddTypeParam(parse_quote!(OffsetItem: #narrow::offset::OffsetElement))
+            .visit_generics_mut(&mut generics);
+
+        let self_ident = self.ident;
+        let (_, self_ty_generics, _) = self.generics.split_for_impl();
+        generics.make_where_clause().predicates.extend(
+            self.variant_indices().map::<WherePredicate, _>(|idx| {
+                parse_quote!(::std::sync::Arc<dyn ::arrow_array::Array>: From<
+                <<#self_ident #self_ty_generics as #narrow::array::union::EnumVariant<#idx>>::Data as #narrow::array::ArrayType>::Array<
+                    Buffer,
+                    OffsetItem,
+                    SparseLayout,
+                >,
+            >)
+            }),
+        );
+
+        let (impl_generics, _, where_clause) = generics.split_for_impl();
+        let mut generics = generics.clone();
+        AddTypeParam(parse_quote!(SparseLayout)).visit_generics_mut(&mut generics);
+        let (_, ty_generics, _) = generics.split_for_impl();
+        let idx = self.variant_indices();
+        let tokens = quote! {
+            impl #impl_generics ::std::convert::From<#ident #ty_generics> for ::arrow_array::StructArray #where_clause {
+                fn from(value: #ident #ty_generics) -> Self {
+                    // Safety:
+                    // - TODO
+                    unsafe {
+                        ::arrow_array::StructArray::new_unchecked(
+                            <#ident #ty_generics as #narrow::arrow::UnionArrayTypeFields>::fields(),
+                            vec![
+                                #(
+                                    value.#idx.into(),
+                                )*
+                            ],
+                            None,
+                        )
+                    }
+                }
+            }
+        };
+        parse2(tokens).expect("union_array_to_struct_array_impl")
+    }
+
+    #[cfg(feature = "arrow-rs")]
+    fn union_array_from_struct_array_impl(&self) -> ItemImpl {
+        let narrow = util::narrow();
+        let self_ident = self.ident;
+        let (_, self_ty_generics, _) = self.generics.split_for_impl();
+        let ident = self.array_struct_ident();
+        let mut generics = self.generics.clone();
+        AddTypeParam(parse_quote!(Buffer: #narrow::buffer::BufferType))
+            .visit_generics_mut(&mut generics);
+        AddTypeParam(parse_quote!(OffsetItem: #narrow::offset::OffsetElement))
+            .visit_generics_mut(&mut generics);
+        AddTypeParam(parse_quote!(UnionLayout: #narrow::array::UnionType))
+            .visit_generics_mut(&mut generics);
+        generics.make_where_clause().predicates.extend(
+            self.variant_indices().map::<WherePredicate, _>(|idx| {
+                parse_quote!(::std::sync::Arc<dyn ::arrow_array::Array>: Into<
+                <<#self_ident #self_ty_generics as #narrow::array::union::EnumVariant<#idx>>::Data as #narrow::array::ArrayType>::Array<
+                    Buffer,
+                    OffsetItem,
+                    SparseLayout,
+                >,
+            >)
+            }),
+        );
+        let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+
+        let idx = (0..self.variants.len()).map(|_| Literal::usize_suffixed(0));
+        let tokens = quote! {
+            impl #impl_generics ::std::convert::From<::std::sync::Arc<dyn arrow_array::Array>> for #ident #ty_generics #where_clause {
+                fn from(value: ::std::sync::Arc<dyn arrow_array::Array>) -> Self {
+                    let struct_array = ::arrow_array::StructArray::from(value.to_data());
+                    let (_, mut arrays, _) = struct_array.into_parts();
+                    Self(
+                        #(
+                            arrays.remove(#idx).into(),
+                        )*
+                    )
+                }
+            }
+        };
+        parse2(tokens).expect("union_array_from_struct_array_impl")
     }
 }

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -14,6 +14,7 @@ pub trait StructArrayType: ArrayType {
     /// The array type that stores items of this struct. Note this differs from
     /// the [`ArrayType`] array because that wraps this array. Also note that this
     /// has no [`Array`] bound.
+    // TODO(mbrobbe): add offset and union generics
     type Array<Buffer: BufferType>; // into<fields> this then requires all arraytype impls to provide a field
 }
 

--- a/src/arrow/array/mod.rs
+++ b/src/arrow/array/mod.rs
@@ -8,4 +8,6 @@ mod r#struct;
 pub use r#struct::StructArrayTypeFields;
 mod logical;
 mod null;
+mod union;
+pub use union::UnionArrayTypeFields;
 mod variable_size_list;

--- a/src/arrow/array/null.rs
+++ b/src/arrow/array/null.rs
@@ -34,13 +34,21 @@ where
     }
 }
 
+impl<T: Unit, Buffer: BufferType> From<NullArray<T, false, Buffer>> for Arc<dyn arrow_array::Array>
+where
+    arrow_array::NullArray: From<NullArray<T, false, Buffer>>,
+{
+    fn from(value: NullArray<T, false, Buffer>) -> Self {
+        Arc::new(arrow_array::NullArray::from(value))
+    }
+}
+
 impl<T: Unit, Buffer: BufferType> From<NullArray<T, false, Buffer>> for arrow_array::NullArray {
     fn from(value: NullArray<T, false, Buffer>) -> Self {
         arrow_array::NullArray::new(value.len())
     }
 }
 
-/// Panics when there are nulls
 impl<T: Unit, Buffer: BufferType> From<arrow_array::NullArray> for NullArray<T, false, Buffer> {
     fn from(value: arrow_array::NullArray) -> Self {
         NullArray(Nulls::new(value.len()))

--- a/src/arrow/array/struct.rs
+++ b/src/arrow/array/struct.rs
@@ -50,6 +50,17 @@ where
     }
 }
 
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType>
+    From<StructArray<T, NULLABLE, Buffer>> for Arc<dyn arrow_array::Array>
+where
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    arrow_array::StructArray: From<StructArray<T, NULLABLE, Buffer>>,
+{
+    fn from(value: StructArray<T, NULLABLE, Buffer>) -> Self {
+        Arc::new(arrow_array::StructArray::from(value))
+    }
+}
+
 impl<T: StructArrayType, Buffer: BufferType> From<StructArray<T, false, Buffer>>
     for arrow_array::StructArray
 where
@@ -62,7 +73,6 @@ where
         unsafe {
             arrow_array::StructArray::new_unchecked(
                 <<T as StructArrayType>::Array<Buffer> as StructArrayTypeFields>::fields(),
-                // value.0.into_arrays(),
                 value.0.into(),
                 None,
             )

--- a/src/arrow/array/union.rs
+++ b/src/arrow/array/union.rs
@@ -1,0 +1,169 @@
+//! Interop with [`arrow-rs`] union arrays.
+
+use std::sync::Arc;
+
+use arrow_array::types::Int8Type;
+use arrow_schema::{DataType, Field, Fields};
+
+use crate::{
+    array::{
+        FixedSizePrimitiveArray, Int8Array, SparseLayout, SparseUnionArray, UnionArray,
+        UnionArrayType,
+    },
+    arrow::ArrowArray,
+    buffer::BufferType,
+    offset::OffsetElement,
+};
+
+/// Arrow schema interop trait for the variants of a union array type.
+pub trait UnionArrayTypeFields {
+    /// Returns the fields of the variants of this union array.
+    fn fields() -> Fields;
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+    > ArrowArray for UnionArray<T, VARIANTS, SparseLayout, Buffer, OffsetItem>
+where
+    for<'a> i8: From<&'a T>,
+    <T as UnionArrayType<VARIANTS>>::Array<Buffer, OffsetItem, SparseLayout>: UnionArrayTypeFields,
+{
+    // NOTE: we don't convert to `arrow_array::UnionArray` here to support
+    // writing these arrays to parquet files.
+    // TODO(mbrobbel): put this choice behind a feature flag.
+    type Array = arrow_array::StructArray;
+
+    fn as_field(name: &str) -> arrow_schema::Field {
+        Field::new(
+            name,
+            DataType::Struct(Fields::from(vec![
+                Field::new("types", DataType::Int8, false),
+                Field::new(
+                    "variants",
+                    DataType::Struct(<<T as UnionArrayType<VARIANTS>>::Array<
+                        Buffer,
+                        OffsetItem,
+                        SparseLayout,
+                    > as UnionArrayTypeFields>::fields()),
+                    false,
+                ),
+            ])),
+            false,
+        )
+    }
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+    > From<UnionArray<T, VARIANTS, SparseLayout, Buffer, OffsetItem>> for arrow_array::StructArray
+where
+    for<'a> i8: From<&'a T>,
+    <T as UnionArrayType<VARIANTS>>::Array<Buffer, OffsetItem, SparseLayout>:
+        UnionArrayTypeFields + Into<arrow_array::StructArray>,
+    arrow_array::PrimitiveArray<Int8Type>: From<FixedSizePrimitiveArray<i8, false, Buffer>>,
+{
+    fn from(value: UnionArray<T, VARIANTS, SparseLayout, Buffer, OffsetItem>) -> Self {
+        // Safety:
+        // - todo
+        unsafe {
+            arrow_array::StructArray::new_unchecked(
+                Fields::from(vec![
+                    Field::new("types", DataType::Int8, false),
+                    Field::new(
+                        "variants",
+                        DataType::Struct(<<T as UnionArrayType<VARIANTS>>::Array<
+                            Buffer,
+                            OffsetItem,
+                            SparseLayout,
+                        > as UnionArrayTypeFields>::fields(
+                        )),
+                        false,
+                    ),
+                ]),
+                vec![
+                    Arc::new(arrow_array::PrimitiveArray::from(value.0.types)),
+                    Arc::new(value.0.variants.into()),
+                ],
+                None,
+            )
+        }
+    }
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+    > From<Arc<dyn arrow_array::Array>>
+    for UnionArray<T, VARIANTS, SparseLayout, Buffer, OffsetItem>
+where
+    for<'a> i8: From<&'a T>,
+    Self: From<arrow_array::StructArray>,
+{
+    fn from(value: Arc<dyn arrow_array::Array>) -> Self {
+        Self::from(arrow_array::StructArray::from(value.to_data()))
+    }
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+    > From<arrow_array::StructArray> for UnionArray<T, VARIANTS, SparseLayout, Buffer, OffsetItem>
+where
+    for<'a> i8: From<&'a T>,
+    <T as UnionArrayType<VARIANTS>>::Array<Buffer, OffsetItem, SparseLayout>:
+        From<Arc<dyn arrow_array::Array>>,
+    Int8Array<false, Buffer>: From<Arc<dyn arrow_array::Array>>,
+{
+    fn from(value: arrow_array::StructArray) -> Self {
+        let (_fields, mut arrays, nulls_opt) = value.into_parts();
+        assert_eq!(arrays.len(), 2);
+        match nulls_opt {
+            Some(_) => panic!("expected array without a null buffer"),
+            None => UnionArray(SparseUnionArray {
+                variants: arrays.pop().expect("an array").into(),
+                types: arrays.pop().expect("an array").into(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "derive")]
+mod tests {
+    use super::*;
+    use crate::array::{DenseLayout, SparseLayout};
+    use crate::arrow::buffer_builder::ArrowBufferBuilder;
+    use arrow_array::Array;
+
+    #[derive(crate::ArrayType)]
+    enum FooBar {
+        Foo,
+        Bar(u8),
+        Baz { a: bool },
+    }
+
+    #[test]
+    fn from() {
+        let union_array = [
+            FooBar::Foo,
+            FooBar::Bar(123),
+            FooBar::Baz { a: true },
+            FooBar::Foo,
+        ]
+        .into_iter()
+        .collect::<UnionArray<FooBar, 3, SparseLayout, ArrowBufferBuilder>>();
+        let struct_array_arrow = arrow_array::StructArray::from(union_array);
+        assert_eq!(struct_array_arrow.len(), 4);
+        let _rb = arrow_array::RecordBatch::from(struct_array_arrow);
+    }
+}

--- a/src/arrow/mod.rs
+++ b/src/arrow/mod.rs
@@ -3,7 +3,7 @@
 //! [`arrow-rs`]: https://crates.io/crates/arrow
 
 mod array;
-pub use array::StructArrayTypeFields;
+pub use array::{StructArrayTypeFields, UnionArrayTypeFields};
 
 mod buffer;
 pub use buffer::*;


### PR DESCRIPTION
A very hacky solution to support writing `UnionArray`s to parquet files by implementing the `arrow-rs` interop to map to `arrow_array::StructArray`. 

It only works for `SparseLayout`, because I don't know if arrow and/or parquet support `StructArrays` with child arrays of different lengths. The union array is mapped to a struct array with two top level fields: `types` and `variants`, where `types` is the `Int8Array` and `variants` is a `StructArray` with the arrays of the different variants as fields.

Note that this is a temporary solution and I'll clean this up later.

Marking breaking change because this changes the default `UnionLayout` to `SparseLayout`. `StructArrayType`'s `ArrayType` needs generics associated types for `OffsetElement` and `UnionType`.