### PR TITLE
fix: add `ArrayType` for `Vec<Option<T>>` and fix `Option<Vec<Option<T>>>` impl

### DIFF
--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -283,7 +283,19 @@ impl<T: ArrayType<T>> ArrayType<Vec<T>> for Option<Vec<T>> {
             Buffer,
         >;
 }
-impl<T: ArrayType<T>> ArrayType<Vec<Option<T>>> for Option<Vec<Option<T>>>
+impl<T> ArrayType<Vec<Option<T>>> for Vec<Option<T>>
+where
+    Option<T>: ArrayType<T>,
+{
+    type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+        VariableSizeListArray<
+            <Option<T> as ArrayType<T>>::Array<Buffer, offset::NA, union::NA>,
+            false,
+            OffsetItem,
+            Buffer,
+        >;
+}
+impl<T> ArrayType<Vec<Option<T>>> for Option<Vec<Option<T>>>
 where
     Option<T>: ArrayType<T>,
 {

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -502,4 +502,17 @@ mod tests {
         let named_output_nullable = named_array_nullable.into_iter().collect::<Vec<_>>();
         assert_eq!(named_output_nullable, named_input_nullable);
     }
+
+    #[cfg(feature = "derive")]
+    #[test]
+    fn nested_option_derived() {
+        #[derive(crate::ArrayType, Clone, Debug, PartialEq)]
+        struct Foo(Vec<Option<String>>);
+
+        let input = [Foo(vec![None]), Foo(vec![Some("hello".to_owned())])];
+        let array = input.clone().into_iter().collect::<StructArray<Foo>>();
+        assert_eq!(array.len(), 2);
+        let output = array.into_iter().collect::<Vec<_>>();
+        assert_eq!(input.as_slice(), output);
+    }
 }


### PR DESCRIPTION
This impl was missing and caused the added test to fail compilation. This also removes the wrong `T: ArrayType<T>` bound for the `ArrayType` impl of `Option<Vec<Option<T>>>`.

The `ArrayType` impls should now cover:
- `Vec<T>`: non-nullable variable size list array, with non-nullable list items
- `Option<Vec<T>>`: nullable variable size list array, with non-nullable list items
- `Vec<Option<T>>`: non-nullable variable size list array, with nullable list items
- `Option<Vec<Option<T>>>`: nullable variable size list array, with nullable list items
