### PR TITLE
feat!: add `IntoIterator` for `VariableSizeBinaryArray`

### DIFF
--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -53,7 +53,7 @@ fn main() {
                 vec![1, 2, 3, 4, 42],
             )])),
             m: NaiveDate::MAX,
-            n: TimeDelta::max_value(),
+            n: TimeDelta::seconds(12345),
         },
         Foo {
             a: 42,
@@ -69,7 +69,7 @@ fn main() {
             k: Utc::now().time(),
             l: None,
             m: NaiveDate::MIN,
-            n: TimeDelta::min_value(),
+            n: TimeDelta::minutes(1234),
         },
     ];
 

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -269,8 +269,8 @@ where
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter().map(|bytes| {
-            // # Safety
-            // - String arrays must have valid UTF8 values.
+            // SAFETY:
+            // - String arrays contain valid UTF8.
             unsafe { String::from_utf8_unchecked(bytes) }
         })
     }
@@ -292,8 +292,8 @@ where
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter().map(|opt| {
             opt.map(|bytes| {
-                // # Safety
-                // - String arrays must have valid UTF8 values.
+                // SAFETY:
+                // - String arrays contain valid UTF8.
                 unsafe { String::from_utf8_unchecked(bytes) }
             })
         })

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -327,7 +327,7 @@ mod tests {
         let input: [Option<&[u8]>; 4] = [Some(&[1]), None, Some(&[4, 5, 6]), Some(&[7, 8, 9, 0])];
         let array = input.into_iter().collect::<VariableSizeBinaryArray<true>>();
         let output = array.into_iter().collect::<Vec<_>>();
-        assert_eq!(output, input.map(|opt| opt.map(|slice| slice.to_vec())));
+        assert_eq!(output, input.map(|opt| opt.map(<[u8]>::to_vec)));
 
         let input_vec = vec![Some(vec![1]), None, Some(vec![2, 3]), Some(vec![4])];
         let array_vec = input_vec

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -22,7 +22,7 @@ where
 pub type BinaryArray<const NULLABLE: bool = false, Buffer = VecBuffer> =
     VariableSizeBinaryArray<NULLABLE, i32, Buffer>;
 
-/// Variable-size binary elements, using `i64` offset value.
+/// Variable-size binary elements, using `i64` offset values.
 pub type LargeBinaryArray<const NULLABLE: bool = false, Buffer = VecBuffer> =
     VariableSizeBinaryArray<NULLABLE, i64, Buffer>;
 
@@ -192,6 +192,26 @@ where
     }
 }
 
+impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> IntoIterator
+    for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
+where
+    <Buffer as BufferType>::Buffer<u8>: Validity<NULLABLE>,
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer>: IntoIterator,
+{
+    type Item = <Offset<FixedSizePrimitiveArray<u8, false, Buffer>, NULLABLE, OffsetItem, Buffer> as IntoIterator>::Item;
+    type IntoIter = <Offset<
+        FixedSizePrimitiveArray<u8, false, Buffer>,
+        NULLABLE,
+        OffsetItem,
+        Buffer,
+    > as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl<const NULLABLE: bool, OffsetItem: OffsetElement, Buffer: BufferType> Length
     for VariableSizeBinaryArray<NULLABLE, OffsetItem, Buffer>
 where
@@ -260,6 +280,22 @@ mod tests {
     }
 
     #[test]
+    fn into_iter() {
+        let input: [&[u8]; 4] = [&[1], &[2, 3], &[4, 5, 6], &[7, 8, 9, 0]];
+        let array = input.into_iter().collect::<VariableSizeBinaryArray>();
+        let output = array.into_iter().collect::<Vec<_>>();
+        assert_eq!(output, input);
+
+        let input_vec = vec![vec![1], vec![], vec![2, 3], vec![4]];
+        let array_vec = input_vec
+            .clone()
+            .into_iter()
+            .collect::<VariableSizeBinaryArray>();
+        let output_vec = array_vec.into_iter().collect::<Vec<_>>();
+        assert_eq!(output_vec, input_vec);
+    }
+
+    #[test]
     fn from_iter_nullable() {
         let input: [Option<&[u8]>; 4] = [Some(&[1]), None, Some(&[4, 5, 6]), Some(&[7, 8, 9, 0])];
         let array = input.into_iter().collect::<VariableSizeBinaryArray<true>>();
@@ -284,6 +320,22 @@ mod tests {
                 .collect::<Vec<_>>(),
             &[true, false, true, true]
         );
+    }
+
+    #[test]
+    fn into_iter_nullable() {
+        let input: [Option<&[u8]>; 4] = [Some(&[1]), None, Some(&[4, 5, 6]), Some(&[7, 8, 9, 0])];
+        let array = input.into_iter().collect::<VariableSizeBinaryArray<true>>();
+        let output = array.into_iter().collect::<Vec<_>>();
+        assert_eq!(output, input.map(|opt| opt.map(|slice| slice.to_vec())));
+
+        let input_vec = vec![Some(vec![1]), None, Some(vec![2, 3]), Some(vec![4])];
+        let array_vec = input_vec
+            .clone()
+            .into_iter()
+            .collect::<VariableSizeBinaryArray<true>>();
+        let output_vec = array_vec.into_iter().collect::<Vec<_>>();
+        assert_eq!(output_vec, input_vec);
     }
 
     #[test]

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -204,9 +204,10 @@ mod tests {
                 .iter()
                 .flatten()
                 .flat_map(|dyn_array| {
-                    let array: StringArray<false, i32, crate::arrow::buffer::ScalarBuffer> =
-                        dyn_array.into();
-                    array.into_iter().collect::<Vec<_>>()
+                    StringArray::<false, i32, crate::arrow::buffer::ScalarBuffer>::from(dyn_array)
+                        .into_iter()
+                        .map(ToOwned::to_owned)
+                        .collect::<Vec<_>>()
                 })
                 .collect::<Vec<_>>(),
             INPUT_NULLABLE
@@ -282,10 +283,6 @@ mod tests {
         let fixed_size_list_array_nullable =
             arrow_array::FixedSizeListArray::from(fixed_size_list_array_nullable_input);
 
-        let owned_input_nullable = INPUT_NULLABLE
-            .into_iter()
-            .map(|item| item.map(|[first, second]| [first.to_owned(), second.to_owned()]))
-            .collect::<Vec<_>>();
         assert_eq!(
             FixedSizeListArray::<
                 2,
@@ -294,7 +291,7 @@ mod tests {
             >::from(fixed_size_list_array_nullable)
             .into_iter()
             .collect::<Vec<_>>(),
-            owned_input_nullable
+            INPUT_NULLABLE
         );
     }
 }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -204,6 +204,21 @@ where
     }
 }
 
+impl<const NULLABLE: bool, T, OffsetItem: OffsetElement, Buffer: BufferType> Clone
+    for Offset<T, NULLABLE, OffsetItem, Buffer>
+where
+    T: Clone,
+    <Buffer as BufferType>::Buffer<OffsetItem>: Validity<NULLABLE>,
+    <<Buffer as BufferType>::Buffer<OffsetItem> as Validity<NULLABLE>>::Storage<Buffer>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            offsets: self.offsets.clone(),
+        }
+    }
+}
+
 impl<T: Default, OffsetItem: OffsetElement, Buffer: BufferType> Default
     for Offset<T, false, OffsetItem, Buffer>
 where


### PR DESCRIPTION
Also changes the `StringArray` `IntoIterator` impl to use the `Offset` iterator and adds a `Clone` impl for `Offset`. Breaking change because the associated `IntoIter` type of the `StringArray` `IntoIterator` impl changed. This made me realize we may want to use a logical array for UTF8 instead.