### PR TITLE
feat: Add benchmarks for primitive array building from an iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
  "chrono",
  "criterion",
  "narrow-derive",
+ "num-traits",
  "parquet",
  "rand",
  "rustversion",
@@ -741,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,11 +57,12 @@ arrow-cast = { version = "52", default-features = false, features = [
 ] }
 bytes = "1.7.2"
 chrono = { version = "0.4.38", default-features = false, features = ["now"] }
-criterion = { version = "0.5.1", default-features = false }
+criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
 rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 rustversion = { version = "1.0.17", default-features = false }
 parquet = { version = "52", default-features = false, features = ["arrow"] }
 uuid = { version = "1.10.0", default-features = false }
+num-traits = { version = "0.2.19" }
 
 [profile.bench]
 lto = true
@@ -70,6 +71,7 @@ codegen-units = 1
 [[bench]]
 name = "narrow"
 harness = false
+required-features = ["arrow-rs"]
 
 [[example]]
 name = "parquet"

--- a/benches/narrow/bitmap/iter.rs
+++ b/benches/narrow/bitmap/iter.rs
@@ -1,10 +1,14 @@
 use criterion::{BenchmarkId, Criterion, Throughput};
 use narrow::{bitmap::Bitmap, buffer::BoxBuffer};
 use rand::{prelude::SmallRng, Rng, SeedableRng};
