### PR TITLE
feat!: make `StructArray` generic over child array `OffsetElement` and `UnionType`

### DIFF
--- a/narrow-derive/src/struct.rs
+++ b/narrow-derive/src/struct.rs
@@ -246,7 +246,7 @@ impl Struct<'_> {
         let array_struct_ident = self.array_struct_ident();
         let tokens = quote! {
             impl #impl_generics #narrow::array::StructArrayType for #ident #ty_generics #where_clause {
-                type Array<Buffer: #narrow::buffer::BufferType> = #array_struct_ident #array_ty_generics;
+                type Array<Buffer: #narrow::buffer::BufferType, OffsetItem: #narrow::offset::OffsetElement, UnionLayout: #narrow::array::r#union::UnionType> = #array_struct_ident #array_ty_generics;
             }
         };
         parse2(tokens).expect("struct_array_type_impl")

--- a/narrow-derive/tests/expand/struct/named/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic.expanded.rs
@@ -30,7 +30,11 @@ impl<'a, T: narrow::array::ArrayType<T>> narrow::array::StructArrayType for Foo<
 where
     T: Copy,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<'a, T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<'a, T, Buffer>;
 }
 struct FooArray<'a, T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>
 where

--- a/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/generic_option.expanded.rs
@@ -19,7 +19,11 @@ for ::std::option::Option<Bar<T>> {
     > = narrow::array::StructArray<Bar<T>, true, Buffer>;
 }
 impl<T: narrow::array::ArrayType<T>> narrow::array::StructArrayType for Bar<T> {
-    type Array<Buffer: narrow::buffer::BufferType> = BarArray<T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = BarArray<T, Buffer>;
 }
 struct BarArray<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType> {
     a: <u32 as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/named/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/named/simple.expanded.rs
@@ -18,7 +18,11 @@ impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
     > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<Buffer>;
 }
 struct FooArray<Buffer: narrow::buffer::BufferType> {
     a: <u32 as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic.expanded.rs
@@ -19,7 +19,11 @@ impl<const N: usize> narrow::array::ArrayType<Foo<N>> for ::std::option::Option<
     > = narrow::array::StructArray<Foo<N>, true, Buffer>;
 }
 impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<N, Buffer>;
 }
 pub struct FooArray<const N: usize, Buffer: narrow::buffer::BufferType>(
     pub narrow::array::NullArray<Foo<N>, false, Buffer>,

--- a/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/const_generic_default.expanded.rs
@@ -19,7 +19,11 @@ impl<const N: usize> narrow::array::ArrayType<Foo<N>> for ::std::option::Option<
     > = narrow::array::StructArray<Foo<N>, true, Buffer>;
 }
 impl<const N: usize> narrow::array::StructArrayType for Foo<N> {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<N, Buffer>;
 }
 pub struct FooArray<const N: usize, Buffer: narrow::buffer::BufferType>(
     pub narrow::array::NullArray<Foo<N>, false, Buffer>,

--- a/narrow-derive/tests/expand/struct/unit/self.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/self.expanded.rs
@@ -33,7 +33,11 @@ impl narrow::array::StructArrayType for Foo
 where
     Self: Debug,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<Buffer>;
 }
 struct FooArray<Buffer: narrow::buffer::BufferType>(
     narrow::array::NullArray<Foo, false, Buffer>,

--- a/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/simple.expanded.rs
@@ -19,7 +19,11 @@ impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
     > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<Buffer>;
 }
 struct FooArray<Buffer: narrow::buffer::BufferType>(
     narrow::array::NullArray<Foo, false, Buffer>,

--- a/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unit/where_clause.expanded.rs
@@ -38,7 +38,11 @@ where
     Self: Sized,
     (): From<Self>,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<N, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<N, Buffer>;
 }
 pub(super) struct FooArray<const N: bool, Buffer: narrow::buffer::BufferType>(
     pub(super) narrow::array::NullArray<Foo<N>, false, Buffer>,

--- a/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/generic.expanded.rs
@@ -34,7 +34,11 @@ where
     Self: Sized,
     <T as Add<Self>>::Output: Debug,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<'a, T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<'a, T, Buffer>;
 }
 struct FooArray<
     'a,
