### PR TITLE
feat: impl `Clone` for arrays

### DIFF
--- a/narrow-derive/tests/expand/enum/named/generic.expanded.rs
+++ b/narrow-derive/tests/expand/enum/named/generic.expanded.rs
@@ -83,6 +83,39 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooArray<T, Buffer, OffsetItem, UnionLayout>
+where
+    <<Foo<
+        T,
+    > as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <Foo<T> as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<Foo<
+        T,
+    > as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <Foo<T> as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<Foo<
+        T,
+    > as narrow::array::union::EnumVariant<
+        2,
+    >>::Data as narrow::array::ArrayType<
+        <Foo<T> as narrow::array::union::EnumVariant<2>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone())
+    }
+}
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooArray<T, Buffer, OffsetItem, UnionLayout>
 where
     <<Foo<

--- a/narrow-derive/tests/expand/enum/named/simple.expanded.rs
+++ b/narrow-derive/tests/expand/enum/named/simple.expanded.rs
@@ -109,6 +109,37 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooBarArray<Buffer, OffsetItem, UnionLayout>
+where
+    <<FooBar as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        2,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<2>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        3,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<3>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone(), self.3.clone())
+    }
+}
+impl<
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooBarArray<Buffer, OffsetItem, UnionLayout>
 where
     <<FooBar as narrow::array::union::EnumVariant<

--- a/narrow-derive/tests/expand/enum/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unit/const_generic.expanded.rs
@@ -48,6 +48,32 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooBarArray<X, Buffer, OffsetItem, UnionLayout>
+where
+    <<FooBar<
+        X,
+    > as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<X> as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar<
+        X,
+    > as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<X> as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+impl<
+    const X: bool,
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooBarArray<X, Buffer, OffsetItem, UnionLayout>
 where
     <<FooBar<

--- a/narrow-derive/tests/expand/enum/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unit/simple.expanded.rs
@@ -68,6 +68,37 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooBarArray<Buffer, OffsetItem, UnionLayout>
+where
+    <<FooBar as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        2,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<2>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        3,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<3>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone(), self.3.clone())
+    }
+}
+impl<
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooBarArray<Buffer, OffsetItem, UnionLayout>
 where
     <<FooBar as narrow::array::union::EnumVariant<

--- a/narrow-derive/tests/expand/enum/unnamed/generic.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unnamed/generic.expanded.rs
@@ -87,6 +87,39 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooBarArray<T, Buffer, OffsetItem, UnionLayout>
+where
+    <<FooBar<
+        T,
+    > as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<T> as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar<
+        T,
+    > as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<T> as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar<
+        T,
+    > as narrow::array::union::EnumVariant<
+        2,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<T> as narrow::array::union::EnumVariant<2>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone())
+    }
+}
+impl<
+    T: Default + narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooBarArray<T, Buffer, OffsetItem, UnionLayout>
 where
     <<FooBar<

--- a/narrow-derive/tests/expand/enum/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unnamed/simple.expanded.rs
@@ -61,6 +61,27 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooBarArray<Buffer, OffsetItem, UnionLayout>
+where
+    <<FooBar as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+impl<
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooBarArray<Buffer, OffsetItem, UnionLayout>
 where
     <<FooBar as narrow::array::union::EnumVariant<

--- a/narrow-derive/tests/expand/enum/unnamed/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/enum/unnamed/where_clause.expanded.rs
@@ -121,6 +121,41 @@ impl<
     Buffer: narrow::buffer::BufferType,
     OffsetItem: narrow::offset::OffsetElement,
     UnionLayout: narrow::array::UnionType,
+> ::std::clone::Clone for FooBarArray<T, Buffer, OffsetItem, UnionLayout>
+where
+    T: Default,
+    FooBar<T>: Clone,
+    <<FooBar<
+        T,
+    > as narrow::array::union::EnumVariant<
+        0,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<T> as narrow::array::union::EnumVariant<0>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar<
+        T,
+    > as narrow::array::union::EnumVariant<
+        1,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<T> as narrow::array::union::EnumVariant<1>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+    <<FooBar<
+        T,
+    > as narrow::array::union::EnumVariant<
+        2,
+    >>::Data as narrow::array::ArrayType<
+        <FooBar<T> as narrow::array::union::EnumVariant<2>>::Data,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone())
+    }
+}
+impl<
+    T: narrow::array::ArrayType,
+    Buffer: narrow::buffer::BufferType,
+    OffsetItem: narrow::offset::OffsetElement,
+    UnionLayout: narrow::array::UnionType,
 > ::std::default::Default for FooBarArray<T, Buffer, OffsetItem, UnionLayout>
 where
     T: Default,

--- a/narrow-derive/tests/expand/struct/named/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic.expanded.rs
@@ -44,6 +44,21 @@ impl<
     'a,
     T: narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for FooArray<'a, T, Buffer>