+use std::time::Duration;
 
 pub(super) fn bench(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("Bitmap::from_iter");
+        group.warm_up_time(Duration::from_millis(100));
+        group.measurement_time(Duration::from_secs(1));
+
         let mut rng = SmallRng::seed_from_u64(1234);
 
         for size in [12345] {

--- a/benches/narrow/main.rs
+++ b/benches/narrow/main.rs
@@ -1,4 +1,3 @@
-use arrow_array::types::{UInt16Type, UInt32Type, UInt64Type, UInt8Type};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 mod bitmap;
@@ -9,14 +8,6 @@ criterion_group! {
   config = Criterion::default();
   targets =
     bitmap::bench,
-    versus::arrow::primitive::bench<UInt8Type>,
-    versus::arrow::primitive::bench<UInt16Type>,
-    versus::arrow::primitive::bench<UInt32Type>,
-    versus::arrow::primitive::bench<UInt64Type>,
-    versus::arrow::primitive::bench_nullable<UInt8Type>,
-    versus::arrow::primitive::bench_nullable<UInt16Type>,
-    versus::arrow::primitive::bench_nullable<UInt32Type>,
-    versus::arrow::primitive::bench_nullable<UInt64Type>,
-
+    versus::arrow::primitive::bench,
 }
 criterion_main!(narrow);

--- a/benches/narrow/main.rs
+++ b/benches/narrow/main.rs
@@ -17,6 +17,6 @@ criterion_group! {
     versus::arrow::primitive::bench_nullable<UInt16Type>,
     versus::arrow::primitive::bench_nullable<UInt32Type>,
     versus::arrow::primitive::bench_nullable<UInt64Type>,
-    
+
 }
 criterion_main!(narrow);

--- a/benches/narrow/main.rs
+++ b/benches/narrow/main.rs
@@ -1,11 +1,22 @@
+use arrow_array::types::{UInt16Type, UInt32Type, UInt64Type, UInt8Type};
 use criterion::{criterion_group, criterion_main, Criterion};
 
 mod bitmap;
+mod versus;
 
 criterion_group! {
   name = narrow;
   config = Criterion::default();
   targets =
-    bitmap::bench
+    bitmap::bench,
+    versus::arrow::primitive::bench<UInt8Type>,
+    versus::arrow::primitive::bench<UInt16Type>,
+    versus::arrow::primitive::bench<UInt32Type>,
+    versus::arrow::primitive::bench<UInt64Type>,
+    versus::arrow::primitive::bench_nullable<UInt8Type>,
+    versus::arrow::primitive::bench_nullable<UInt16Type>,
+    versus::arrow::primitive::bench_nullable<UInt32Type>,
+    versus::arrow::primitive::bench_nullable<UInt64Type>,
+    
 }
 criterion_main!(narrow);

--- a/benches/narrow/versus/arrow/mod.rs
+++ b/benches/narrow/versus/arrow/mod.rs
@@ -1,0 +1,1 @@
+pub mod primitive;

--- a/benches/narrow/versus/arrow/primitive.rs
+++ b/benches/narrow/versus/arrow/primitive.rs
@@ -12,7 +12,7 @@ where
     let mut group = c.benchmark_group("PrimitiveBuilder");
     group.warm_up_time(Duration::from_millis(100));
     group.measurement_time(Duration::from_secs(1));
-    
+
     let max: usize = num_traits::cast(T::Native::max_value()).unwrap();
 
     for size in [0, 4, 8, 16].map(|v| 1usize << v).into_iter() {
@@ -34,7 +34,7 @@ where
     T: ArrowPrimitiveType,
 {
     let mut builder: PrimitiveBuilder<T> = PrimitiveBuilder::new();
-    builder.extend(input.into_iter().map(|v| Some(v)));
+    builder.extend(input.into_iter().map(Some));
     builder.finish()
 }
 
@@ -91,7 +91,7 @@ where
     T: ArrowPrimitiveType,
 {
     let mut builder: PrimitiveBuilder<T> = PrimitiveBuilder::new();
-    builder.extend(input.into_iter());
+    builder.extend(input);
     builder.finish()
 }
 

--- a/benches/narrow/versus/arrow/primitive.rs
+++ b/benches/narrow/versus/arrow/primitive.rs
@@ -9,8 +9,8 @@ use std::{ops::Rem, time::Duration};
 pub fn bench(c: &mut Criterion) {
     bench_primitive::<UInt8Type>(c);
     bench_primitive::<UInt16Type>(c);
-    bench_primitive::<UInt64Type>(c);
     bench_primitive::<UInt32Type>(c);
+    bench_primitive::<UInt64Type>(c);
     bench_nullable_primitive::<UInt8Type>(c);
     bench_nullable_primitive::<UInt16Type>(c);
     bench_nullable_primitive::<UInt32Type>(c);
@@ -32,7 +32,7 @@ where
         .unwrap()
         .saturating_add(1);
 
-    for size in [0, 4, 8, 16].map(|v| 1usize << v).into_iter() {
+    for size in [0, 8, 16].map(|v| 1usize << v).into_iter() {
         let input = (0..size)
             .map(|v| num_traits::cast(v % max).unwrap())
             .collect::<Vec<T::Native>>();

--- a/benches/narrow/versus/arrow/primitive.rs
+++ b/benches/narrow/versus/arrow/primitive.rs
@@ -103,7 +103,7 @@ where
                 .collect::<Vec<Option<T::Native>>>();
             group.throughput(criterion::Throughput::Elements(size as u64));
             group.bench_with_input(
-                BenchmarkId::new(format!("arrow-rs/{}/", null_fraction), size),
+                BenchmarkId::new(format!("arrow-rs/{null_fraction}"), size),
                 &input,
                 |bencher, input| {
                     bencher.iter(|| {
@@ -114,7 +114,7 @@ where
                 },
             );
             group.bench_with_input(
-                BenchmarkId::new(format!("narrow/{}/", null_fraction), size),
+                BenchmarkId::new(format!("narrow/{null_fraction}"), size),
                 &input,
                 |bencher, input| {
                     bencher.iter(|| {

--- a/benches/narrow/versus/arrow/primitive.rs
+++ b/benches/narrow/versus/arrow/primitive.rs
@@ -1,0 +1,106 @@
+use arrow_array::{builder::PrimitiveBuilder, ArrowPrimitiveType, PrimitiveArray};
+use criterion::{BenchmarkId, Criterion};
+use narrow::{array::FixedSizePrimitiveArray, FixedSize};
+use num_traits::{Bounded, NumCast};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
+use std::{ops::Rem, time::Duration};
+
+pub fn bench<T: ArrowPrimitiveType>(c: &mut Criterion)
+where
+    <T as ArrowPrimitiveType>::Native: NumCast + Bounded + Rem + FixedSize,
+{
+    let mut group = c.benchmark_group("PrimitiveBuilder");
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_secs(1));
+    
+    let max: usize = num_traits::cast(T::Native::max_value()).unwrap();
+
+    for size in [0, 4, 8, 16].map(|v| 1usize << v).into_iter() {
+        let input = (0..size)
+            .map(|v| num_traits::cast(v % max).unwrap())
+            .collect::<Vec<T::Native>>();
+        group.throughput(criterion::Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::new("Arrow", size), &input, |b, i| {
+            b.iter(|| arrow_build_primitive_array_from_iterator::<T>(i.clone()))
+        });
+        group.bench_with_input(BenchmarkId::new("Narrow", size), &input, |b, i| {
+            b.iter(|| narrow_build_primitive_array_from_iterator::<T>(i.clone()))
+        });
+    }
+}
+
+fn arrow_build_primitive_array_from_iterator<T>(input: Vec<T::Native>) -> PrimitiveArray<T>
+where
+    T: ArrowPrimitiveType,
+{
+    let mut builder: PrimitiveBuilder<T> = PrimitiveBuilder::new();
+    builder.extend(input.into_iter().map(|v| Some(v)));
+    builder.finish()
+}
+
+fn narrow_build_primitive_array_from_iterator<T>(
+    input: Vec<T::Native>,
+) -> FixedSizePrimitiveArray<T::Native, false>
+where
+    T: ArrowPrimitiveType,
+    <T as ArrowPrimitiveType>::Native: FixedSize,
+{
+    input.into_iter().collect()
+}
+
+pub fn bench_nullable<T: ArrowPrimitiveType>(c: &mut Criterion)
+where
+    <T as ArrowPrimitiveType>::Native: NumCast + Bounded + Rem + FixedSize,
+{
+    let mut group = c.benchmark_group("NullablePrimitiveBuilder");
+    group.warm_up_time(Duration::from_millis(100));
+    group.measurement_time(Duration::from_secs(1));
+
+    let max: usize = num_traits::cast(T::Native::max_value()).unwrap();
+    let mut rng = SmallRng::seed_from_u64(1337);
+
+    for size in [0, 4, 8, 16].map(|v| 1usize << v).into_iter() {
+        for null_fraction in [0., 0.5, 1.] {
+            let input = (0..size)
+                .map(|v| num_traits::cast(v % max).unwrap())
+                .map(|v| rng.gen_bool(1. - null_fraction).then_some(v))
+                .collect::<Vec<Option<T::Native>>>();
+            group.throughput(criterion::Throughput::Elements(size as u64));
+            group.bench_with_input(
+                BenchmarkId::new(format!("Arrow/{}/", null_fraction), size),
+                &input,
+                |b, i| {
+                    b.iter(|| arrow_build_primitive_array_from_iterator_nullable::<T>(i.clone()))
+                },
+            );
+            group.bench_with_input(
+                BenchmarkId::new(format!("Narrow/{}/", null_fraction), size),
+                &input,
+                |b, i| {
+                    b.iter(|| narrow_build_primitive_array_from_iterator_nullable::<T>(i.clone()))
+                },
+            );
+        }
+    }
+}
+
+fn arrow_build_primitive_array_from_iterator_nullable<T>(
+    input: Vec<Option<T::Native>>,
+) -> PrimitiveArray<T>
+where
+    T: ArrowPrimitiveType,
+{
+    let mut builder: PrimitiveBuilder<T> = PrimitiveBuilder::new();
+    builder.extend(input.into_iter());
+    builder.finish()
+}
+
+fn narrow_build_primitive_array_from_iterator_nullable<T>(
+    input: Vec<Option<T::Native>>,
+) -> FixedSizePrimitiveArray<T::Native, true>
+where
+    T: ArrowPrimitiveType,
+    <T as ArrowPrimitiveType>::Native: FixedSize,
+{
+    input.into_iter().collect()
+}

--- a/benches/narrow/versus/mod.rs
+++ b/benches/narrow/versus/mod.rs
@@ -1,0 +1,1 @@
+pub mod arrow;


### PR DESCRIPTION
This adds benchmarks that compare `narrow` versus `arrow-rs` when building an Arrow array of primitive values of varying bit lengths (`u8`, `u16`, `u32`, and `u64`) from an iterator.