@@ -227,7 +231,11 @@ for ::std::option::Option<FooBar<T>> {
     > = narrow::array::StructArray<FooBar<T>, true, Buffer>;
 }
 impl<T: narrow::array::ArrayType<T>> narrow::array::StructArrayType for FooBar<T> {
-    type Array<Buffer: narrow::buffer::BufferType> = FooBarArray<T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooBarArray<T, Buffer>;
 }
 struct FooBarArray<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>(
     <T as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/lifetime.expanded.rs
@@ -16,7 +16,11 @@ for ::std::option::Option<Foo<'a, T>> {
     > = narrow::array::StructArray<Foo<'a, T>, true, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType<T>> narrow::array::StructArrayType for Foo<'a, T> {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<'a, T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<'a, T, Buffer>;
 }
 struct FooArray<'a, T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>(
     <&'a T as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/multiple.expanded.rs
@@ -14,7 +14,11 @@ impl narrow::array::ArrayType<Bar> for ::std::option::Option<Bar> {
     > = narrow::array::StructArray<Bar, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Bar {
-    type Array<Buffer: narrow::buffer::BufferType> = BarArray<Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = BarArray<Buffer>;
 }
 struct BarArray<Buffer: narrow::buffer::BufferType>(
     <u8 as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested.expanded.rs
@@ -14,7 +14,11 @@ impl narrow::array::ArrayType<Foo> for ::std::option::Option<Foo> {
     > = narrow::array::StructArray<Foo, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Foo {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<Buffer>;
 }
 struct FooArray<Buffer: narrow::buffer::BufferType>(
     <u32 as narrow::array::ArrayType<
@@ -152,7 +156,11 @@ impl narrow::array::ArrayType<Bar> for ::std::option::Option<Bar> {
     > = narrow::array::StructArray<Bar, true, Buffer>;
 }
 impl narrow::array::StructArrayType for Bar {
-    type Array<Buffer: narrow::buffer::BufferType> = BarArray<Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = BarArray<Buffer>;
 }
 struct BarArray<Buffer: narrow::buffer::BufferType>(
     <Foo as narrow::array::ArrayType<

--- a/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/nested_generic.expanded.rs
@@ -28,7 +28,11 @@ impl<T: narrow::array::ArrayType<T>> narrow::array::StructArrayType for Foo<T>
 where
     T: Copy,
 {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<T, Buffer>;
 }
 struct FooArray<T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>(
     <T as narrow::array::ArrayType<
@@ -196,7 +200,11 @@ for ::std::option::Option<Bar<'a, T>> {
     > = narrow::array::StructArray<Bar<'a, T>, true, Buffer>;
 }
 impl<'a, T: narrow::array::ArrayType<T>> narrow::array::StructArrayType for Bar<'a, T> {
-    type Array<Buffer: narrow::buffer::BufferType> = BarArray<'a, T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = BarArray<'a, T, Buffer>;
 }
 struct BarArray<'a, T: narrow::array::ArrayType<T>, Buffer: narrow::buffer::BufferType>(
     <&'a Foo<
@@ -385,7 +393,11 @@ impl<'a> narrow::array::ArrayType<FooBar<'a>> for ::std::option::Option<FooBar<'
     > = narrow::array::StructArray<FooBar<'a>, true, Buffer>;
 }
 impl<'a> narrow::array::StructArrayType for FooBar<'a> {
-    type Array<Buffer: narrow::buffer::BufferType> = FooBarArray<'a, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooBarArray<'a, Buffer>;
 }
 struct FooBarArray<'a, Buffer: narrow::buffer::BufferType>(
     <Bar<

--- a/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
+++ b/narrow-derive/tests/expand/struct/unnamed/simple.expanded.rs
@@ -16,7 +16,11 @@ for ::std::option::Option<Foo<T>> {
     > = narrow::array::StructArray<Foo<T>, true, Buffer>;
 }
 impl<T: Sized + narrow::array::ArrayType<T>> narrow::array::StructArrayType for Foo<T> {
-    type Array<Buffer: narrow::buffer::BufferType> = FooArray<T, Buffer>;
+    type Array<
+        Buffer: narrow::buffer::BufferType,
+        OffsetItem: narrow::offset::OffsetElement,
+        UnionLayout: narrow::array::union::UnionType,
+    > = FooArray<T, Buffer>;
 }
 struct FooArray<
     T: Sized + narrow::array::ArrayType<T>,

--- a/src/arrow/array/struct.rs
+++ b/src/arrow/array/struct.rs
@@ -6,10 +6,11 @@ use arrow_buffer::NullBuffer;
 use arrow_schema::{DataType, Field, Fields};
 
 use crate::{
-    array::{StructArray, StructArrayType},
+    array::{StructArray, StructArrayType, UnionType},
     bitmap::Bitmap,
     buffer::BufferType,
     nullable::Nullable,
+    offset::OffsetElement,
     validity::{Nullability, Validity},
     Length,
 };
@@ -20,10 +21,16 @@ pub trait StructArrayTypeFields {
     fn fields() -> Fields;
 }
 
-impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> crate::arrow::Array
-    for StructArray<T, NULLABLE, Buffer>
+impl<
+        T: StructArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > crate::arrow::Array for StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
 where
-    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE> + StructArrayTypeFields,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>:
+        Validity<NULLABLE> + StructArrayTypeFields,
     T: Nullability<NULLABLE>,
 {
     type Array = arrow_array::StructArray;
@@ -31,18 +38,26 @@ where
     fn as_field(name: &str) -> arrow_schema::Field {
         Field::new(
             name,
-            DataType::Struct(
-                <<T as StructArrayType>::Array<Buffer> as StructArrayTypeFields>::fields(),
-            ),
+            DataType::Struct(<<T as StructArrayType>::Array<
+                Buffer,
+                OffsetItem,
+                UnionLayout,
+            > as StructArrayTypeFields>::fields()),
             NULLABLE,
         )
     }
 }
 
-impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> From<Arc<dyn arrow_array::Array>>
-    for StructArray<T, NULLABLE, Buffer>
+impl<
+        T: StructArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<Arc<dyn arrow_array::Array>>
+    for StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
 where
-    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
     Self: From<arrow_array::StructArray>,
 {
     fn from(value: Arc<dyn arrow_array::Array>) -> Self {
@@ -50,29 +65,35 @@ where
     }
 }
 
-impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType>
-    From<StructArray<T, NULLABLE, Buffer>> for Arc<dyn arrow_array::Array>
+impl<
+        T: StructArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>>
+    for Arc<dyn arrow_array::Array>
 where
-    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
-    arrow_array::StructArray: From<StructArray<T, NULLABLE, Buffer>>,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    arrow_array::StructArray: From<StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>>,
 {
-    fn from(value: StructArray<T, NULLABLE, Buffer>) -> Self {
+    fn from(value: StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         Arc::new(arrow_array::StructArray::from(value))
     }
 }
 
-impl<T: StructArrayType, Buffer: BufferType> From<StructArray<T, false, Buffer>>
-    for arrow_array::StructArray
+impl<T: StructArrayType, Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>
+    From<StructArray<T, false, Buffer, OffsetItem, UnionLayout>> for arrow_array::StructArray
 where
-    <T as StructArrayType>::Array<Buffer>:
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>:
         StructArrayTypeFields + Into<Vec<Arc<dyn arrow_array::Array>>>,
 {
-    fn from(value: StructArray<T, false, Buffer>) -> Self {
+    fn from(value: StructArray<T, false, Buffer, OffsetItem, UnionLayout>) -> Self {
         // Safety:
         // - struct arrays are valid by construction
         unsafe {
             arrow_array::StructArray::new_unchecked(
-                <<T as StructArrayType>::Array<Buffer> as StructArrayTypeFields>::fields(),
+                <<T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout> as StructArrayTypeFields>::fields(),
                 value.0.into(),
                 None,
             )
@@ -80,19 +101,19 @@ where
     }
 }
 
-impl<T: StructArrayType, Buffer: BufferType> From<StructArray<T, true, Buffer>>
-    for arrow_array::StructArray
+impl<T: StructArrayType, Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>
+    From<StructArray<T, true, Buffer, OffsetItem, UnionLayout>> for arrow_array::StructArray
 where
-    <T as StructArrayType>::Array<Buffer>:
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>:
         StructArrayTypeFields + Into<Vec<Arc<dyn arrow_array::Array>>>,
     Bitmap<Buffer>: Into<NullBuffer>,
 {
-    fn from(value: StructArray<T, true, Buffer>) -> Self {
+    fn from(value: StructArray<T, true, Buffer, OffsetItem, UnionLayout>) -> Self {
         // Safety:
         // - struct arrays are valid by construction
         unsafe {
             arrow_array::StructArray::new_unchecked(
-                <<T as StructArrayType>::Array<Buffer> as StructArrayTypeFields>::fields(),
+                <<T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout> as StructArrayTypeFields>::fields(),
                 value.0.data.into(),
                 Some(value.0.validity.into()),
             )
@@ -101,10 +122,11 @@ where
 }
 
 /// Panics when there are nulls
-impl<T: StructArrayType, Buffer: BufferType> From<arrow_array::StructArray>
-    for StructArray<T, false, Buffer>
+impl<T: StructArrayType, Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>
+    From<arrow_array::StructArray> for StructArray<T, false, Buffer, OffsetItem, UnionLayout>
 where
-    <T as StructArrayType>::Array<Buffer>: From<Vec<Arc<dyn arrow_array::Array>>>,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>:
+        From<Vec<Arc<dyn arrow_array::Array>>>,
 {
     fn from(value: arrow_array::StructArray) -> Self {
         let (_fields, arrays, nulls_opt) = value.into_parts();
@@ -115,10 +137,11 @@ where
     }
 }
 
-impl<T: StructArrayType, Buffer: BufferType> From<arrow_array::StructArray>
-    for StructArray<T, true, Buffer>
+impl<T: StructArrayType, Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType>
+    From<arrow_array::StructArray> for StructArray<T, true, Buffer, OffsetItem, UnionLayout>
 where
-    <T as StructArrayType>::Array<Buffer>: From<Vec<Arc<dyn arrow_array::Array>>> + Length,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>:
+        From<Vec<Arc<dyn arrow_array::Array>>> + Length,
     Bitmap<Buffer>: From<NullBuffer> + FromIterator<bool>,
 {
     fn from(value: arrow_array::StructArray) -> Self {
@@ -129,26 +152,36 @@ where
                 data,
                 validity: null_buffer.into(),
             }),
-            None => StructArray::<T, false, Buffer>(data).into(),
+            None => StructArray::<T, false, Buffer, OffsetItem, UnionLayout>(data).into(),
         }
     }
 }
 
-impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType>
-    From<StructArray<T, NULLABLE, Buffer>> for arrow_array::RecordBatch
+impl<
+        T: StructArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>> for arrow_array::RecordBatch
 where
-    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
-    arrow_array::StructArray: From<StructArray<T, NULLABLE, Buffer>>,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
+    arrow_array::StructArray: From<StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>>,
 {
-    fn from(value: StructArray<T, NULLABLE, Buffer>) -> Self {
+    fn from(value: StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         Self::from(arrow_array::StructArray::from(value))
     }
 }
 
-impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> From<arrow_array::RecordBatch>
-    for StructArray<T, NULLABLE, Buffer>
+impl<
+        T: StructArrayType,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+    > From<arrow_array::RecordBatch> for StructArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
 where
-    <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
+    <T as StructArrayType>::Array<Buffer, OffsetItem, UnionLayout>: Validity<NULLABLE>,
     Self: From<arrow_array::StructArray>,
 {
     fn from(value: arrow_array::RecordBatch) -> Self {
@@ -250,7 +283,8 @@ mod tests {
         }
     }
     impl StructArrayType for Foo {
-        type Array<Buffer: BufferType> = FooArray<Buffer>;
+        type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
+            FooArray<Buffer>;
     }
     impl<Buffer: BufferType> StructArrayTypeFields for FooArray<Buffer> {
         fn fields() -> Fields {


### PR DESCRIPTION
This still needs to be propagated via the (derive) generated wrapper structs generics. Also note that this doesn't enable per field modifications, that would require field attribute support in the derive macro (that would then remove the generics from the fields that don't want to propagate these generics).