+where
+    T: Copy,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self { a: self.a.clone() }
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<'a, T, Buffer>
 where
     T: Copy,

--- a/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
@@ -39,6 +39,33 @@ struct BarArray<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferTy
 impl<
     T: narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for BarArray<T, Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <Option<
+        bool,
+    > as narrow::array::ArrayType<
+        bool,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <Option<
+        T,
+    > as narrow::array::ArrayType<
+        T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            a: self.a.clone(),
+            b: self.b.clone(),
+            c: self.c.clone(),
+        }
+    }
+}
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for BarArray<T, Buffer>
 where
     <u32 as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/named/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/simple.expanded.rs
@@ -33,6 +33,28 @@ struct FooArray<Buffer: narrow::buffer::BufferType> {
         Vec<u8>,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 }
+impl<Buffer: narrow::buffer::BufferType> ::std::clone::Clone for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <bool as narrow::array::ArrayType<
+        bool,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <Option<
+        Vec<u8>,
+    > as narrow::array::ArrayType<
+        Vec<u8>,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            a: self.a.clone(),
+            b: self.b.clone(),
+            c: self.c.clone(),
+        }
+    }
+}
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
 where
     <u32 as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -24,6 +24,12 @@ impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
 pub struct FooArray<const N: usize, Buffer: narrow::buffer::BufferType>(
     pub narrow::array::NullArray<Foo<N>, false, Buffer>,
 );
+impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::clone::Clone
+for FooArray<N, Buffer> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer> {
     fn default() -> Self {

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -24,6 +24,12 @@ impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
 pub struct FooArray<const N: usize, Buffer: narrow::buffer::BufferType>(
     pub narrow::array::NullArray<Foo<N>, false, Buffer>,
 );
+impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::clone::Clone
+for FooArray<N, Buffer> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<const N: usize, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer> {
     fn default() -> Self {

--- a/narrow-derive/tests/expand/struct/unit/self.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/self.expanded.rs
@@ -40,6 +40,14 @@ struct FooArray<Buffer: narrow::buffer::BufferType>(
 )
 where
     Foo: Debug;
+impl<Buffer: narrow::buffer::BufferType> ::std::clone::Clone for FooArray<Buffer>
+where
+    Foo: Debug,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
 where
     Foo: Debug,

--- a/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
@@ -24,6 +24,11 @@ impl narrow::array::StructArrayType for Foo {
 struct FooArray<Buffer: narrow::buffer::BufferType>(
     narrow::array::NullArray<Foo, false, Buffer>,
 );
+impl<Buffer: narrow::buffer::BufferType> ::std::clone::Clone for FooArray<Buffer> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer> {
     fn default() -> Self {
         Self(::std::default::Default::default())

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -46,6 +46,16 @@ pub(super) struct FooArray<const N: bool, Buffer: narrow::buffer::BufferType>(
 where
     Foo<N>: Sized,
     (): From<Foo<N>>;
+impl<const N: bool, Buffer: narrow::buffer::BufferType> ::std::clone::Clone
+for FooArray<N, Buffer>
+where
+    Foo<N>: Sized,
+    (): From<Foo<N>>,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<const N: bool, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooArray<N, Buffer>
 where

--- a/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
@@ -52,6 +52,22 @@ impl<
     'a,
     T: Add<Foo<'a, T>> + narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for FooArray<'a, T, Buffer>
+where
+    Foo<'a, T>: Sized,
+    <T as Add<Foo<'a, T>>>::Output: Debug,
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<
+    'a,
+    T: Add<Foo<'a, T>> + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<'a, T, Buffer>
 where
     Foo<'a, T>: Sized,
@@ -218,6 +234,19 @@ struct FooBarArray<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::Buffe
         T,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for FooBarArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<
     T: narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,

--- a/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
@@ -27,6 +27,20 @@ impl<
     'a,
     T: narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for FooArray<'a, T, Buffer>
+where
+    <&'a T as narrow::array::ArrayType<
+        &'a T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<'a, T, Buffer>
 where
     <&'a T as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
@@ -30,6 +30,25 @@ struct BarArray<Buffer: narrow::buffer::BufferType>(
         u64,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
+impl<Buffer: narrow::buffer::BufferType> ::std::clone::Clone for BarArray<Buffer>
+where
+    <u8 as narrow::array::ArrayType<
+        u8,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <u16 as narrow::array::ArrayType<
+        u16,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <u64 as narrow::array::ArrayType<
+        u64,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone(), self.2.clone(), self.3.clone())
+    }
+}
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for BarArray<Buffer>
 where
     <u8 as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
@@ -21,6 +21,16 @@ struct FooArray<Buffer: narrow::buffer::BufferType>(
         u32,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
+impl<Buffer: narrow::buffer::BufferType> ::std::clone::Clone for FooArray<Buffer>
+where
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for FooArray<Buffer>
 where
     <u32 as narrow::array::ArrayType<
@@ -149,6 +159,16 @@ struct BarArray<Buffer: narrow::buffer::BufferType>(
         Foo,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
+impl<Buffer: narrow::buffer::BufferType> ::std::clone::Clone for BarArray<Buffer>
+where
+    <Foo as narrow::array::ArrayType<
+        Foo,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<Buffer: narrow::buffer::BufferType> ::std::default::Default for BarArray<Buffer>
 where
     <Foo as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
@@ -40,6 +40,20 @@ where
 impl<
     T: narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for FooArray<T, Buffer>
+where
+    T: Copy,
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+impl<
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<T, Buffer>
 where
     T: Copy,
@@ -191,6 +205,22 @@ struct BarArray<'a, T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::Buff
         &'a Foo<T>,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
+impl<
+    'a,
+    T: narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for BarArray<'a, T, Buffer>
+where
+    <&'a Foo<
+        T,
+    > as narrow::array::ArrayType<
+        &'a Foo<T>,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<
     'a,
     T: narrow::array::ArrayType<T>,
@@ -365,6 +395,20 @@ struct FooBarArray<'a, Buffer: narrow::buffer::BufferType>(
         Bar<'a, u32>,
     >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>,
 );
+impl<'a, Buffer: narrow::buffer::BufferType> ::std::clone::Clone
+for FooBarArray<'a, Buffer>
+where
+    <Bar<
+        'a,
+        u32,
+    > as narrow::array::ArrayType<
+        Bar<'a, u32>,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
 impl<'a, Buffer: narrow::buffer::BufferType> ::std::default::Default
 for FooBarArray<'a, Buffer>
 where

--- a/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
@@ -32,6 +32,22 @@ struct FooArray<
 impl<
     T: Sized + narrow::array::ArrayType<T>,
     Buffer: narrow::buffer::BufferType,
+> ::std::clone::Clone for FooArray<T, Buffer>
+where
+    <T as narrow::array::ArrayType<
+        T,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+    <u32 as narrow::array::ArrayType<
+        u32,
+    >>::Array<Buffer, narrow::offset::NA, narrow::array::union::NA>: ::std::clone::Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone(), self.1.clone())
+    }
+}
+impl<
+    T: Sized + narrow::array::ArrayType<T>,
+    Buffer: narrow::buffer::BufferType,
 > ::std::default::Default for FooArray<T, Buffer>
 where
     <T as narrow::array::ArrayType<

--- a/src/array/fixed_size_binary.rs
+++ b/src/array/fixed_size_binary.rs
@@ -55,6 +55,17 @@ impl<const N: usize, Buffer: BufferType> BitmapRefMut for FixedSizeBinaryArray<N
     }
 }
 
+impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> Clone
+    for FixedSizeBinaryArray<N, NULLABLE, Buffer>
+where
+    FixedSizePrimitiveArray<u8, false, Buffer>: Validity<NULLABLE>,
+    FixedSizeListArray<N, FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<const N: usize, const NULLABLE: bool, Buffer: BufferType> Default
     for FixedSizeBinaryArray<N, NULLABLE, Buffer>
 where

--- a/src/array/fixed_size_list.rs
+++ b/src/array/fixed_size_list.rs
@@ -64,6 +64,17 @@ impl<const N: usize, T: Array, Buffer: BufferType> BitmapRefMut
     }
 }
 
+impl<const N: usize, T: Array, const NULLABLE: bool, Buffer: BufferType> Clone
+    for FixedSizeListArray<N, T, NULLABLE, Buffer>
+where
+    T: Validity<NULLABLE>,
+    <T as Validity<NULLABLE>>::Storage<Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<const N: usize, T: Array, const NULLABLE: bool, Buffer: BufferType> Default
     for FixedSizeListArray<N, T, NULLABLE, Buffer>
 where

--- a/src/array/fixed_size_primitive.rs
+++ b/src/array/fixed_size_primitive.rs
@@ -82,6 +82,17 @@ impl<T: FixedSize, Buffer: BufferType> AsRef<[T]> for FixedSizePrimitiveArray<T,
     }
 }
 
+impl<T: FixedSize, const NULLABLE: bool, Buffer: BufferType> Clone
+    for FixedSizePrimitiveArray<T, NULLABLE, Buffer>
+where
+    <Buffer as BufferType>::Buffer<T>: Validity<NULLABLE>,
+    <<Buffer as BufferType>::Buffer<T> as Validity<NULLABLE>>::Storage<Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T: FixedSize, const NULLABLE: bool, Buffer: BufferType> Debug
     for FixedSizePrimitiveArray<T, NULLABLE, Buffer>
 where

