### PR TITLE
ci: use `workflow_dispatch` instead of `push` to `main` for `release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
 
 jobs:
   changelog:


### PR DESCRIPTION
Instead of releasing on every `push` to `main`, releases are now triggered manually. This is not to reduce release cadence, but to prevent multiple bumps when merging multiple PRs at once.