### PR TITLE
fix: return `Large` variants of datatypes in `arrow::Array::as_field`

### DIFF
--- a/src/arrow/array/string.rs
+++ b/src/arrow/array/string.rs
@@ -8,10 +8,11 @@ use arrow_schema::{DataType, Field};
 
 use crate::{
     array::{FixedSizePrimitiveArray, StringArray, VariableSizeBinaryArray},
+    arrow::OffsetElement,
     bitmap::Bitmap,
     buffer::BufferType,
     nullable::Nullable,
-    offset::{Offset, OffsetElement},
+    offset::Offset,
     validity::{Nullability, Validity},
 };
 
@@ -24,7 +25,15 @@ where
     type Array = arrow_array::GenericStringArray<OffsetItem>;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(name, DataType::Utf8, NULLABLE)
+        Field::new(
+            name,
+            if OffsetItem::LARGE {
+                DataType::LargeUtf8
+            } else {
+                DataType::Utf8
+            },
+            NULLABLE,
+        )
     }
 }
 

--- a/src/arrow/array/variable_size_list.rs
+++ b/src/arrow/array/variable_size_list.rs
@@ -8,10 +8,11 @@ use arrow_schema::{DataType, Field};
 
 use crate::{
     array::{Array, VariableSizeListArray},
+    arrow::OffsetElement,
     bitmap::Bitmap,
     buffer::BufferType,
     nullable::Nullable,
-    offset::{Offset, OffsetElement},
+    offset::Offset,
     validity::{Nullability, Validity},
 };
 
@@ -30,7 +31,11 @@ where
     fn as_field(name: &str) -> arrow_schema::Field {
         Field::new(
             name,
-            DataType::List(Arc::new(T::as_field("item"))),
+            if OffsetItem::LARGE {
+                DataType::LargeList(Arc::new(T::as_field("item")))
+            } else {
+                DataType::List(Arc::new(T::as_field("item")))
+            },
             NULLABLE,
         )
     }

--- a/src/arrow/mod.rs
+++ b/src/arrow/mod.rs
@@ -17,3 +17,18 @@ pub trait Array: crate::array::Array + Sized {
     /// Returns the field of this array.
     fn as_field(name: &str) -> arrow_schema::Field;
 }
+
+/// Extension trait for [`OffsetElement`] for [`arrow-rs`] interop.
+pub trait OffsetElement: crate::offset::OffsetElement {
+    /// This constant is true when this offset maps to the large variant of a
+    /// datatype.
+    const LARGE: bool;
+}
+
+impl OffsetElement for i32 {
+    const LARGE: bool = false;
+}
+
+impl OffsetElement for i64 {
+    const LARGE: bool = true;
+}


### PR DESCRIPTION
Closes #189.