--- a/src/array/null.rs
+++ b/src/array/null.rs
@@ -52,6 +52,16 @@ where
     type Item = <T as Nullability<NULLABLE>>::Item;
 }
 
+impl<T: Unit, const NULLABLE: bool, Buffer: BufferType> Clone for NullArray<T, NULLABLE, Buffer>
+where
+    Nulls<T>: Validity<NULLABLE>,
+    <Nulls<T> as Validity<NULLABLE>>::Storage<Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T: Unit, const NULLABLE: bool, Buffer: BufferType> Default for NullArray<T, NULLABLE, Buffer>
 where
     Nulls<T>: Validity<NULLABLE>,

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -49,6 +49,17 @@ where
     type Item = <String as Nullability<NULLABLE>>::Item;
 }
 
+impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Clone
+    for StringArray<NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Default
     for StringArray<NULLABLE, OffsetItem, Buffer>
 where

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -47,6 +47,17 @@ where
     type Item = <T as Nullability<NULLABLE>>::Item;
 }
 
+impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Clone
+    for StructArray<T, NULLABLE, Buffer>
+where
+    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <<T as StructArrayType>::Array<Buffer> as Validity<NULLABLE>>::Storage<Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> Default
     for StructArray<T, NULLABLE, Buffer>
 where

--- a/src/array/union.rs
+++ b/src/array/union.rs
@@ -106,6 +106,22 @@ impl<
         UnionLayout: UnionType,
         Buffer: BufferType,
         OffsetItem: OffsetElement,
+    > Clone for UnionArray<T, VARIANTS, UnionLayout, Buffer, OffsetItem>
+where
+    for<'a> i8: From<&'a T>,
+    <UnionLayout as UnionType>::Array<T, VARIANTS, Buffer, OffsetItem>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        UnionLayout: UnionType,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
     > Default for UnionArray<T, VARIANTS, UnionLayout, Buffer, OffsetItem>
 where
     for<'a> i8: From<&'a T>,
@@ -180,6 +196,27 @@ pub struct DenseUnionArray<
     pub types: Int8Array<false, Buffer>,
     /// The offsets in the variant arrays
     pub offsets: Int32Array<false, Buffer>,
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+    > Clone for DenseUnionArray<T, VARIANTS, Buffer, OffsetItem>
+where
+    for<'a> i8: From<&'a T>,
+    <T as UnionArrayType<VARIANTS>>::Array<Buffer, OffsetItem, DenseLayout>: Clone,
+    Int8Array<false, Buffer>: Clone,
+    Int32Array<false, Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            variants: self.variants.clone(),
+            types: self.types.clone(),
+            offsets: self.offsets.clone(),
+        }
+    }
 }
 
 impl<
@@ -265,6 +302,25 @@ pub struct SparseUnionArray<
     pub variants: <T as UnionArrayType<VARIANTS>>::Array<Buffer, OffsetItem, SparseLayout>,
     /// The types field encodes the variants
     pub types: Int8Array<false, Buffer>,
+}
+
+impl<
+        T: UnionArrayType<VARIANTS>,
+        const VARIANTS: usize,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+    > Clone for SparseUnionArray<T, VARIANTS, Buffer, OffsetItem>
+where
+    for<'a> i8: From<&'a T>,
+    <T as UnionArrayType<VARIANTS>>::Array<Buffer, OffsetItem, SparseLayout>: Clone,
+    Int8Array<false, Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            variants: self.variants.clone(),
+            types: self.types.clone(),
+        }
+    }
 }
 
 impl<

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -35,6 +35,17 @@ where
     type Item = <Vec<u8> as Nullability<NULLABLE>>::Item;
 }
 
+impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Clone
+    for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Default
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where

--- a/src/array/variable_size_list.rs
+++ b/src/array/variable_size_list.rs
@@ -42,6 +42,17 @@ where
     }
 }
 
+impl<T: Array, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Clone
+    for VariableSizeListArray<T, NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Offset<T, NULLABLE, OffsetItem, Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
 impl<T: Array, const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Default
     for VariableSizeListArray<T, NULLABLE, OffsetItem, Buffer>
 where

--- a/src/logical/mod.rs
+++ b/src/logical/mod.rs
@@ -88,6 +88,27 @@ impl<
         Buffer: BufferType,
         OffsetItem: OffsetElement,
         UnionLayout: UnionType,
+    > Clone for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
+where
+    Option<T>: ArrayType<T>,
+    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
+    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
+        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
+    <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
+        <T as LogicalArrayType<T>>::ArrayType,
+    >>::Array<Buffer, OffsetItem, UnionLayout>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<
+        T: LogicalArrayType<T>,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
     > Default for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
 where
     Option<T>: ArrayType<T>,


### PR DESCRIPTION
This ends up cloning the underlying buffers, so depending on the `BufferType`'s `Clone` impl this may be a ref-count increase or a new allocation and copy.