### PR TITLE
feat: implement `IntoIterator` for `StructArray`

### DIFF
--- a/narrow-derive/tests/expand/struct/named/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic.expanded.rs
@@ -118,3 +118,69 @@ where
         Self { a }
     }
 }
+struct FooArrayIter<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+>
+where
+    T: Copy,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    a: <<&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for FooArrayIter<'a, T, Buffer>
+where
+    T: Copy,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    type Item = Foo<'a, T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.a.next().map(|a| { Foo { a } })
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for FooArray<'a, T, Buffer>
+where
+    T: Copy,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    type Item = Foo<'a, T>;
+    type IntoIter = FooArrayIter<'a, T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter {
+            a: self.a.into_iter(),
+        }
+    }
+}

--- a/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
@@ -175,3 +175,142 @@ where
         Self { a, b, c }
     }
 }
+struct BarArrayIter<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <Option<
+        bool,
+    > as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<bool>>,
+    <Option<
+        T,
+    > as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<T>>,
+{
+    a: <<u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    b: <<Option<
+        bool,
+    > as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    c: <<Option<
+        T,
+    > as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+}
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for BarArrayIter<T, Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <Option<
+        bool,
+    > as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<bool>>,
+    <Option<
+        T,
+    > as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<T>>,
+{
+    type Item = Bar<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.a
+            .next()
+            .map(|a| {
+                Bar {
+                    a,
+                    b: self.b.next().unwrap(),
+                    c: self.c.next().unwrap(),
+                }
+            })
+    }
+}
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for BarArray<T, Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <Option<
+        bool,
+    > as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<bool>>,
+    <Option<
+        T,
+    > as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<T>>,
+{
+    type Item = Bar<T>;
+    type IntoIter = BarArrayIter<T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        BarArrayIter {
+            a: self.a.into_iter(),
+            b: self.b.into_iter(),
+            c: self.c.into_iter(),
+        }
+    }
+}

--- a/narrow-derive/tests/expand/struct/named/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/simple.expanded.rs
@@ -155,3 +155,128 @@ where
         Self { a, b, c }
     }
 }
+struct FooArrayIter<Buffer: narrow::buffer::BufferType>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <bool as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = bool>,
+    <Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType<
+        Vec<u8>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<Vec<u8>>>,
+{
+    a: <<u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    b: <<bool as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    c: <<Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType<
+        Vec<u8>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Iterator for FooArrayIter<Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <bool as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = bool>,
+    <Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType<
+        Vec<u8>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<Vec<u8>>>,
+{
+    type Item = Foo;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.a
+            .next()
+            .map(|a| {
+                Foo {
+                    a,
+                    b: self.b.next().unwrap(),
+                    c: self.c.next().unwrap(),
+                }
+            })
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <bool as narrow::array::ArrayType<
+        bool,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = bool>,
+    <Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType<
+        Vec<u8>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Option<Vec<u8>>>,
+{
+    type Item = Foo;
+    type IntoIter = FooArrayIter<Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter {
+            a: self.a.into_iter(),
+            b: self.b.into_iter(),
+            c: self.c.into_iter(),
+        }
+    }
+}

--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -50,3 +50,27 @@ impl<
         Self(iter.into_iter().collect())
     }
 }
+pub struct FooArrayIter<const N: usize, Buffer: narrow::buffer::BufferType>(
+    <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
+)
+where
+    narrow::array::NullArray<
+        Foo<N>,
+        false,
+        Buffer,
+    >: ::std::iter::IntoIterator<Item = Foo<N>>;
+impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::iter::Iterator
+for FooArrayIter<N, Buffer> {
+    type Item = Foo<N>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator
+for FooArray<N, Buffer> {
+    type Item = Foo<N>;
+    type IntoIter = FooArrayIter<N, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -50,3 +50,27 @@ impl<
         Self(iter.into_iter().collect())
     }
 }
+pub struct FooArrayIter<const N: usize, Buffer: narrow::buffer::BufferType>(
+    <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
+)
+where
+    narrow::array::NullArray<
+        Foo<N>,
+        false,
+        Buffer,
+    >: ::std::iter::IntoIterator<Item = Foo<N>>;
+impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::iter::Iterator
+for FooArrayIter<N, Buffer> {
+    type Item = Foo<N>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator
+for FooArray<N, Buffer> {
+    type Item = Foo<N>;
+    type IntoIter = FooArrayIter<N, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}

--- a/narrow-derive/tests/expand/struct/unit/self.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/self.expanded.rs
@@ -73,3 +73,28 @@ where
         Self(iter.into_iter().collect())
     }
 }
