### PR TITLE
feat: Add function to StructArray that returns the Arrow schema

### DIFF
--- a/src/arrow/array/struct.rs
+++ b/src/arrow/array/struct.rs
@@ -160,7 +160,8 @@ impl<T: StructArrayType, const NULLABLE: bool, Buffer: BufferType> StructArray<T
 where
     <T as StructArrayType>::Array<Buffer>: Validity<NULLABLE>,
 {
-    /// Return the Arrow schema using the fields of this StructArray.
+    /// Return the Arrow schema using the fields of this `StructArray`.
+    #[must_use]
     pub fn schema() -> Arc<arrow_schema::Schema>
     where
         T: StructArrayType,
@@ -169,7 +170,8 @@ where
         Vec<Arc<(dyn arrow_array::Array + 'static)>>:
             From<<T as StructArrayType>::Array<VecBuffer>>,
     {
-        let dummy_array = ([] as [T; 0]).into_iter().collect::<StructArray<T>>();
+        let dummy_slice: [T; 0] = [];
+        let dummy_array = dummy_slice.into_iter().collect::<StructArray<T>>();
         let dummy_batch = arrow_array::RecordBatch::from(dummy_array);
         dummy_batch.schema()
     }
@@ -431,11 +433,11 @@ mod tests {
         assert_eq!(fields.len(), 2);
 
         assert_eq!(fields[0].name(), "a");
-        assert_eq!(fields[0].is_nullable(), false);
+        assert!(!fields[0].is_nullable());
         assert_eq!(*fields[0].data_type(), arrow_schema::DataType::UInt8);
 
         assert_eq!(fields[1].name(), "b");
-        assert_eq!(fields[1].is_nullable(), true);
+        assert!(fields[1].is_nullable());
         assert_eq!(
             *fields[1].data_type(),
             arrow_schema::DataType::List(Arc::new(Field::new(

--- a/tests/derive.rs
+++ b/tests/derive.rs
@@ -165,10 +165,7 @@ mod tests {
                     assert_eq!(array.len(), 2);
                     assert_eq!(array.0 .0 .0, &[1, 3]);
                     assert_eq!(array.0 .1 .0, &[2, 4]);
-                    assert_eq!(
-                        array.0 .2 .0 .0.data.0.as_slice(),
-                        &[b'a', b's', b'd', b'f']
-                    );
+                    assert_eq!(array.0 .2 .0 .0.data.0.as_slice(), b"asdf");
                     assert_eq!(array.0 .2 .0 .0.offsets.as_slice(), &[0, 2, 4]);
 
                     let input = [
@@ -257,7 +254,7 @@ mod tests {
 
                 #[derive(ArrayType, Default)]
                 struct FooBar {
-                    foo: bool,
+                    fuu: bool,
                     bar: Bar,
                 }
 


### PR DESCRIPTION
This PR adds the `schema()` function to `StructArray` that provides the means to obtain an `arrow_schema::Schema`. This is useful if you want to compare e.g. the schema of some Arrow `RecordBatch` before wrapping it as a Narrow `StructArray`.

This can be implemented in a more elegant way, which would prevent the allocations of buffers, but this works fine for now.

Also closes #187 well enough (for me).