### PR TITLE
feat: add `data_type` method to `arrow-rs` `Array` extension trait

### DIFF
--- a/src/arrow/array/boolean.rs
+++ b/src/arrow/array/boolean.rs
@@ -22,7 +22,11 @@ where
     type Array = arrow_array::BooleanArray;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        arrow_schema::Field::new(name, arrow_schema::DataType::Boolean, NULLABLE)
+        arrow_schema::Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        arrow_schema::DataType::Boolean
     }
 }
 

--- a/src/arrow/array/fixed_size_binary.rs
+++ b/src/arrow/array/fixed_size_binary.rs
@@ -34,7 +34,7 @@ where
     }
 
     fn data_type() -> arrow_schema::DataType {
-        DataType::FixedSizeBinary(N as i32)
+        DataType::FixedSizeBinary(i32::try_from(N).expect("overflow"))
     }
 }
 
@@ -62,7 +62,11 @@ where
             clippy::cast_possible_truncation,
             clippy::cast_possible_wrap
         )]
-        arrow_array::FixedSizeBinaryArray::new(N as i32, value.0 .0.into(), None)
+        arrow_array::FixedSizeBinaryArray::new(
+            i32::try_from(N).expect("overflow"),
+            value.0 .0.into(),
+            None,
+        )
     }
 }
 
@@ -92,7 +96,7 @@ where
             clippy::cast_possible_wrap
         )]
         arrow_array::FixedSizeBinaryArray::new(
-            N as i32,
+            i32::try_from(N).expect("overflow"),
             value.0 .0.data.into(),
             Some(value.0 .0.validity.into()),
         )

--- a/src/arrow/array/fixed_size_binary.rs
+++ b/src/arrow/array/fixed_size_binary.rs
@@ -30,7 +30,11 @@ where
             clippy::cast_possible_truncation,
             clippy::cast_possible_wrap
         )]
-        Field::new(name, DataType::FixedSizeBinary(N as i32), NULLABLE)
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        DataType::FixedSizeBinary(N as i32)
     }
 }
 

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -30,11 +30,11 @@ where
             clippy::cast_possible_truncation,
             clippy::cast_possible_wrap
         )]
-        Field::new(
-            name,
-            DataType::FixedSizeList(Arc::new(T::as_field("item")), N as i32),
-            NULLABLE,
-        )
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        DataType::FixedSizeList(Arc::new(T::as_field("item")), N as i32)
     }
 }
 

--- a/src/arrow/array/fixed_size_list.rs
+++ b/src/arrow/array/fixed_size_list.rs
@@ -34,7 +34,10 @@ where
     }
 
     fn data_type() -> arrow_schema::DataType {
-        DataType::FixedSizeList(Arc::new(T::as_field("item")), N as i32)
+        DataType::FixedSizeList(
+            Arc::new(T::as_field("item")),
+            i32::try_from(N).expect("overflow"),
+        )
     }
 }
 
@@ -95,7 +98,7 @@ where
         )]
         arrow_array::FixedSizeListArray::new(
             Arc::new(T::as_field("item")),
-            N as i32,
+            i32::try_from(N).expect("overflow"),
             Arc::<<T as crate::arrow::Array>::Array>::new(value.0.into()),
             None,
         )
@@ -118,7 +121,7 @@ where
         )]
         arrow_array::FixedSizeListArray::new(
             Arc::new(T::as_field("item")),
-            N as i32,
+            i32::try_from(N).expect("overflow"),
             Arc::<<T as crate::arrow::Array>::Array>::new(value.0.data.into()),
             Some(value.0.validity.into()),
         )

--- a/src/arrow/array/fixed_size_primitive.rs
+++ b/src/arrow/array/fixed_size_primitive.rs
@@ -66,11 +66,11 @@ where
     type Array = arrow_array::PrimitiveArray<<T as FixedSizeExt>::ArrowPrimitiveType>;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        arrow_schema::Field::new(
-            name,
-            <T as FixedSizeExt>::ArrowPrimitiveType::DATA_TYPE,
-            NULLABLE,
-        )
+        arrow_schema::Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        <T as FixedSizeExt>::ArrowPrimitiveType::DATA_TYPE
     }
 }
 

--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -40,6 +40,12 @@ where
             <T as LogicalArrayType<T>>::ArrayType,
         >>::Array<Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::as_field(name)
     }
+
+    fn data_type() -> arrow_schema::DataType {
+        <<<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
+            <T as LogicalArrayType<T>>::ArrayType,
+        >>::Array<Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::data_type()
+    }
 }
 
 impl<