+struct FooArrayIter<Buffer: narrow::buffer::BufferType>(
+    <narrow::array::NullArray<Foo, false, Buffer> as IntoIterator>::IntoIter,
+)
+where
+    Self: Debug,
+    narrow::array::NullArray<Foo, false, Buffer>: ::std::iter::IntoIterator<Item = Foo>;
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Iterator for FooArrayIter<Buffer>
+where
+    Self: Debug,
+{
+    type Item = Foo;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator for FooArray<Buffer>
+where
+    Self: Debug,
+{
+    type Item = Foo;
+    type IntoIter = FooArrayIter<Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}

--- a/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
@@ -45,3 +45,21 @@ for FooArray<Buffer> {
         Self(iter.into_iter().collect())
     }
 }
+struct FooArrayIter<Buffer: narrow::buffer::BufferType>(
+    <narrow::array::NullArray<Foo, false, Buffer> as IntoIterator>::IntoIter,
+)
+where
+    narrow::array::NullArray<Foo, false, Buffer>: ::std::iter::IntoIterator<Item = Foo>;
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Iterator for FooArrayIter<Buffer> {
+    type Item = Foo;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator for FooArray<Buffer> {
+    type Item = Foo;
+    type IntoIter = FooArrayIter<Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -86,3 +86,37 @@ where
         Self(iter.into_iter().collect())
     }
 }
+pub(super) struct FooArrayIter<const N: bool, Buffer: narrow::buffer::BufferType>(
+    <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
+)
+where
+    Self: Sized,
+    (): From<Self>,
+    narrow::array::NullArray<
+        Foo<N>,
+        false,
+        Buffer,
+    >: ::std::iter::IntoIterator<Item = Foo<N>>;
+impl<const N: bool, Buffer: narrow::buffer::BufferType> ::std::iter::Iterator
+for FooArrayIter<N, Buffer>
+where
+    Self: Sized,
+    (): From<Self>,
+{
+    type Item = Foo<N>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next()
+    }
+}
+impl<const N: bool, Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator
+for FooArray<N, Buffer>
+where
+    Self: Sized,
+    (): From<Self>,
+{
+    type Item = Foo<N>;
+    type IntoIter = FooArrayIter<N, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
@@ -128,6 +128,72 @@ where
         Self(_0)
     }
 }
+struct FooArrayIter<
+    'a,
+    T: Add<Self> + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+>(
+    <<&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    Self: Sized,
+    <T as Add<Self>>::Output: Debug,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>;
+impl<
+    'a,
+    T: Add<Self> + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for FooArrayIter<'a, T, Buffer>
+where
+    Self: Sized,
+    <T as Add<Self>>::Output: Debug,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    type Item = Foo<'a, T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Foo(first) })
+    }
+}
+impl<
+    'a,
+    T: Add<Self> + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for FooArray<'a, T, Buffer>
+where
+    Self: Sized,
+    <T as Add<Self>>::Output: Debug,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    type Item = Foo<'a, T>;
+    type IntoIter = FooArrayIter<'a, T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}
 struct FooBar<T>(T);
 impl<T: narrow::array::ArrayType<T>> narrow::array::ArrayType<FooBar<T>> for FooBar<T> {
     type Array<
@@ -216,5 +282,62 @@ where
     fn from_iter<_I: ::std::iter::IntoIterator<Item = FooBar<T>>>(iter: _I) -> Self {
         let (_0, ()) = iter.into_iter().map(|FooBar(_0)| (_0, ())).unzip();
         Self(_0)
+    }
+}
+struct FooBarArrayIter<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+>(
+    <<T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>;
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for FooBarArrayIter<T, Buffer>
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+{
+    type Item = FooBar<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { FooBar(first) })
+    }
+}
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for FooBarArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+{
+    type Item = FooBar<T>;
+    type IntoIter = FooBarArrayIter<T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooBarArrayIter(self.0.into_iter())
     }
 }

--- a/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
@@ -95,3 +95,63 @@ where
         Self(_0)
     }
 }
+struct FooArrayIter<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+>(
+    <<&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>;
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for FooArrayIter<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    type Item = Foo<'a, T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Foo(first) })
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for FooArray<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a T>,
+{
+    type Item = Foo<'a, T>;
+    type IntoIter = FooArrayIter<'a, T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
@@ -170,3 +170,149 @@ where
         Self(_0, _1, _2, _3)
     }
 }
