### PR TITLE
feat: add `chrono` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,9 +229,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -651,6 +651,7 @@ dependencies = [
  "arrow-cast",
  "arrow-schema",
  "bytes",
+ "chrono",
  "criterion",
  "narrow-derive",
  "parquet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ arrow-rs = [
     "dep:arrow-schema",
     "narrow-derive?/arrow-rs",
 ]
+chrono = ["dep:chrono"]
 derive = ["dep:narrow-derive"]
 uuid = ["dep:uuid"]
 
@@ -45,6 +46,7 @@ uuid = ["dep:uuid"]
 arrow-array = { version = "52", default-features = false, optional = true }
 arrow-buffer = { version = "52", default-features = false, optional = true }
 arrow-schema = { version = "52", default-features = false, optional = true }
+chrono = { version = "0.4.38", default-features = false, optional = true }
 narrow-derive = { path = "narrow-derive", version = "^0.6.7", optional = true }
 uuid = { version = "1.10.0", default-features = false, optional = true }
 
@@ -53,9 +55,10 @@ arrow-cast = { version = "52", default-features = false, features = [
     "prettyprint",
 ] }
 bytes = "1.7.1"
+chrono = { version = "0.4.38", default-features = false, features = ["now"] }
 criterion = { version = "0.5.1", default-features = false }
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
-rustversion = "1.0.17"
+rustversion = { version = "1.0.17", default-features = false }
 parquet = { version = "52", default-features = false, features = ["arrow"] }
 uuid = { version = "1.10.0", default-features = false }
 
@@ -69,7 +72,7 @@ harness = false
 
 [[example]]
 name = "parquet"
-required-features = ["arrow-rs", "derive", "uuid"]
+required-features = ["arrow-rs", "chrono", "derive", "uuid"]
 
 [[example]]
 name = "basic"