--- a/src/arrow/array/null.rs
+++ b/src/arrow/array/null.rs
@@ -20,7 +20,11 @@ where
     type Array = arrow_array::NullArray;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(name, DataType::Null, NULLABLE)
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        DataType::Null
     }
 }
 

--- a/src/arrow/array/string.rs
+++ b/src/arrow/array/string.rs
@@ -25,15 +25,15 @@ where
     type Array = arrow_array::GenericStringArray<OffsetItem>;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(
-            name,
-            if OffsetItem::LARGE {
-                DataType::LargeUtf8
-            } else {
-                DataType::Utf8
-            },
-            NULLABLE,
-        )
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        if OffsetItem::LARGE {
+            DataType::LargeUtf8
+        } else {
+            DataType::Utf8
+        }
     }
 }
 

--- a/src/arrow/array/struct.rs
+++ b/src/arrow/array/struct.rs
@@ -29,13 +29,11 @@ where
     type Array = arrow_array::StructArray;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(
-            name,
-            DataType::Struct(
-                <<T as StructArrayType>::Array<Buffer> as StructArrayTypeFields>::fields(),
-            ),
-            NULLABLE,
-        )
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        DataType::Struct(<<T as StructArrayType>::Array<Buffer> as StructArrayTypeFields>::fields())
     }
 }
 

--- a/src/arrow/array/union.rs
+++ b/src/arrow/array/union.rs
@@ -50,21 +50,21 @@ where
     type Array = arrow_array::UnionArray;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(
-            name,
-            DataType::Union(
-                <<T as UnionArrayType<VARIANTS>>::Array<
-                    Buffer,
-                    OffsetItem,
-                    UnionLayout,
-                > as UnionArrayTypeFields<VARIANTS>>::type_ids().iter().copied().zip(<<T as UnionArrayType<VARIANTS>>::Array<
-                    Buffer,
-                    OffsetItem,
-                    UnionLayout,
-                > as UnionArrayTypeFields<VARIANTS>>::fields().iter().map(Arc::clone)).collect(),
-                <UnionLayout as UnionLayoutExt>::MODE
-            ),
-            false
+        Field::new(name, Self::data_type(), false)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        DataType::Union(
+            <<T as UnionArrayType<VARIANTS>>::Array<
+                Buffer,
+                OffsetItem,
+                UnionLayout,
+            > as UnionArrayTypeFields<VARIANTS>>::type_ids().iter().copied().zip(<<T as UnionArrayType<VARIANTS>>::Array<
+                Buffer,
+                OffsetItem,
+                UnionLayout,
+            > as UnionArrayTypeFields<VARIANTS>>::fields().iter().map(Arc::clone)).collect(),
+            <UnionLayout as UnionLayoutExt>::MODE
         )
     }
 }

--- a/src/arrow/array/variable_size_binary.rs
+++ b/src/arrow/array/variable_size_binary.rs
@@ -25,15 +25,15 @@ where
     type Array = arrow_array::GenericBinaryArray<OffsetItem>;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(
-            name,
-            if OffsetItem::LARGE {
-                DataType::LargeBinary
-            } else {
-                DataType::Binary
-            },
-            NULLABLE,
-        )
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        if OffsetItem::LARGE {
+            DataType::LargeBinary
+        } else {
+            DataType::Binary
+        }
     }
 }
 

--- a/src/arrow/array/variable_size_list.rs
+++ b/src/arrow/array/variable_size_list.rs
@@ -29,15 +29,15 @@ where
     type Array = arrow_array::GenericListArray<OffsetItem>;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        Field::new(
-            name,
-            if OffsetItem::LARGE {
-                DataType::LargeList(Arc::new(T::as_field("item")))
-            } else {
-                DataType::List(Arc::new(T::as_field("item")))
-            },
-            NULLABLE,
-        )
+        Field::new(name, Self::data_type(), NULLABLE)
+    }
+
+    fn data_type() -> arrow_schema::DataType {
+        if OffsetItem::LARGE {
+            DataType::LargeList(Arc::new(T::as_field("item")))
+        } else {
+            DataType::List(Arc::new(T::as_field("item")))
+        }
     }
 }
 

--- a/src/arrow/mod.rs
+++ b/src/arrow/mod.rs
@@ -16,6 +16,9 @@ pub trait Array: crate::array::Array + Sized {
 
     /// Returns the field of this array.
     fn as_field(name: &str) -> arrow_schema::Field;
+
+    /// Returns the data type of this array.
+    fn data_type() -> arrow_schema::DataType;
 }
 
 /// Extension trait for [`OffsetElement`] for [`arrow-rs`] interop.


### PR DESCRIPTION
A first step towards supporting overriding the data type for logical array types.