+struct BarArrayIter<Buffer: narrow::buffer::BufferType>(
+    <<u8 as narrow::array::ArrayType<
+        u8,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    <<u16 as narrow::array::ArrayType<
+        u16,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    <<u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    <<u64 as narrow::array::ArrayType<
+        u64,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <u8 as narrow::array::ArrayType<
+        u8,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u8>,
+    <u16 as narrow::array::ArrayType<
+        u16,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u16>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <u64 as narrow::array::ArrayType<
+        u64,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u64>;
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Iterator for BarArrayIter<Buffer>
+where
+    <u8 as narrow::array::ArrayType<
+        u8,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u8>,
+    <u16 as narrow::array::ArrayType<
+        u16,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u16>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <u64 as narrow::array::ArrayType<
+        u64,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u64>,
+{
+    type Item = Bar;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0
+            .next()
+            .map(|first| {
+                Bar(
+                    first,
+                    self.1.next().unwrap(),
+                    self.2.next().unwrap(),
+                    self.3.next().unwrap(),
+                )
+            })
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator for BarArray<Buffer>
+where
+    <u8 as narrow::array::ArrayType<
+        u8,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u8>,
+    <u16 as narrow::array::ArrayType<
+        u16,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u16>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+    <u64 as narrow::array::ArrayType<
+        u64,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u64>,
+{
+    type Item = Bar;
+    type IntoIter = BarArrayIter<Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        BarArrayIter(
+            self.0.into_iter(),
+            self.1.into_iter(),
+            self.2.into_iter(),
+            self.3.into_iter(),
+        )
+    }
+}

--- a/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
@@ -78,6 +78,54 @@ where
         Self(_0)
     }
 }
+struct FooArrayIter<Buffer: narrow::buffer::BufferType>(
+    <<u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>;
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Iterator for FooArrayIter<Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+{
+    type Item = Foo;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Foo(first) })
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+{
+    type Item = Foo;
+    type IntoIter = FooArrayIter<Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}
 struct Bar(Foo);
 impl narrow::array::ArrayType<Bar> for Bar {
     type Array<
@@ -156,5 +204,53 @@ where
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Bar>>(iter: _I) -> Self {
         let (_0, ()) = iter.into_iter().map(|Bar(_0)| (_0, ())).unzip();
         Self(_0)
+    }
+}
+struct BarArrayIter<Buffer: narrow::buffer::BufferType>(
+    <<Foo as narrow::array::ArrayType<
+        Foo,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <Foo as narrow::array::ArrayType<
+        Foo,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Foo>;
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::Iterator for BarArrayIter<Buffer>
+where
+    <Foo as narrow::array::ArrayType<
+        Foo,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Foo>,
+{
+    type Item = Bar;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Bar(first) })
+    }
+}
+impl<Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator for BarArray<Buffer>
+where
+    <Foo as narrow::array::ArrayType<
+        Foo,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Foo>,
+{
+    type Item = Bar;
+    type IntoIter = BarArrayIter<Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        BarArrayIter(self.0.into_iter())
     }
 }

--- a/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
@@ -107,6 +107,63 @@ where
         Self(_0)
     }
 }
+struct FooArrayIter<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>(
+    <<T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    T: Copy,
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>;
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for FooArrayIter<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+{
+    type Item = Foo<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Foo(first) })
+    }
+}
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for FooArray<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+{
+    type Item = Foo<T>;
+    type IntoIter = FooArrayIter<T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter())
+    }
+}
 struct Bar<'a, T>(&'a Foo<T>);
 impl<'a, T: narrow::array::ArrayType<T>> narrow::array::ArrayType<Bar<'a, T>>
 for Bar<'a, T> {
@@ -214,6 +271,74 @@ where
         Self(_0)
     }
 }
+struct BarArrayIter<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+>(
+    <<&'a Foo<
+        T,
+    > as narrow::array::ArrayType<
+        &'a Foo<T>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType<
+        &'a Foo<T>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a Foo<T>>;
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for BarArrayIter<'a, T, Buffer>
+where
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType<
+        &'a Foo<T>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a Foo<T>>,
+{
+    type Item = Bar<'a, T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Bar(first) })
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for BarArray<'a, T, Buffer>
+where
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType<
+        &'a Foo<T>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = &'a Foo<T>>,
+{
+    type Item = Bar<'a, T>;
+    type IntoIter = BarArrayIter<'a, T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        BarArrayIter(self.0.into_iter())
+    }
+}
 struct FooBar<'a>(Bar<'a, u32>);
 impl<'a> narrow::array::ArrayType<FooBar<'a>> for FooBar<'a> {
     type Array<
