### PR TITLE
feat!: add `FixedSizeBinaryArray` and use it for `Uuid`

### DIFF
--- a/src/array/fixed_size_binary.rs
+++ b/src/array/fixed_size_binary.rs
@@ -1,0 +1,249 @@
+//! Array with fixed-size binary values.
+
+use crate::{
+    bitmap::{Bitmap, BitmapRef, BitmapRefMut, ValidityBitmap},
+    buffer::{BufferType, VecBuffer},
+    validity::{Nullability, Validity},
+    Index, Length,
+};
+
+use super::{Array, FixedSizeListArray, FixedSizePrimitiveArray};
+
+/// Array with fixed-size binary elements.
+// to support `arrow-rs` interop we can't use
+// FixedSizePrimitiveArray<[u8; N], NULLABLE, Buffer>
+pub struct FixedSizeBinaryArray<
+    const N: usize,
+    const NULLABLE: bool = false,
+    Buffer: BufferType = VecBuffer,
+>(pub(crate) FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer>)
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>;
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType>
+    FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeBinaryArray<N, NULLABLE, Buffer>: Index + Length,
+{
+    /// Returns an iterator over items in this [`FixedSizeListArray`].
+    pub fn iter(&self) -> FixedSizeBinaryIter<'_, N, NULLABLE, Buffer> {
+        <&Self as IntoIterator>::into_iter(self)
+    }
+}
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> Array
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    [u8; N]: Nullability<NULLABLE>,
+{
+    type Item = <[u8; N] as Nullability<NULLABLE>>::Item;
+}
+
+impl<const N: usize, Buffer: BufferType> BitmapRef for FixedSizeBinaryArray<N, true, Buffer> {
+    type Buffer = Buffer;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Buffer> {
+        self.0.bitmap_ref()
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> BitmapRefMut for FixedSizeBinaryArray<N, true, Buffer> {
+    fn bitmap_ref_mut(&mut self) -> &mut Bitmap<Self::Buffer> {
+        self.0.bitmap_ref_mut()
+    }
+}
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> Default
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer>: Default,
+{
+    fn default() -> Self {
+        Self(FixedSizeListArray::default())
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> Extend<[u8; N]> for FixedSizeBinaryArray<N, false, Buffer>
+where
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>:
+        Extend<[u8; N]>,
+{
+    fn extend<I: IntoIterator<Item = [u8; N]>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> Extend<Option<[u8; N]>>
+    for FixedSizeBinaryArray<N, true, Buffer>
+where
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, true, Buffer>:
+        Extend<Option<[u8; N]>>,
+{
+    fn extend<I: IntoIterator<Item = Option<[u8; N]>>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> From<FixedSizeBinaryArray<N, false, Buffer>>
+    for FixedSizeBinaryArray<N, true, Buffer>
+where
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, true, Buffer>:
+        From<FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>>,
+{
+    fn from(value: FixedSizeBinaryArray<N, false, Buffer>) -> Self {
+        Self(value.0.into())
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> FromIterator<[u8; N]>
+    for FixedSizeBinaryArray<N, false, Buffer>
+where
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>:
+        FromIterator<[u8; N]>,
+{
+    fn from_iter<I: IntoIterator<Item = [u8; N]>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> FromIterator<Option<[u8; N]>>
+    for FixedSizeBinaryArray<N, true, Buffer>
+where
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, true, Buffer>:
+        FromIterator<Option<[u8; N]>>,
+{
+    fn from_iter<I: IntoIterator<Item = Option<[u8; N]>>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> Index
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer>: Index,
+{
+    type Item<'a> = <FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer> as Index>::Item<'a>
+    where
+        Self: 'a;
+
+    unsafe fn index_unchecked(&self, index: usize) -> Self::Item<'_> {
+        self.0.index_unchecked(index)
+    }
+}
+
+/// An iterator over fixed-size lists in a [`FixedSizeBinaryArray`].
+pub struct FixedSizeBinaryIter<'a, const N: usize, const NULLABLE: bool, Buffer: BufferType>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+{
+    /// Reference to the array.
+    array: &'a FixedSizeBinaryArray<N, NULLABLE, Buffer>,
+    /// Current index.
+    index: usize,
+}
+
+impl<'a, const N: usize, const NULLABLE: bool, Buffer: BufferType> Iterator
+    for FixedSizeBinaryIter<'a, N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeBinaryArray<N, NULLABLE, Buffer>: Length + Index,
+{
+    type Item = <FixedSizeBinaryArray<N, NULLABLE, Buffer> as Index>::Item<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.array
+            .index(self.index)
+            .into_iter()
+            .inspect(|_| {
+                self.index += 1;
+            })
+            .next()
+    }
+}
+
+impl<'a, const N: usize, const NULLABLE: bool, Buffer: BufferType> IntoIterator
+    for &'a FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeBinaryArray<N, NULLABLE, Buffer>: Index + Length,
+{
+    type Item = <FixedSizeBinaryArray<N, NULLABLE, Buffer> as Index>::Item<'a>;
+    type IntoIter = FixedSizeBinaryIter<'a, N, NULLABLE, Buffer>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        FixedSizeBinaryIter {
+            array: self,
+            index: 0,
+        }
+    }
+}
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> Length
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer>: Length,
+{
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> ValidityBitmap for FixedSizeBinaryArray<N, true, Buffer> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_iter() {
+        let input = [[1_u8, 2], [3, 4]];
+        let array = input.into_iter().collect::<FixedSizeBinaryArray<2>>();
+        assert_eq!(array.len(), 2);
+        assert_eq!(array.0 .0.len(), 4);
+
+        let input_nullable = [Some([1_u8, 2]), None];
+        let array_nullable = input_nullable
+            .into_iter()
+            .collect::<FixedSizeBinaryArray<2, true>>();
+        assert_eq!(array_nullable.len(), 2);
+        assert_eq!(array_nullable.0 .0.data.len(), 4);
+        assert_eq!(array_nullable.0 .0.validity.len(), 2);
+    }
+
+    #[test]
+    fn index() {
+        let input = [[1_u8, 2], [3, 4]];
+        let array = input.into_iter().collect::<FixedSizeBinaryArray<2>>();
+        assert_eq!(array.index(0), Some([&1, &2]));
+        assert_eq!(array.index(1), Some([&3, &4]));
+
+        let input_nullable = [Some([1_u8, 2]), None];
+        let array_nullable = input_nullable
+            .into_iter()
+            .collect::<FixedSizeBinaryArray<2, true>>();
+        assert_eq!(array_nullable.index(0), Some(Some([&1, &2])));
+        assert_eq!(array_nullable.index(1), Some(None));
+        assert_eq!(array_nullable.index(2), None);
+    }
+
+    #[test]
+    fn into_iter() {
+        let input = [[1_u8, 2], [3, 4]];
+        let array = input.into_iter().collect::<FixedSizeBinaryArray<2>>();
+        assert_eq!(array.into_iter().collect::<Vec<_>>(), [[&1, &2], [&3, &4]]);
+
+        let input_nullable = [Some([1_u8, 2]), None];
+        let array_nullable = input_nullable
+            .into_iter()
+            .collect::<FixedSizeBinaryArray<2, true>>();
+        assert_eq!(
+            array_nullable.into_iter().collect::<Vec<_>>(),
+            [Some([&1, &2]), None]
+        );
+    }
+}

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -9,6 +9,9 @@ use std::collections::VecDeque;
 mod boolean;
 pub use boolean::*;
 
+mod fixed_size_binary;
+pub use fixed_size_binary::*;
+
 mod fixed_size_list;
 pub use fixed_size_list::*;
 

--- a/src/arrow/array/fixed_size_binary.rs
+++ b/src/arrow/array/fixed_size_binary.rs
@@ -1,0 +1,216 @@
+//! Interop with `arrow-rs` fixed-sized binary array.
+
+use std::sync::Arc;
+
+use arrow_array::types::UInt8Type;
+use arrow_buffer::NullBuffer;
+use arrow_schema::{DataType, Field};
+
+use crate::{
+    array::{FixedSizeBinaryArray, FixedSizeListArray, FixedSizePrimitiveArray},
+    arrow::ArrowArray,
+    bitmap::Bitmap,
+    buffer::BufferType,
+    nullable::Nullable,
+    validity::{Nullability, Validity},
+};
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> ArrowArray
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    [u8; N]: Nullability<NULLABLE>,
+{
+    type Array = arrow_array::FixedSizeBinaryArray;
+
+    fn as_field(name: &str) -> Field {
+        // todo(mbrobbel): const_assert
+        assert!(N <= 0x7FFF_FFFF); // i32::MAX
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+        Field::new(name, DataType::FixedSizeBinary(N as i32), NULLABLE)
+    }
+}
+
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> From<Arc<dyn arrow_array::Array>>
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    Self: From<arrow_array::FixedSizeBinaryArray>,
+{
+    fn from(value: Arc<dyn arrow_array::Array>) -> Self {
+        Self::from(arrow_array::FixedSizeBinaryArray::from(value.to_data()))
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> From<FixedSizeBinaryArray<N, false, Buffer>>
+    for arrow_array::FixedSizeBinaryArray
+where
+    arrow_array::PrimitiveArray<UInt8Type>: From<FixedSizePrimitiveArray<u8, false, Buffer>>,
+{
+    fn from(value: FixedSizeBinaryArray<N, false, Buffer>) -> Self {
+        // todo(mbrobbel): const_assert
+        assert!(N <= 0x7FFF_FFFF); // i32::MAX
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+        arrow_array::FixedSizeBinaryArray::new(N as i32, value.0 .0.into(), None)
+    }
+}
+
+impl<const N: usize, Buffer: BufferType> From<FixedSizeBinaryArray<N, true, Buffer>>
+    for arrow_array::FixedSizeBinaryArray
+where
+    arrow_array::PrimitiveArray<UInt8Type>: From<FixedSizePrimitiveArray<u8, false, Buffer>>,
+    Bitmap<Buffer>: Into<NullBuffer>,
+{
+    fn from(value: FixedSizeBinaryArray<N, true, Buffer>) -> Self {
+        // todo(mbrobbel): const_assert
+        assert!(N <= 0x7FFF_FFFF); // i32::MAX
+        #[allow(
+            clippy::as_conversions,
+            clippy::cast_possible_truncation,
+            clippy::cast_possible_wrap
+        )]
+        arrow_array::FixedSizeBinaryArray::new(
+            N as i32,
+            value.0 .0.data.into(),
+            Some(value.0 .0.validity.into()),
+        )
+    }
+}
+
+/// Panics when there are nulls
+impl<const N: usize, Buffer: BufferType> From<arrow_array::FixedSizeBinaryArray>
+    for FixedSizeBinaryArray<N, false, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: From<arrow_buffer::ScalarBuffer<u8>>,
+{
+    fn from(value: arrow_array::FixedSizeBinaryArray) -> Self {
+        let (n, values, nulls_opt) = value.into_parts();
+        assert_eq!(N, n.try_into().expect("size to cast to usize"));
+        match nulls_opt {
+            Some(_) => panic!("expected array without a null buffer"),
+            None => FixedSizeBinaryArray(FixedSizeListArray(
+                arrow_buffer::ScalarBuffer::from(values).into(),
+            )),
+        }
+    }
+}
+
+/// Panics when there are no nulls
+impl<const N: usize, Buffer: BufferType> From<arrow_array::FixedSizeBinaryArray>
+    for FixedSizeBinaryArray<N, true, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: From<arrow_buffer::ScalarBuffer<u8>>,
+    Bitmap<Buffer>: From<NullBuffer>,
+{
+    fn from(value: arrow_array::FixedSizeBinaryArray) -> Self {
+        let (n, values, nulls_opt) = value.into_parts();
+        assert_eq!(N, n.try_into().expect("size to cast to usize"));
+        match nulls_opt {
+            Some(null_buffer) => FixedSizeBinaryArray(FixedSizeListArray(Nullable {
+                data: arrow_buffer::ScalarBuffer::from(values).into(),
+                validity: null_buffer.into(),
+            })),
+            None => panic!("expected array with a null buffer"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::arrow::scalar_buffer::ArrowScalarBuffer;
+
+    use super::*;
+
+    const INPUT: [[u8; 2]; 3] = [[1, 2], [3, 4], [5, 6]];
+    const INPUT_NULLABLE: [Option<[u8; 2]>; 3] = [Some([1, 2]), None, Some([5, 6])];
+
+    #[test]
+    fn from() {
+        let fixed_size_binary_array = INPUT.into_iter().collect::<FixedSizeBinaryArray<2>>();
+        assert_eq!(
+            arrow_array::FixedSizeBinaryArray::from(fixed_size_binary_array)
+                .iter()
+                .flatten()
+                .flatten()
+                .copied()
+                .collect::<Vec<_>>(),
+            INPUT.into_iter().flatten().collect::<Vec<_>>()
+        );
+
+        let fixed_size_binary_array_nullable = INPUT_NULLABLE
+            .into_iter()
+            .collect::<FixedSizeBinaryArray<2, true>>();
+        assert_eq!(
+            arrow_array::FixedSizeBinaryArray::from(fixed_size_binary_array_nullable)
+                .iter()
+                .flatten()
+                .flatten()
+                .copied()
+                .collect::<Vec<_>>(),
+            INPUT_NULLABLE
+                .into_iter()
+                .flatten()
+                .flatten()
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected array with a null buffer")]
+    fn into_nullable() {
+        let fixed_size_binary_array =
+            arrow_array::FixedSizeBinaryArray::try_from_iter(INPUT.into_iter()).expect("");
+        // TODO(mbrobbel): we need scalarbuffer here because arrow_array::
+        // FixedSizeBinary uses Buffer instead of ScalarBuffer.
+        let _ = FixedSizeBinaryArray::<2, true, ArrowScalarBuffer>::from(fixed_size_binary_array);
+    }
+
+    #[test]
+    #[should_panic(expected = "expected array without a null buffer")]
+    fn into_non_nullable() {
+        let fixed_size_binary_array_nullable =
+            arrow_array::FixedSizeBinaryArray::from(vec![None, Some([1_u8, 2, 3].as_slice())]);
+        // TODO(mbrobbel): we need scalarbuffer here because arrow_array::
+        // FixedSizeBinary uses Buffer instead of ScalarBuffer.
+        let _ = FixedSizeBinaryArray::<3, false, ArrowScalarBuffer>::from(
+            fixed_size_binary_array_nullable,
+        );
+    }
+
+    #[test]
+    fn into() {
+        let fixed_size_binary_array =
+            arrow_array::FixedSizeBinaryArray::try_from_iter(INPUT.into_iter()).expect("");
+        assert_eq!(
+            FixedSizeBinaryArray::<2, false, ArrowScalarBuffer>::from(fixed_size_binary_array)
+                .into_iter()
+                .flatten()
+                .copied()
+                .collect::<Vec<_>>(),
+            INPUT.into_iter().flatten().collect::<Vec<_>>()
+        );
+
+        let fixed_size_binary_array_nullable_input = INPUT_NULLABLE
+            .into_iter()
+            .collect::<FixedSizeBinaryArray<2, true>>();
+        let fixed_size_binary_array_nullable =
+            arrow_array::FixedSizeBinaryArray::from(fixed_size_binary_array_nullable_input);
+        assert_eq!(
+            FixedSizeBinaryArray::<2, true, ArrowScalarBuffer>::from(
+                fixed_size_binary_array_nullable
+            )
+            .into_iter()
+            .map(|item| item.map(|value| value.map(Clone::clone)))
+            .collect::<Vec<_>>(),
+            INPUT_NULLABLE
+        );
+    }
+}

--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -71,3 +71,25 @@ where
         value.0.into()
     }
 }
+
+impl<
+        T: LogicalArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>>
+    for arrow_array::FixedSizeBinaryArray
+where
+    <T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    arrow_array::FixedSizeBinaryArray:
+        From<
+            <<T as LogicalArrayType>::Array<Buffer, OffsetItem, UnionLayout> as Validity<
+                NULLABLE,
+            >>::Storage<Buffer>,
+        >,
+{
+    fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
+        value.0.into()
+    }
+}

--- a/src/arrow/array/mod.rs
+++ b/src/arrow/array/mod.rs
@@ -1,6 +1,7 @@
 //! Interop with [`arrow-array`].
 
 mod boolean;
+mod fixed_size_binary;
 mod fixed_size_list;
 mod fixed_size_primitive;
 mod string;

--- a/src/logical/uuid.rs
+++ b/src/logical/uuid.rs
@@ -1,7 +1,7 @@
 use uuid::Uuid;
 
 use crate::{
-    array::{Array, ArrayType, FixedSizeListArray, FixedSizePrimitiveArray, UnionType},
+    array::{Array, ArrayType, FixedSizeBinaryArray, UnionType},
     buffer::BufferType,
     offset::OffsetElement,
 };
@@ -20,7 +20,7 @@ impl ArrayType for Option<Uuid> {
 
 impl LogicalArrayType for Uuid {
     type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
-        FixedSizeListArray<16, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>;
+        FixedSizeBinaryArray<16, false, Buffer>;
 
     fn convert<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>(
         self,
@@ -31,7 +31,7 @@ impl LogicalArrayType for Uuid {
 
 impl LogicalArrayType for Option<Uuid> {
     type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
-        FixedSizeListArray<16, FixedSizePrimitiveArray<u8, false, Buffer>, true, Buffer>;
+        FixedSizeBinaryArray<16, true, Buffer>;
 
     fn convert<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>(
         self,
@@ -42,7 +42,7 @@ impl LogicalArrayType for Option<Uuid> {
 
 impl<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>
     From<LogicalArray<Uuid, false, Buffer, OffsetItem, UnionLayout>>
-    for FixedSizeListArray<16, FixedSizePrimitiveArray<u8, false, Buffer>, false, Buffer>
+    for FixedSizeBinaryArray<16, false, Buffer>
 {
     fn from(value: LogicalArray<Uuid, false, Buffer, OffsetItem, UnionLayout>) -> Self {
         value.0


### PR DESCRIPTION
Adds a `FixedSizeBinaryArray` and use it for the logical array support for `Uuid`, to match the recommendation from [Arrow](https://arrow.apache.org/docs/format/Columnar.html#extensibility).

It just wraps `FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer>`. We can't use `FixedSizePrimitiveArray<[u8; N], NULLABLE, Buffer>` because `FixedSize` is not implemented when the `arrow-rs` feature is enabled.

Closes #170.

The parquet example now outputs:
```console
From narrow StructArray to Arrow RecordBatch
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
| a  | b | c     | d            | e        | f          | g                               | h                                | i                                                                   |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
| 1  | 2 | true  | hello world! | [true, ] | {_0: true} | [1, 2, 3, 4, 5, 6, 7, 8]        | 000000000000000000000000000004d2 | {types: 1, variants: {0: , 1: {_0: true}, 2: {a: 0, b: 0, c: 0}}}   |
| 42 |   | false | narrow       |          | {_0: }     | [9, 10, 11, 12, 13, 14, 15, 16] | 0000000000000000000000000000002a | {types: 2, variants: {0: , 1: {_0: false}, 2: {a: 1, b: 2, c: 42}}} |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
From Arrow RecordBatch to Parquet and back to Arrow RecordBatch
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
| a  | b | c     | d            | e        | f          | g                               | h                                | i                                                                   |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
| 1  | 2 | true  | hello world! | [true, ] | {_0: true} | [1, 2, 3, 4, 5, 6, 7, 8]        | 000000000000000000000000000004d2 | {types: 1, variants: {0: , 1: {_0: true}, 2: {a: 0, b: 0, c: 0}}}   |
| 42 |   | false | narrow       |          | {_0: }     | [9, 10, 11, 12, 13, 14, 15, 16] | 0000000000000000000000000000002a | {types: 2, variants: {0: , 1: {_0: false}, 2: {a: 1, b: 2, c: 42}}} |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
From Arrow RecordBatch (via Parquet) to narrow StructArray and back to Arrow RecordBatch
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
| a  | b | c     | d            | e        | f          | g                               | h                                | i                                                                   |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
| 1  | 2 | true  | hello world! | [true, ] | {_0: true} | [1, 2, 3, 4, 5, 6, 7, 8]        | 000000000000000000000000000004d2 | {types: 1, variants: {0: , 1: {_0: true}, 2: {a: 0, b: 0, c: 0}}}   |
| 42 |   | false | narrow       |          | {_0: }     | [9, 10, 11, 12, 13, 14, 15, 16] | 0000000000000000000000000000002a | {types: 2, variants: {0: , 1: {_0: false}, 2: {a: 1, b: 2, c: 42}}} |
+----+---+-------+--------------+----------+------------+---------------------------------+----------------------------------+---------------------------------------------------------------------+
```