### PR TITLE
fix(derive): match field visibility in array struct definition

### DIFF
--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -22,7 +22,7 @@ impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;
 }
 pub struct FooArray<const N: usize, Buffer: narrow::buffer::BufferType>(
-    narrow::array::NullArray<Foo<N>, false, Buffer>,
+    pub narrow::array::NullArray<Foo<N>, false, Buffer>,
 );
 impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer> {
@@ -51,7 +51,7 @@ impl<
     }
 }
 pub struct FooArrayIter<const N: usize, Buffer: narrow::buffer::BufferType>(
-    <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
+    pub <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
 )
 where
     narrow::array::NullArray<

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -22,7 +22,7 @@ impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;
 }
 pub struct FooArray<const N: usize, Buffer: narrow::buffer::BufferType>(
-    narrow::array::NullArray<Foo<N>, false, Buffer>,
+    pub narrow::array::NullArray<Foo<N>, false, Buffer>,
 );
 impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer> {
@@ -51,7 +51,7 @@ impl<
     }
 }
 pub struct FooArrayIter<const N: usize, Buffer: narrow::buffer::BufferType>(
-    <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
+    pub <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
 )
 where
     narrow::array::NullArray<

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -41,7 +41,7 @@ where
     type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;
 }
 pub(super) struct FooArray<const N: bool, Buffer: narrow::buffer::BufferType>(
-    narrow::array::NullArray<Foo<N>, false, Buffer>,
+    pub(super) narrow::array::NullArray<Foo<N>, false, Buffer>,
 )
 where
     Foo<N>: Sized,
@@ -87,7 +87,11 @@ where
     }
 }
 pub(super) struct FooArrayIter<const N: bool, Buffer: narrow::buffer::BufferType>(
-    <narrow::array::NullArray<Foo<N>, false, Buffer> as IntoIterator>::IntoIter,
+    pub(super) <narrow::array::NullArray<
+        Foo<N>,
+        false,
+        Buffer,
+    > as IntoIterator>::IntoIter,
 )
 where
     Self: Sized,


### PR DESCRIPTION
Fields in the generated array struct definition copy the field visibility of the input struct.