@@ -309,5 +434,67 @@ where
     fn from_iter<_I: ::std::iter::IntoIterator<Item = FooBar<'a>>>(iter: _I) -> Self {
         let (_0, ()) = iter.into_iter().map(|FooBar(_0)| (_0, ())).unzip();
         Self(_0)
+    }
+}
+struct FooBarArrayIter<'a, Buffer: narrow::buffer::BufferType>(
+    <<Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType<
+        Bar<'a, u32>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType<
+        Bar<'a, u32>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Bar<'a, u32>>;
+impl<'a, Buffer: narrow::buffer::BufferType> ::std::iter::Iterator
+for FooBarArrayIter<'a, Buffer>
+where
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType<
+        Bar<'a, u32>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Bar<'a, u32>>,
+{
+    type Item = FooBar<'a>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { FooBar(first) })
+    }
+}
+impl<'a, Buffer: narrow::buffer::BufferType> ::std::iter::IntoIterator
+for FooBarArray<'a, Buffer>
+where
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType<
+        Bar<'a, u32>,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = Bar<'a, u32>>,
+{
+    type Item = FooBar<'a>;
+    type IntoIter = FooBarArrayIter<'a, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooBarArrayIter(self.0.into_iter())
     }
 }

--- a/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
@@ -1,4 +1,4 @@
-struct Foo<T: Sized>(T);
+struct Foo<T: Sized>(T, u32);
 impl<T: Sized + narrow::array::ArrayType<T>> narrow::array::ArrayType<Foo<T>>
 for Foo<T> {
     type Array<
@@ -25,6 +25,9 @@ struct FooArray<
     <T as narrow::array::ArrayType<
         T,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
 impl<
     T: Sized + narrow::array::ArrayType<T>,
@@ -38,9 +41,16 @@ where
         narrow::offset::NA,
         narrow::array::union::NA,
     >: ::std::default::Default,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default,
 {
     fn default() -> Self {
-        Self(::std::default::Default::default())
+        Self(::std::default::Default::default(), ::std::default::Default::default())
     }
 }
 impl<
@@ -50,6 +60,9 @@ impl<
 where
     <T as narrow::array::ArrayType<
         T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: narrow::Length,
+    <u32 as narrow::array::ArrayType<
+        u32,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: narrow::Length,
 {
     fn len(&self) -> usize {
@@ -68,11 +81,19 @@ where
         narrow::offset::NA,
         narrow::array::union::NA,
     >: ::std::iter::Extend<T>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::Extend<u32>,
 {
     fn extend<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(&mut self, iter: _I) {
         iter.into_iter()
-            .for_each(|Foo(_0)| {
+            .for_each(|Foo(_0, _1)| {
                 self.0.extend(::std::iter::once(_0));
+                self.1.extend(::std::iter::once(_1));
             });
     }
 }
@@ -88,9 +109,101 @@ where
         narrow::offset::NA,
         narrow::array::union::NA,
     >: ::std::default::Default + ::std::iter::Extend<T>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::default::Default + ::std::iter::Extend<u32>,
 {
     fn from_iter<_I: ::std::iter::IntoIterator<Item = Foo<T>>>(iter: _I) -> Self {
-        let (_0, ()) = iter.into_iter().map(|Foo(_0)| (_0, ())).unzip();
-        Self(_0)
+        let (_0, (_1, ())) = iter.into_iter().map(|Foo(_0, _1)| (_0, (_1, ()))).unzip();
+        Self(_0, _1)
+    }
+}
+struct FooArrayIter<
+    T: Sized + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+>(
+    <<T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+    <<u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    > as ::std::iter::IntoIterator>::IntoIter,
+)
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>;
+impl<
+    T: Sized + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::Iterator for FooArrayIter<T, Buffer>
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+{
+    type Item = Foo<T>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|first| { Foo(first, self.1.next().unwrap()) })
+    }
+}
+impl<
+    T: Sized + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::iter::IntoIterator for FooArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = T>,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<
+        Buffer,
+        narrow::offset::NA,
+        narrow::array::union::NA,
+    >: ::std::iter::IntoIterator<Item = u32>,
+{
+    type Item = Foo<T>;
+    type IntoIter = FooArrayIter<T, Buffer>;
+    fn into_iter(self) -> Self::IntoIter {
+        FooArrayIter(self.0.into_iter(), self.1.into_iter())
     }
 }

--- a/narrow-derive/tests/expand/struct/unnamed/simple.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.rs
@@ -1,2 +1,2 @@
 #[derive(narrow_derive::ArrayType)]
-struct Foo<T: Sized>(T);
+struct Foo<T: Sized>(T, u32);

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -490,12 +490,16 @@ mod tests {
         assert_eq!(named_array.len(), named_input.len());
         let named_output = named_array.into_iter().collect::<Vec<_>>();
         assert_eq!(named_output, named_input);
-        // let named_input_nullable = named_input.map(Option::Some);
-        // let named_array_nullable = named_input_nullable
-        //     .into_iter()
-        //     .collect::<StructArray<Named, true>>();
-        // assert_eq!(named_array_nullable.len(), named_input_nullable.len());
-        // let named_output_nullable = named_array_nullable.into_iter().collect::<Vec<_>>();
-        // assert_eq!(named_output_nullable, named_input_nullable);
+        let named_input_nullable = named_input
+            .into_iter()
+            .map(Option::Some)
+            .collect::<Vec<_>>();
+        let named_array_nullable = named_input_nullable
+            .clone()
+            .into_iter()
+            .collect::<StructArray<Named, true>>();
+        assert_eq!(named_array_nullable.len(), named_input_nullable.len());
+        let named_output_nullable = named_array_nullable.into_iter().collect::<Vec<_>>();
+        assert_eq!(named_output_nullable, named_input_nullable);
     }
 }

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -439,12 +439,14 @@ mod tests {
         #[derive(crate::ArrayType, Copy, Clone, Debug, Default, PartialEq)]
         struct Unnamed(u8, Option<u16>, u32, u64);
 
-        #[derive(crate::ArrayType, Copy, Clone, Debug, Default, PartialEq)]
+        #[derive(crate::ArrayType, Clone, Debug, Default, PartialEq)]
         struct Named {
             a: u8,
             b: bool,
             c: Option<u16>,
             d: Option<bool>,
+            e: String,
+            f: Option<String>,
         }
 
         let unit_input = [Unit; 3];
@@ -478,17 +480,22 @@ mod tests {
             b: false,
             c: Some(3),
             d: Some(true),
-        }; 3];
-        let named_array = named_input.into_iter().collect::<StructArray<Named>>();
+            e: "hello".to_owned(),
+            f: None,
+        }];
+        let named_array = named_input
+            .clone()
+            .into_iter()
+            .collect::<StructArray<Named>>();
         assert_eq!(named_array.len(), named_input.len());
         let named_output = named_array.into_iter().collect::<Vec<_>>();
         assert_eq!(named_output, named_input);
