### PR TITLE
chore(deps): revert bump of once_cell from 1.19.0 to 1.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "oorandom"

--- a/narrow-derive/Cargo.toml
+++ b/narrow-derive/Cargo.toml
@@ -20,7 +20,7 @@ arrow-rs = []
 proc-macro = true
 
 [dependencies]
-once_cell = "1.20.0"
+once_cell = "1.18.0"
 proc-macro-crate = "3.2.0"
 proc-macro2 = "1.0.86"
 quote = "1.0.37"


### PR DESCRIPTION
Reverts mbrobbel/narrow#249. This release was yanked, causing the release workflow to break.