### PR TITLE
feat: Implement `IntoIterator` for `FixedSizeListArray`

### DIFF
--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -363,7 +363,7 @@ mod tests {
         assert_eq!(array.0.c.into_iter().collect::<Vec<_>>(), &[(), (), (), ()]);
         assert_eq!(
             array.0.d.into_iter().collect::<Vec<_>>(),
-            &[Some([&1, &2]), Some([&3, &4]), None, None]
+            &[Some([1, 2]), Some([3, 4]), None, None]
         );
         assert_eq!(
             array.0.e.into_iter().collect::<Vec<_>>(),

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -277,16 +277,20 @@ mod tests {
             .collect::<FixedSizeListArray<2, StringArray, true>>();
         let fixed_size_list_array_nullable =
             arrow_array::FixedSizeListArray::from(fixed_size_list_array_nullable_input);
+
+        let owned_input_nullable = INPUT_NULLABLE
+            .into_iter()
+            .map(|item| item.map(|[first, second]| [first.to_owned(), second.to_owned()]))
+            .collect::<Vec<_>>();
         assert_eq!(
             FixedSizeListArray::<
                 2,
                 StringArray<false, i32, crate::arrow::buffer::ScalarBuffer>,
                 true,
-                crate::arrow::buffer::ScalarBuffer,
             >::from(fixed_size_list_array_nullable)
             .into_iter()
             .collect::<Vec<_>>(),
-            INPUT_NULLABLE
+            owned_input_nullable
         );
     }
 }


### PR DESCRIPTION
Implements `IntoIterator` for `FixedSizeListArray` by introducing a `FixedSizeArrayChunk` struct that yields an iterator with items being (fixed size) arrays of the supplied iterator's items.