-        let named_input_nullable = named_input.map(Option::Some);
-        let named_array_nullable = named_input_nullable
-            .into_iter()
-            .collect::<StructArray<Named, true>>();
-        assert_eq!(named_array_nullable.len(), named_input_nullable.len());
-        let named_output_nullable = named_array_nullable.into_iter().collect::<Vec<_>>();
-        assert_eq!(named_output_nullable, named_input_nullable);
+        // let named_input_nullable = named_input.map(Option::Some);
+        // let named_array_nullable = named_input_nullable
+        //     .into_iter()
+        //     .collect::<StructArray<Named, true>>();
+        // assert_eq!(named_array_nullable.len(), named_input_nullable.len());
+        // let named_output_nullable = named_array_nullable.into_iter().collect::<Vec<_>>();
+        // assert_eq!(named_output_nullable, named_input_nullable);
     }
 }

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -27,6 +27,17 @@ pub struct StructArray<
 where
     <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>;
 
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> StructArray<T, NULLABLE, Buffer>
+where
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    for<'a> &'a Self: IntoIterator,
+{
+    /// Returns an iterator over the items in this [`StructArray`].
+    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        self.into_iter()
+    }
+}
+
 impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Array
     for StructArray<T, NULLABLE, Buffer>
 where
@@ -84,6 +95,42 @@ where
 {
     fn extend<I: IntoIterator<Item = Option<U>>>(&mut self, iter: I) {
         self.0.extend(iter);
+    }
+}
+
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> IntoIterator
+    for StructArray<T, NULLABLE, Buffer>
+where
+    T: Nullability<NULLABLE>,
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>: IntoIterator,
+{
+    type Item = <<<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer> as
+        IntoIterator>::Item;
+    type IntoIter = <<<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer> as
+        IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> IntoIterator
+    for &'a StructArray<T, NULLABLE, Buffer>
+where
+    T: Nullability<NULLABLE>,
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    &'a <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>:
+        IntoIterator,
+{
+    type Item = <&'a <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer> as
+        IntoIterator>::Item;
+    type IntoIter = <&'a <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<
+        Buffer,
+    > as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 
@@ -381,5 +428,67 @@ mod tests {
         let mut foo_bar_nullable = StructArray::<FooBar, true>::default();
         foo_bar_nullable.extend(std::iter::once(Some(FooBar(None))));
         foo_bar_nullable.extend(std::iter::once(None));
+    }
+
+    #[cfg(feature = "derive")]
+    #[test]
+    fn into_iter() {
+        #[derive(crate::ArrayType, Copy, Clone, Debug, Default, PartialEq)]
+        struct Unit;
+
+        #[derive(crate::ArrayType, Copy, Clone, Debug, Default, PartialEq)]
+        struct Unnamed(u8, Option<u16>, u32, u64);
+
+        #[derive(crate::ArrayType, Copy, Clone, Debug, Default, PartialEq)]
+        struct Named {
+            a: u8,
+            b: bool,
+            c: Option<u16>,
+            d: Option<bool>,
+        }
+
+        let unit_input = [Unit; 3];
+        let unit_array = unit_input.into_iter().collect::<StructArray<Unit>>();
+        assert_eq!(unit_array.len(), unit_input.len());
+        let unit_output = unit_array.into_iter().collect::<Vec<_>>();
+        assert_eq!(unit_output, unit_input);
+        let unit_input_nullable = unit_input.map(Option::Some);
+        let unit_array_nullable = unit_input_nullable
+            .into_iter()
+            .collect::<StructArray<Unit, true>>();
+        assert_eq!(unit_array_nullable.len(), unit_input_nullable.len());
+        let unit_output_nullable = unit_array_nullable.into_iter().collect::<Vec<_>>();
+        assert_eq!(unit_output_nullable, unit_input_nullable);
+
+        let unnamed_input = [Unnamed(1, Some(2), 3, 4); 3];
+        let unnamed_array = unnamed_input.into_iter().collect::<StructArray<Unnamed>>();
+        assert_eq!(unnamed_array.len(), unnamed_input.len());
+        let unnamed_output = unnamed_array.into_iter().collect::<Vec<_>>();
+        assert_eq!(unnamed_output, unnamed_input);
+        let unnamed_input_nullable = unnamed_input.map(Option::Some);
+        let unnamed_array_nullable = unnamed_input_nullable
+            .into_iter()
+            .collect::<StructArray<Unnamed, true>>();
+        assert_eq!(unnamed_array_nullable.len(), unnamed_input_nullable.len());
+        let unnamed_output_nullable = unnamed_array_nullable.into_iter().collect::<Vec<_>>();
+        assert_eq!(unnamed_output_nullable, unnamed_input_nullable);
+
+        let named_input = [Named {
+            a: 1,
+            b: false,
+            c: Some(3),
+            d: Some(true),
+        }; 3];
+        let named_array = named_input.into_iter().collect::<StructArray<Named>>();
+        assert_eq!(named_array.len(), named_input.len());
+        let named_output = named_array.into_iter().collect::<Vec<_>>();
+        assert_eq!(named_output, named_input);
+        let named_input_nullable = named_input.map(Option::Some);
+        let named_array_nullable = named_input_nullable
+            .into_iter()
+            .collect::<StructArray<Named, true>>();
+        assert_eq!(named_array_nullable.len(), named_input_nullable.len());
+        let named_output_nullable = named_array_nullable.into_iter().collect::<Vec<_>>();
+        assert_eq!(named_output_nullable, named_input_nullable);
     }
 }

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -202,7 +202,7 @@ mod tests {
                 .flat_map(|dyn_array| {
                     let array: StringArray<false, i32, crate::arrow::buffer::ScalarBuffer> =
                         dyn_array.into();
-                    array.into_iter().map(ToOwned::to_owned).collect::<Vec<_>>()
+                    array.into_iter().collect::<Vec<_>>()
                 })
                 .collect::<Vec<_>>(),
             INPUT_NULLABLE


### PR DESCRIPTION
This is the first step to roundtrip `Vec<T>` -> `StructArray<T>` -> `Vec<T>` (`where T: StructArrayType`). This only works with fields that have array types that have `IntoIterator` implementations. Later I'll add support to iterate over items that reference data in the underlying arrays (e.g. getting a `&str` instead of `String` for a `String` field).