--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -1,3 +1,5 @@
+use chrono::{DateTime, NaiveTime, Utc};
+
 #[rustversion::attr(nightly, allow(non_local_definitions))]
 fn main() {
     use arrow_array::RecordBatch;
@@ -25,6 +27,8 @@ fn main() {
         g: [u8; 8],
         h: Uuid,
         i: VariableSizeBinary,
+        j: DateTime<Utc>,
+        k: NaiveTime,
     }
     let input = [
         Foo {
@@ -37,6 +41,8 @@ fn main() {
             g: [1, 2, 3, 4, 5, 6, 7, 8],
             h: Uuid::from_u128(1234),
             i: vec![1, 3, 3, 7].into(),
+            j: DateTime::UNIX_EPOCH,
+            k: NaiveTime::MIN,
         },
         Foo {
             a: 42,
@@ -48,6 +54,8 @@ fn main() {
             g: [9, 10, 11, 12, 13, 14, 15, 16],
             h: Uuid::from_u128(42),
             i: vec![4, 2].into(),
+            j: Utc::now(),
+            k: Utc::now().time(),
         },
     ];
 

--- a/src/logical/chrono.rs
+++ b/src/logical/chrono.rs
@@ -1,0 +1,149 @@
+use chrono::{DateTime, NaiveDateTime, NaiveTime, Timelike, Utc};
+
+use crate::{
+    array::{ArrayType, UnionType},
+    buffer::BufferType,
+    offset::OffsetElement,
+};
+
+use super::{LogicalArray, LogicalArrayType};
+
+impl ArrayType<DateTime<Utc>> for DateTime<Utc> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<DateTime<Utc>, false, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl ArrayType<DateTime<Utc>> for Option<DateTime<Utc>> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<DateTime<Utc>, true, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl LogicalArrayType<DateTime<Utc>> for DateTime<Utc> {
+    type ArrayType = i64;
+
+    fn from_array_type(item: Self::ArrayType) -> Self {
+        DateTime::from_timestamp_nanos(item)
+    }
+
+    fn into_array_type(self) -> Self::ArrayType {
+        self.timestamp_nanos_opt().expect("out of range")
+    }
+}
+
+/// An array for [`DateTime`] items.
+pub type DateTimeArray<const NULLABLE: bool = false, Buffer = crate::buffer::VecBuffer> =
+    LogicalArray<DateTime<Utc>, NULLABLE, Buffer, crate::offset::NA, crate::array::union::NA>;
+
+impl ArrayType<NaiveDateTime> for NaiveDateTime {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<NaiveDateTime, false, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl ArrayType<NaiveDateTime> for Option<NaiveDateTime> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<NaiveDateTime, true, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl LogicalArrayType<NaiveDateTime> for NaiveDateTime {
+    type ArrayType = i64;
+
+    fn from_array_type(item: Self::ArrayType) -> Self {
+        DateTime::from_timestamp_nanos(item).naive_utc()
+    }
+
+    fn into_array_type(self) -> Self::ArrayType {
+        self.and_utc().timestamp_nanos_opt().expect("out of range")
+    }
+}
+
+/// An array for [`NaiveDateTime`] items.
+pub type NaiveDateTimeArray<const NULLABLE: bool = false, Buffer = crate::buffer::VecBuffer> =
+    LogicalArray<NaiveDateTime, NULLABLE, Buffer, crate::offset::NA, crate::array::union::NA>;
+
+impl ArrayType<NaiveTime> for NaiveTime {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<NaiveTime, false, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl ArrayType<NaiveTime> for Option<NaiveTime> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        LogicalArray<NaiveTime, true, Buffer, OffsetItem, UnionLayout>;
+}
+
+/// The number of nano seconds in a second.
+const NANO_SECONDS: i64 = 1_000_000_000;
+
+impl LogicalArrayType<NaiveTime> for NaiveTime {
+    type ArrayType = i64;
+
+    fn from_array_type(item: Self::ArrayType) -> Self {
+        let (secs, nano) = (item.div_euclid(NANO_SECONDS), item.rem_euclid(NANO_SECONDS));
+        Self::from_num_seconds_from_midnight_opt(
+            u32::try_from(secs).expect("out of range"),
+            u32::try_from(nano).expect("out of range"),
+        )
+        .expect("out of range")
+    }
+
+    fn into_array_type(self) -> Self::ArrayType {
+        i64::from(self.num_seconds_from_midnight()) * NANO_SECONDS + i64::from(self.nanosecond())
+    }
+}
+
+/// An array for [`NaiveTime`] items.
+pub type NaiveTimeArray<const NULLABLE: bool = false, Buffer = crate::buffer::VecBuffer> =
+    LogicalArray<NaiveTime, NULLABLE, Buffer, crate::offset::NA, crate::array::union::NA>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Length;
+
+    #[test]
+    fn round_trip() {
+        for value in [
+            0,
+            1234,
+            1234 * NANO_SECONDS,
+            86_398 * NANO_SECONDS + 1_999_999_999,
+        ] {
+            assert_eq!(NaiveTime::from_array_type(value).into_array_type(), value);
+        }
+    }
+
+    #[test]
+    fn from_iter() {
+        let array = [DateTime::<Utc>::UNIX_EPOCH, DateTime::<Utc>::UNIX_EPOCH]
+            .into_iter()
+            .collect::<DateTimeArray>();
+        assert_eq!(array.len(), 2);
+        assert_eq!(array.0.len(), 2);
+
+        let array_nullable = [
+            Some(DateTime::<Utc>::UNIX_EPOCH),
+            None,
+            Some(DateTime::<Utc>::UNIX_EPOCH),
+        ]
+        .into_iter()
+        .collect::<DateTimeArray<true>>();
+        assert_eq!(array_nullable.len(), 3);
+        assert_eq!(array_nullable.0.len(), 3);
+    }
+
+    #[test]
+    fn into_iter() {
+        let input = [DateTime::<Utc>::UNIX_EPOCH, DateTime::<Utc>::UNIX_EPOCH];
+        let array = input.into_iter().collect::<DateTimeArray>();
+        let output = array.into_iter().collect::<Vec<_>>();
+        assert_eq!(input, output.as_slice());
+
+        let input_nullable = [
+            Some(DateTime::<Utc>::UNIX_EPOCH),
+            None,
+            Some(DateTime::<Utc>::UNIX_EPOCH),
+        ];
+        let array_nullable = input_nullable.into_iter().collect::<DateTimeArray<true>>();
+        let output_nullable = array_nullable.into_iter().collect::<Vec<_>>();
+        assert_eq!(input_nullable, output_nullable.as_slice());
+    }
+}

--- a/src/logical/mod.rs
+++ b/src/logical/mod.rs
@@ -14,6 +14,10 @@ use crate::{
 /// Uuid support via logical arrays.
 pub mod uuid;
 
+#[cfg(feature = "chrono")]
+/// Chrono support via logical arrays.
+pub mod chrono;
+
 /// Types that can be stored in Arrow arrays, but require mapping via
 /// [`LogicalArray`].
 ///


### PR DESCRIPTION
Add logical array support for `chrono` types: `DateTime<Utc>`, `NaiveDateTime` and `NaiveTime`.

This does not include generics to control the different logical types supported by Arrow, and it also doesn't map to parquet temportal logical types yet. This needs more work (see #183). 

Part of #165. 