### PR TITLE
feat: impl `LogicalArrayType` for `VariableSizeBinary` to fix `IntoIterator` when used in `StructArray`

### DIFF
--- a/examples/parquet.rs
+++ b/examples/parquet.rs
@@ -15,10 +15,10 @@ fn main() {
     use parquet::arrow::{arrow_reader::ParquetRecordBatchReader, ArrowWriter};
     use uuid::Uuid;
 
-    #[derive(ArrayType, Default)]
+    #[derive(ArrayType, Clone, Debug, Default, PartialEq)]
     struct Bar(Option<bool>);
 
-    #[derive(ArrayType, Default)]
+    #[derive(ArrayType, Clone, Debug, Default, PartialEq)]
     struct Foo {
         a: u32,
         b: Option<u8>,
@@ -73,7 +73,9 @@ fn main() {
         },
     ];
 
-    let narrow_array = input.into_iter().collect::<StructArray<Foo>>();
+    let narrow_array = input.clone().into_iter().collect::<StructArray<Foo>>();
+    let output = narrow_array.clone().into_iter().collect::<Vec<_>>();
+    assert_eq!(input.as_slice(), output);
 
     let record_batch = RecordBatch::from(narrow_array);
     println!("From narrow StructArray to Arrow RecordBatch");

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     buffer::BufferType,
+    logical::{LogicalArray, LogicalArrayType},
     offset::{self, OffsetElement},
     Length,
 };
@@ -172,12 +173,24 @@ pub struct VariableSizeBinary(Vec<u8>);
 
 impl ArrayType<VariableSizeBinary> for VariableSizeBinary {
     type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
-        VariableSizeBinaryArray<false, OffsetItem, Buffer>;
+        LogicalArray<Self, false, Buffer, OffsetItem, UnionLayout>;
 }
 
 impl ArrayType<VariableSizeBinary> for Option<VariableSizeBinary> {
     type Array<Buffer: BufferType, OffsetItem: OffsetElement, UnionLayout: UnionType> =
-        VariableSizeBinaryArray<true, OffsetItem, Buffer>;
+        LogicalArray<VariableSizeBinary, true, Buffer, OffsetItem, UnionLayout>;
+}
+
+impl LogicalArrayType<VariableSizeBinary> for VariableSizeBinary {
+    type ArrayType = Vec<u8>;
+
+    fn from_array_type(item: Self::ArrayType) -> Self {
+        item.into()
+    }
+
+    fn into_array_type(self) -> Self::ArrayType {
+        self.into()
+    }
 }
 
 impl From<Vec<u8>> for VariableSizeBinary {

--- a/src/array/variable_size_binary.rs
+++ b/src/array/variable_size_binary.rs
@@ -338,6 +338,22 @@ mod tests {
         assert_eq!(output_vec, input_vec);
     }
 
+    #[cfg(feature = "derive")]
+    #[test]
+    fn with_derive() {
+        use crate::array::{StructArray, VariableSizeBinary};
+
+        #[derive(crate::ArrayType, Clone, Debug, PartialEq)]
+        struct Foo {
+            a: Option<Vec<VariableSizeBinary>>,
+        }
+
+        let input = [Foo { a: None }];
+        let array = input.clone().into_iter().collect::<StructArray<Foo>>();
+        let output = array.into_iter().collect::<Vec<_>>();
+        assert_eq!(input.as_slice(), output);
+    }
+
     #[test]
     fn index() {
         let input: [&[u8]; 4] = [&[1], &[2, 3], &[4, 5, 6], &[7, 8, 9, 0]];


### PR DESCRIPTION
This fixes the added test. Because the bounds in the derived `IntoIterator` implementation for structs have bounds on the `Item` associated type of the `IntoIterator` impls of the fields, they must match, so for `VariableSizeBinary` we have to map via `LogicalArray`.