### PR TITLE
feat: support `arrow` conversion of `LogicalArray` to `GenericListArray`

### DIFF
--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -2,6 +2,8 @@
 
 use std::sync::Arc;
 
+use arrow_array::OffsetSizeTrait;
+
 use crate::{
     array::{ArrayType, UnionType},
     buffer::BufferType,
@@ -129,5 +131,49 @@ where
 {
     fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         value.0.into()
+    }
+}
+
+impl<
+        T: LogicalArrayType<T>,
+        const NULLABLE: bool,
+        Buffer: BufferType,
+        OffsetItem: OffsetElement,
+        UnionLayout: UnionType,
+        O: OffsetSizeTrait,
+    > From<LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>>
+    for arrow_array::GenericListArray<O>
+where
+    Option<T>: ArrayType<T>,
+    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
+    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
+        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
+    arrow_array::GenericListArray<O>: From<
+        <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
+            <T as LogicalArrayType<T>>::ArrayType,
+        >>::Array<Buffer, OffsetItem, UnionLayout>,
+    >,
+{
+    fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
+        value.0.into()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    #[cfg(feature = "derive")]
+    fn optional_variable_size_list_logical() {
+        use crate::array::{StructArray, VariableSizeBinary};
+
+        #[derive(crate::ArrayType)]
+        struct Foo {
+            items: Option<Vec<VariableSizeBinary>>,
+        }
+
+        let input = [Foo { items: None }];
+        let array = input.into_iter().collect::<StructArray<Foo>>();
+        let record_batch = arrow_array::RecordBatch::from(array);
+        assert_eq!(record_batch.num_rows(), 1);
     }
 }


### PR DESCRIPTION
Maybe I should just write a macro to generate all these impls.