### PR TITLE
feat: Add support for variable size binary interop with arrow-rs

### DIFF
--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -3,7 +3,11 @@ fn main() {
     use arrow_array::RecordBatch;
     use arrow_cast::pretty;
     use bytes::Bytes;
-    use narrow::{array::StructArray, arrow::buffer::ScalarBuffer, ArrayType};
+    use narrow::{
+        array::{StructArray, VariableSizeBinary},
+        arrow::buffer::ScalarBuffer,
+        ArrayType,
+    };
     use parquet::arrow::{arrow_reader::ParquetRecordBatchReader, ArrowWriter};
     use uuid::Uuid;
 
@@ -20,6 +24,7 @@ fn main() {
         f: Bar,
         g: [u8; 8],
         h: Uuid,
+        i: VariableSizeBinary,
     }
     let input = [
         Foo {
@@ -31,6 +36,7 @@ fn main() {
             f: Bar(Some(true)),
             g: [1, 2, 3, 4, 5, 6, 7, 8],
             h: Uuid::from_u128(1234),
+            i: vec![1, 3, 3, 7].into(),
         },
         Foo {
             a: 42,
@@ -41,6 +47,7 @@ fn main() {
             f: Bar(None),
             g: [9, 10, 11, 12, 13, 14, 15, 16],
             h: Uuid::from_u128(42),
+            i: vec![4, 2].into(),
         },
     ];
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -3,6 +3,7 @@
 use crate::{
     buffer::BufferType,
     offset::{self, OffsetElement},
+    Length,
 };
 use std::{collections::VecDeque, marker::PhantomData};
 
@@ -160,6 +161,49 @@ impl<const N: usize> From<[u8; N]> for FixedSizeBinary<N> {
 impl<const N: usize> From<FixedSizeBinary<N>> for [u8; N] {
     fn from(value: FixedSizeBinary<N>) -> Self {
         value.0
+    }
+}
+
+/// An byte vector wrapper that maps to [`VariableSizeBinaryArray`] via its
+/// [`ArrayType`] implementation. Used for example to map `Vec<u8>` to
+/// a [`VariableSizeBinaryArray`] instead of a [`VariableSizeListArray`].
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct VariableSizeBinary(Vec<u8>);
+
+impl ArrayType<VariableSizeBinary> for VariableSizeBinary {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        VariableSizeBinaryArray<false, OffsetItem, Buffer>;
+}
+
+impl ArrayType<VariableSizeBinary> for Option<VariableSizeBinary> {
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        VariableSizeBinaryArray<true, OffsetItem, Buffer>;
+}
+
+impl From<Vec<u8>> for VariableSizeBinary {
+    fn from(value: Vec<u8>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<VariableSizeBinary> for Vec<u8> {
+    fn from(value: VariableSizeBinary) -> Self {
+        value.0
+    }
+}
+
+impl Length for VariableSizeBinary {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl IntoIterator for VariableSizeBinary {
+    type Item = u8;
+    type IntoIter = std::vec::IntoIter<u8>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
     }
 }
 

--- a/src/arrow/array/mod.rs
+++ b/src/arrow/array/mod.rs
@@ -11,4 +11,5 @@ mod logical;
 mod null;
 mod union;
 pub use union::UnionArrayTypeFields;
+mod variable_size_binary;
 mod variable_size_list;

--- a/src/arrow/array/variable_size_binary.rs
+++ b/src/arrow/array/variable_size_binary.rs
@@ -85,7 +85,7 @@ where
     fn from(value: VariableSizeBinaryArray<false, OffsetItem, Buffer>) -> Self {
         arrow_array::GenericBinaryArray::new(
             // Safety:
-            // - The narrow offfset buffer contains valid offset data
+            // - The narrow offset buffer contains valid offset data
             unsafe { OffsetBuffer::new_unchecked(value.0.offsets.into()) },
             value.0.data.into().into_inner(),
             None,
@@ -104,7 +104,7 @@ where
     fn from(value: VariableSizeBinaryArray<true, OffsetItem, Buffer>) -> Self {
         arrow_array::GenericBinaryArray::new(
             // Safety:
-            // - The narrow offfset buffer contains valid offset data
+            // - The narrow offset buffer contains valid offset data
             unsafe { OffsetBuffer::new_unchecked(value.0.offsets.data.into()) },
             value.0.data.into().into_inner(),
             Some(value.0.offsets.validity.into()),

--- a/src/arrow/array/variable_size_binary.rs
+++ b/src/arrow/array/variable_size_binary.rs
@@ -1,0 +1,232 @@
+//! Interop with [`arrow-rs`] binary array.
+
+use std::sync::Arc;
+
+use arrow_array::OffsetSizeTrait;
+use arrow_buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow_schema::{DataType, Field};
+
+use crate::{
+    array::{FixedSizePrimitiveArray, VariableSizeBinaryArray},
+    arrow::OffsetElement,
+    bitmap::Bitmap,
+    buffer::BufferType,
+    nullable::Nullable,
+    offset::Offset,
+    validity::{Nullability, Validity},
+};
+
+impl<const NULLABLE: bool, OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    crate::arrow::Array for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Vec<u8>: Nullability<NULLABLE>,
+{
+    type Array = arrow_array::GenericBinaryArray<OffsetItem>;
+
+    fn as_field(name: &str) -> arrow_schema::Field {
+        Field::new(
+            name,
+            if OffsetItem::LARGE {
+                DataType::LargeBinary
+            } else {
+                DataType::Binary
+            },
+            NULLABLE,
+        )
+    }
+}
+
+impl<const NULLABLE: bool, OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<Arc<dyn arrow_array::Array>> for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Self: From<arrow_array::GenericBinaryArray<OffsetItem>>,
+{
+    fn from(value: Arc<dyn arrow_array::Array>) -> Self {
+        Self::from(arrow_array::GenericBinaryArray::<OffsetItem>::from(
+            value.to_data(),
+        ))
+    }
+}
+
+impl<OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<VariableSizeBinaryArray<false, OffsetItem, Buffer>> for Arc<dyn arrow_array::Array>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Into<ScalarBuffer<OffsetItem>>,
+    FixedSizePrimitiveArray<u8, false, Buffer>: Into<arrow_buffer::ScalarBuffer<u8>>,
+{
+    fn from(value: VariableSizeBinaryArray<false, OffsetItem, Buffer>) -> Self {
+        let array: arrow_array::GenericBinaryArray<OffsetItem> = value.into();
+        Arc::new(array)
+    }
+}
+
+impl<OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<VariableSizeBinaryArray<true, OffsetItem, Buffer>> for Arc<dyn arrow_array::Array>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Into<ScalarBuffer<OffsetItem>>,
+    FixedSizePrimitiveArray<u8, false, Buffer>: Into<arrow_buffer::ScalarBuffer<u8>>,
+    Bitmap<Buffer>: Into<NullBuffer>,
+{
+    fn from(value: VariableSizeBinaryArray<true, OffsetItem, Buffer>) -> Self {
+        let array: arrow_array::GenericBinaryArray<OffsetItem> = value.into();
+        Arc::new(array)
+    }
+}
+
+impl<OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<VariableSizeBinaryArray<false, OffsetItem, Buffer>>
+    for arrow_array::GenericBinaryArray<OffsetItem>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Into<ScalarBuffer<OffsetItem>>,
+    FixedSizePrimitiveArray<u8, false, Buffer>: Into<arrow_buffer::ScalarBuffer<u8>>,
+{
+    fn from(value: VariableSizeBinaryArray<false, OffsetItem, Buffer>) -> Self {
+        arrow_array::GenericBinaryArray::new(
+            // Safety:
+            // - The narrow offfset buffer contains valid offset data
+            unsafe { OffsetBuffer::new_unchecked(value.0.offsets.into()) },
+            value.0.data.into().into_inner(),
+            None,
+        )
+    }
+}
+
+impl<OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<VariableSizeBinaryArray<true, OffsetItem, Buffer>>
+    for arrow_array::GenericBinaryArray<OffsetItem>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Into<ScalarBuffer<OffsetItem>>,
+    FixedSizePrimitiveArray<u8, false, Buffer>: Into<arrow_buffer::ScalarBuffer<u8>>,
+    Bitmap<Buffer>: Into<NullBuffer>,
+{
+    fn from(value: VariableSizeBinaryArray<true, OffsetItem, Buffer>) -> Self {
+        arrow_array::GenericBinaryArray::new(
+            // Safety:
+            // - The narrow offfset buffer contains valid offset data
+            unsafe { OffsetBuffer::new_unchecked(value.0.offsets.data.into()) },
+            value.0.data.into().into_inner(),
+            Some(value.0.offsets.validity.into()),
+        )
+    }
+}
+
+/// Panics when there are nulls
+impl<OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<arrow_array::GenericBinaryArray<OffsetItem>>
+    for VariableSizeBinaryArray<false, OffsetItem, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: From<ScalarBuffer<u8>>,
+    <Buffer as BufferType>::Buffer<OffsetItem>: From<ScalarBuffer<OffsetItem>>,
+{
+    fn from(value: arrow_array::GenericBinaryArray<OffsetItem>) -> Self {
+        let (offsets, values, nulls_opt) = value.into_parts();
+        match nulls_opt {
+            Some(_) => panic!("expected array without a null buffer"),
+            None => VariableSizeBinaryArray(Offset {
+                data: ScalarBuffer::from(values).into(),
+                offsets: offsets.into_inner().into(),
+            }),
+        }
+    }
+}
+
+/// Panics when there are no nulls
+impl<OffsetItem: OffsetElement + OffsetSizeTrait, Buffer: BufferType>
+    From<arrow_array::GenericBinaryArray<OffsetItem>>
+    for VariableSizeBinaryArray<true, OffsetItem, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: From<ScalarBuffer<u8>>,
+    <Buffer as BufferType>::Buffer<OffsetItem>: From<ScalarBuffer<OffsetItem>>,
+    Bitmap<Buffer>: From<NullBuffer>,
+{
+    fn from(value: arrow_array::GenericBinaryArray<OffsetItem>) -> Self {
+        let (offsets, values, nulls_opt) = value.into_parts();
+        match nulls_opt {
+            Some(null_buffer) => VariableSizeBinaryArray(Offset {
+                data: ScalarBuffer::from(values).into(),
+                offsets: Nullable {
+                    data: offsets.into_inner().into(),
+                    validity: null_buffer.into(),
+                },
+            }),
+            None => panic!("expected array with a null buffer"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::VariableSizeBinaryArray;
+
+    fn input() -> [Vec<u8>; 3] {
+        [vec![0, 1, 2], vec![3], vec![]]
+    }
+
+    fn input_nullable() -> [Option<Vec<u8>>; 3] {
+        [Some(vec![0, 1, 2]), Some(vec![3]), None]
+    }
+
+    #[test]
+    fn from() {
+        let vsb_array = input().into_iter().collect::<VariableSizeBinaryArray>();
+        assert_eq!(
+            arrow_array::BinaryArray::from(vsb_array)
+                .into_iter()
+                .flatten()
+                .collect::<Vec<_>>(),
+            input()
+        );
+
+        let vsb_array_nullable = input_nullable()
+            .into_iter()
+            .collect::<VariableSizeBinaryArray<true, i64>>();
+        assert_eq!(
+            arrow_array::GenericBinaryArray::<i64>::from(vsb_array_nullable)
+                .into_iter()
+                .map(|o| o.map(<[u8]>::to_vec))
+                .collect::<Vec<_>>(),
+            input_nullable()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "expected array with a null buffer")]
+    fn into_nullable() {
+        let vsb_array = input()
+            .into_iter()
+            .map(Option::Some)
+            .collect::<arrow_array::BinaryArray>();
+        let _: VariableSizeBinaryArray<true, i32, crate::arrow::buffer::ScalarBuffer> =
+            vsb_array.into();
+    }
+
+    #[test]
+    #[should_panic(expected = "expected array without a null buffer")]
+    fn into_non_nullable() {
+        let vsb_array_nullable = input_nullable()
+            .into_iter()
+            .collect::<arrow_array::BinaryArray>();
+        let _: VariableSizeBinaryArray<false, i32, crate::arrow::buffer::ScalarBuffer> =
+            vsb_array_nullable.into();
+    }
+
+    #[test]
+    fn into() {
+        let vsb_array = input()
+            .into_iter()
+            .map(Option::Some)
+            .collect::<arrow_array::BinaryArray>();
+        let _: VariableSizeBinaryArray<false, i32, crate::arrow::buffer::ScalarBuffer> =
+            vsb_array.into();
+        // todo(mbrobbel): intoiterator for Binaryarray
+
+        let vsb_array_nullable = input_nullable()
+            .into_iter()
+            .collect::<arrow_array::BinaryArray>();
+        let _: VariableSizeBinaryArray<true, i32, crate::arrow::buffer::ScalarBuffer> =
+            vsb_array_nullable.into();
+        // todo(mbrobbel): intoiterator for Binaryarray
+    }
+}

--- a/src/length.rs
+++ b/src/length.rs
@@ -94,3 +94,15 @@ impl<T: Length> Length for Option<T> {
         self.as_ref().map_or(0, Length::len)
     }
 }
+
+impl<T> Length for std::vec::IntoIter<T> {
+    fn len(&self) -> usize {
+        ExactSizeIterator::len(self)
+    }
+}
+
+impl<T> Length for std::slice::Iter<'_, T> {
+    fn len(&self) -> usize {
+        ExactSizeIterator::len(self)
+    }
+}

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -345,6 +345,21 @@ where
     }
 }
 
+impl<T, U: IntoIterator + Length, OffsetItem: OffsetElement, Buffer: BufferType>
+    FromIterator<std::option::IntoIter<U>> for Offset<T, true, OffsetItem, Buffer>
+where
+    Self: Default,
+    T: Extend<<U as IntoIterator>::Item>,
+    <<Buffer as BufferType>::Buffer<OffsetItem> as Validity<true>>::Storage<Buffer>:
+        Extend<(bool, OffsetItem)>,
+{
+    fn from_iter<I: IntoIterator<Item = std::option::IntoIter<U>>>(iter: I) -> Self {
+        let mut offset = Self::default();
+        offset.extend(iter.into_iter().map(|mut v| v.next()));
+        offset
+    }
+}
+
 /// An iterator over items in an offset.
 pub struct OffsetSlice<'a, T, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType>
 where


### PR DESCRIPTION
While converting between iterators over structs with a `Vec<u8>` field and a `VariableSizeBinaryArray` is already implemented, it doesn't work well yet for `Vec<Vec<u8>>` because it gets converted to a `ListArray` of `ListArrays` of `u8`'s. This introduces a wrapper type `VariableSizeBinary` around `Vec<u8>` to solve this problem.