### PR TITLE
refactor: Simplified type signatures related to `ArrayType::Array`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.70.0
+      - uses: dtolnay/rust-toolchain@1.79.0
         id: rust-toolchain
       - uses: dtolnay/install@master
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
 edition = "2021"
-rust-version = "1.70.0"
+rust-version = "1.79.0"
 description = "An implementation of Apache Arrow"
 readme = "README.md"
 repository = "https://github.com/mbrobbel/narrow"

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The crate supports the following optional features:
 
 # Minimum supported Rust version
 
-The minimum supported Rust version for this crate is Rust 1.70.0.
+The minimum supported Rust version for this crate is Rust 1.79.0.
 
 # License
 

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -80,7 +80,7 @@ pub type OptionArrayTypeOf<
     UnionLayout = union::NA,
 > = <Option<T> as ArrayType<T>>::Array<Buffer, OffsetItem, UnionLayout>;
 
-/// A helper type that allows extracting the [`ArrayType::Array`] type for any `ArrayType<T>::Item> for <T as Nullability<NULLABLE>`
+/// A helper type that allows extracting the [`ArrayType::Array`] type for any `ArrayType<T>::Item for <T as Nullability<NULLABLE>`
 pub type NullableArrayTypeOf<
     const NULLABLE: bool,
     T,

--- a/src/array/string.rs
+++ b/src/array/string.rs
@@ -337,17 +337,12 @@ impl<OffsetItem: OffsetElement, Buffer: BufferType> ValidityBitmap
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        array::{union, ArrayType},
-        buffer::BufferRef,
-    };
+    use crate::{array::ArrayTypeOf, buffer::BufferRef};
 
     #[test]
     fn from_iter() {
         let input = ["1", "23", "456", "7890"];
-        let array = input
-            .into_iter()
-            .collect::<<String as ArrayType<String>>::Array<VecBuffer, i64, union::NA>>();
+        let array = input.into_iter().collect::<ArrayTypeOf<String>>();
         assert_eq!(array.len(), 4);
         assert_eq!(array.0 .0.data.0, b"1234567890");
 

--- a/src/array/struct.rs
+++ b/src/array/struct.rs
@@ -175,8 +175,8 @@ impl<T: StructArrayType, Buffer: BufferType> ValidityBitmap for StructArray<T, t
 #[cfg(test)]
 mod tests {
     use crate::{
-        array::{union, UnionType},
-        offset::{self, OffsetElement},
+        array::{ArrayTypeOf, OptionArrayTypeOf, UnionType},
+        offset::OffsetElement,
     };
 
     use super::*;
@@ -203,49 +203,47 @@ mod tests {
     }
 
     struct FooArray<'a, Buffer: BufferType> {
-        a: <u32 as ArrayType<u32>>::Array<Buffer, offset::NA, union::NA>,
-        b: <Option<()> as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>,
-        c: <() as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>,
-        d: <Option<[u64; 2]> as ArrayType<[u64; 2]>>::Array<Buffer, offset::NA, union::NA>,
-        e: <bool as ArrayType<bool>>::Array<Buffer, offset::NA, union::NA>,
-        f: <&'a [u8] as ArrayType<&'a [u8]>>::Array<Buffer, offset::NA, union::NA>,
-        g: <String as ArrayType<String>>::Array<Buffer, offset::NA, union::NA>,
+        a: ArrayTypeOf<u32, Buffer>,
+        b: OptionArrayTypeOf<(), Buffer>,
+        c: ArrayTypeOf<(), Buffer>,
+        d: OptionArrayTypeOf<[u64; 2], Buffer>,
+        e: ArrayTypeOf<bool, Buffer>,
+        f: ArrayTypeOf<&'a [u8], Buffer>,
+        g: ArrayTypeOf<String, Buffer>,
     }
 
     impl<'a, Buffer: BufferType> Default for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType<u32>>::Array<Buffer, offset::NA, union::NA>: Default,
-        <Option<()> as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>: Default,
-        <() as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>: Default,
-        <Option<[u64; 2]> as ArrayType<[u64; 2]>>::Array<Buffer, offset::NA, union::NA>: Default,
-        <bool as ArrayType<bool>>::Array<Buffer, offset::NA, union::NA>: Default,
-        <&'a [u8] as ArrayType<&'a [u8]>>::Array<Buffer, offset::NA, union::NA>: Default,
-        <String as ArrayType<String>>::Array<Buffer, offset::NA, union::NA>: Default,
+        ArrayTypeOf<u32, Buffer>: Default,
+        OptionArrayTypeOf<(), Buffer>: Default,
+        ArrayTypeOf<(), Buffer>: Default,
+        OptionArrayTypeOf<[u64; 2], Buffer>: Default,
+        ArrayTypeOf<bool, Buffer>: Default,
+        ArrayTypeOf<&'a [u8], Buffer>: Default,
+        ArrayTypeOf<String, Buffer>: Default,
     {
         fn default() -> Self {
             Self {
-                a: <u32 as ArrayType<u32>>::Array::<Buffer, offset::NA, union::NA>::default(),
-                b: <Option<()> as ArrayType<()>>::Array::<Buffer, offset::NA, union::NA>::default(),
-                c: <() as ArrayType<()>>::Array::<Buffer, offset::NA, union::NA>::default(),
-                d: <Option<[u64; 2]> as ArrayType<[u64; 2]>>::Array::<Buffer, offset::NA, union::NA>::default(
-                ),
-                e: <bool as ArrayType<bool>>::Array::<Buffer, offset::NA, union::NA>::default(),
-                f: <&'a [u8] as ArrayType<&'a [u8]>>::Array::<Buffer, offset::NA, union::NA>::default(),
-                g: <String as ArrayType<String>>::Array::<Buffer, offset::NA, union::NA>::default(),
+                a: <ArrayTypeOf<u32, Buffer>>::default(),
+                b: <OptionArrayTypeOf<(), Buffer>>::default(),
+                c: <ArrayTypeOf<(), Buffer>>::default(),
+                d: <OptionArrayTypeOf<[u64; 2], Buffer>>::default(),
+                e: <ArrayTypeOf<bool, Buffer>>::default(),
+                f: <ArrayTypeOf<&'a [u8], Buffer>>::default(),
+                g: <ArrayTypeOf<String, Buffer>>::default(),
             }
         }
     }
 
     impl<'a, Buffer: BufferType> Extend<Foo<'a>> for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType<u32>>::Array<Buffer, offset::NA, union::NA>: Extend<u32>,
-        <Option<()> as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>: Extend<Option<()>>,
-        <() as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>: Extend<()>,
-        <Option<[u64; 2]> as ArrayType<[u64; 2]>>::Array<Buffer, offset::NA, union::NA>:
-            Extend<Option<[u64; 2]>>,
-        <bool as ArrayType<bool>>::Array<Buffer, offset::NA, union::NA>: Extend<bool>,
-        <&'a [u8] as ArrayType<&'a [u8]>>::Array<Buffer, offset::NA, union::NA>: Extend<&'a [u8]>,
-        <String as ArrayType<String>>::Array<Buffer, offset::NA, union::NA>: Extend<String>,
+        ArrayTypeOf<u32, Buffer>: Extend<u32>,
+        OptionArrayTypeOf<(), Buffer>: Extend<Option<()>>,
+        ArrayTypeOf<(), Buffer>: Extend<()>,
+        OptionArrayTypeOf<[u64; 2], Buffer>: Extend<Option<[u64; 2]>>,
+        ArrayTypeOf<bool, Buffer>: Extend<bool>,
+        ArrayTypeOf<&'a [u8], Buffer>: Extend<&'a [u8]>,
+        ArrayTypeOf<String, Buffer>: Extend<String>,
     {
         fn extend<I: IntoIterator<Item = Foo<'a>>>(&mut self, iter: I) {
             iter.into_iter().for_each(
@@ -272,17 +270,13 @@ mod tests {
 
     impl<'a, Buffer: BufferType> FromIterator<Foo<'a>> for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType<u32>>::Array<Buffer, offset::NA, union::NA>: Default + Extend<u32>,
-        <Option<()> as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>:
-            Default + Extend<Option<()>>,
-        <() as ArrayType<()>>::Array<Buffer, offset::NA, union::NA>: Default + Extend<()>,
-        <Option<[u64; 2]> as ArrayType<[u64; 2]>>::Array<Buffer, offset::NA, union::NA>:
-            Default + Extend<Option<[u64; 2]>>,
-        <bool as ArrayType<bool>>::Array<Buffer, offset::NA, union::NA>: Default + Extend<bool>,
-        <&'a [u8] as ArrayType<&'a [u8]>>::Array<Buffer, offset::NA, union::NA>:
-            Default + Extend<&'a [u8]>,
-        <String as ArrayType<String>>::Array<Buffer, offset::NA, union::NA>:
-            Default + Extend<String>,
+        ArrayTypeOf<u32, Buffer>: Default + Extend<u32>,
+        OptionArrayTypeOf<(), Buffer>: Default + Extend<Option<()>>,
+        ArrayTypeOf<(), Buffer>: Default + Extend<()>,
+        OptionArrayTypeOf<[u64; 2], Buffer>: Default + Extend<Option<[u64; 2]>>,
+        ArrayTypeOf<bool, Buffer>: Default + Extend<bool>,
+        ArrayTypeOf<&'a [u8], Buffer>: Default + Extend<&'a [u8]>,
+        ArrayTypeOf<String, Buffer>: Default + Extend<String>,
     {
         #[allow(clippy::many_single_char_names)]
         fn from_iter<T: IntoIterator<Item = Foo<'a>>>(iter: T) -> Self {
@@ -317,7 +311,7 @@ mod tests {
 
     impl<'a, Buffer: BufferType> Length for FooArray<'a, Buffer>
     where
-        <u32 as ArrayType<u32>>::Array<Buffer, offset::NA, union::NA>: Length,
+        ArrayTypeOf<u32, Buffer>: Length,
     {
         fn len(&self) -> usize {
             self.a.len()

--- a/src/array/union.rs
+++ b/src/array/union.rs
@@ -700,7 +700,7 @@ mod tests {
     #[allow(unused)]
     #[rustversion::attr(nightly, allow(non_local_definitions))]
     fn with_multiple_fields() {
-        use crate::{offset, ArrayType, Length};
+        use crate::{array::ArrayTypeOf, offset, ArrayType, Length};
 
         #[derive(Clone, Debug, PartialEq, Eq)]
         enum Foo {
@@ -758,43 +758,16 @@ mod tests {
         }
 
         struct FooArray<Buffer: BufferType, UnionLayout: UnionType> {
-            unit:
-                <<Foo as EnumVariant<0>>::Data as ArrayType<<Foo as EnumVariant<0>>::Data>>::Array<
-                    Buffer,
-                    offset::NA,
-                    UnionLayout,
-                >,
-            unnamed:
-                <<Foo as EnumVariant<1>>::Data as ArrayType<<Foo as EnumVariant<1>>::Data>>::Array<
-                    Buffer,
-                    offset::NA,
-                    UnionLayout,
-                >,
-            named:
-                <<Foo as EnumVariant<2>>::Data as ArrayType<<Foo as EnumVariant<2>>::Data>>::Array<
-                    Buffer,
-                    offset::NA,
-                    UnionLayout,
-                >,
+            unit: ArrayTypeOf<<Foo as EnumVariant<0>>::Data, Buffer, offset::NA, UnionLayout>,
+            unnamed: ArrayTypeOf<<Foo as EnumVariant<1>>::Data, Buffer, offset::NA, UnionLayout>,
+            named: ArrayTypeOf<<Foo as EnumVariant<2>>::Data, Buffer, offset::NA, UnionLayout>,
         }
 
         impl<Buffer: BufferType, UnionLayout: UnionType> Default for FooArray<Buffer, UnionLayout>
         where
-            <<Foo as EnumVariant<0>>::Data as ArrayType<<Foo as EnumVariant<0>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                UnionLayout,
-            >: Default,
-            <<Foo as EnumVariant<1>>::Data as ArrayType<<Foo as EnumVariant<1>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                UnionLayout,
-            >: Default,
-            <<Foo as EnumVariant<2>>::Data as ArrayType<<Foo as EnumVariant<2>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                UnionLayout,
-            >: Default,
+            ArrayTypeOf<<Foo as EnumVariant<0>>::Data, Buffer, offset::NA, UnionLayout>: Default,
+            ArrayTypeOf<<Foo as EnumVariant<1>>::Data, Buffer, offset::NA, UnionLayout>: Default,
+            ArrayTypeOf<<Foo as EnumVariant<2>>::Data, Buffer, offset::NA, UnionLayout>: Default,
         {
             fn default() -> Self {
                 #[allow(clippy::default_trait_access)]
@@ -808,21 +781,12 @@ mod tests {
 
         impl<Buffer: BufferType> Extend<Foo> for FooArray<Buffer, DenseLayout>
         where
-            <<Foo as EnumVariant<0>>::Data as ArrayType<<Foo as EnumVariant<0>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                DenseLayout,
-            >: Extend<<Foo as EnumVariant<0>>::Data>,
-            <<Foo as EnumVariant<1>>::Data as ArrayType<<Foo as EnumVariant<1>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                DenseLayout,
-            >: Extend<<Foo as EnumVariant<1>>::Data>,
-            <<Foo as EnumVariant<2>>::Data as ArrayType<<Foo as EnumVariant<2>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                DenseLayout,
-            >: Extend<<Foo as EnumVariant<2>>::Data>,
+            ArrayTypeOf<<Foo as EnumVariant<0>>::Data, Buffer, offset::NA, DenseLayout>:
+                Extend<<Foo as EnumVariant<0>>::Data>,
+            ArrayTypeOf<<Foo as EnumVariant<1>>::Data, Buffer, offset::NA, DenseLayout>:
+                Extend<<Foo as EnumVariant<1>>::Data>,
+            ArrayTypeOf<<Foo as EnumVariant<2>>::Data, Buffer, offset::NA, DenseLayout>:
+                Extend<<Foo as EnumVariant<2>>::Data>,
         {
             fn extend<T: IntoIterator<Item = Foo>>(&mut self, iter: T) {
                 iter.into_iter().for_each(|item| match item {
@@ -837,21 +801,12 @@ mod tests {
 
         impl<Buffer: BufferType> Extend<Foo> for FooArray<Buffer, SparseLayout>
         where
-            <<Foo as EnumVariant<0>>::Data as ArrayType<<Foo as EnumVariant<0>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                SparseLayout,
-            >: Extend<<Foo as EnumVariant<0>>::Data>,
-            <<Foo as EnumVariant<1>>::Data as ArrayType<<Foo as EnumVariant<1>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                SparseLayout,
-            >: Extend<<Foo as EnumVariant<1>>::Data>,
-            <<Foo as EnumVariant<2>>::Data as ArrayType<<Foo as EnumVariant<2>>::Data>>::Array<
-                Buffer,
-                offset::NA,
-                SparseLayout,
-            >: Extend<<Foo as EnumVariant<2>>::Data>,
+            ArrayTypeOf<<Foo as EnumVariant<0>>::Data, Buffer, offset::NA, SparseLayout>:
+                Extend<<Foo as EnumVariant<0>>::Data>,
+            ArrayTypeOf<<Foo as EnumVariant<1>>::Data, Buffer, offset::NA, SparseLayout>:
+                Extend<<Foo as EnumVariant<1>>::Data>,
+            ArrayTypeOf<<Foo as EnumVariant<2>>::Data, Buffer, offset::NA, SparseLayout>:
+                Extend<<Foo as EnumVariant<2>>::Data>,
         {
             fn extend<T: IntoIterator<Item = Foo>>(&mut self, iter: T) {
                 iter.into_iter().for_each(|item| match item {
@@ -876,15 +831,8 @@ mod tests {
             }
         }
 
-        type FooEnumVariantArray<const INDEX: usize, Buffer, UnionLayout> = <<Foo as EnumVariant<
-            INDEX,
-        >>::Data as ArrayType<
-            <Foo as EnumVariant<INDEX>>::Data,
-        >>::Array<
-            Buffer,
-            offset::NA,
-            UnionLayout,
-        >;
+        type FooEnumVariantArray<const INDEX: usize, Buffer, UnionLayout> =
+            ArrayTypeOf<<Foo as EnumVariant<INDEX>>::Data, Buffer, offset::NA, UnionLayout>;
 
         struct FooArrayIntoIter<Buffer: BufferType, UnionLayout: UnionType>
         where

--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use arrow_array::OffsetSizeTrait;
 
 use crate::{
-    array::{ArrayType, UnionType},
+    array::{ArrayType, NullableArrayTypeOf, UnionType},
     buffer::BufferType,
     logical::{LogicalArray, LogicalArrayType},
     offset::OffsetElement,
@@ -23,28 +23,20 @@ impl<
     > crate::arrow::Array for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
 where
     Option<T>: ArrayType<T>,
-    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
-    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
-        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
-    <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-        <T as LogicalArrayType<T>>::ArrayType,
-    >>::Array<Buffer, OffsetItem, UnionLayout>: crate::arrow::Array,
+    T::ArrayType: Nullability<
+        NULLABLE,
+        Item: ArrayType<T::ArrayType, Array<Buffer, OffsetItem, UnionLayout>: crate::arrow::Array>,
+    >,
 {
-    type Array =
-        <<<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-            <T as LogicalArrayType<T>>::ArrayType,
-        >>::Array<Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::Array;
+    // ArrayTypeOf<T::ArrayType, Buffer, OffsetItem, UnionLayout, NullableItem<NULLABLE, T::ArrayType>>
+    type Array = <NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::Array;
 
     fn as_field(name: &str) -> arrow_schema::Field {
-        <<<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-            <T as LogicalArrayType<T>>::ArrayType,
-        >>::Array<Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::as_field(name)
+        <NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::as_field(name)
     }
 
     fn data_type() -> arrow_schema::DataType {
-        <<<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-            <T as LogicalArrayType<T>>::ArrayType,
-        >>::Array<Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::data_type()
+        <NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::data_type()
     }
 }
 
@@ -58,12 +50,13 @@ impl<
     for LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>
 where
     Option<T>: ArrayType<T>,
-    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
-    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
-        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
-    <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-        <T as LogicalArrayType<T>>::ArrayType,
-    >>::Array<Buffer, OffsetItem, UnionLayout>: From<Arc<dyn arrow_array::Array>>,
+    T::ArrayType: Nullability<
+        NULLABLE,
+        Item: ArrayType<
+            T::ArrayType,
+            Array<Buffer, OffsetItem, UnionLayout>: From<Arc<dyn arrow_array::Array>>,
+        >,
+    >,
 {
     fn from(value: Arc<dyn arrow_array::Array>) -> Self {
         Self(value.into())
@@ -80,12 +73,13 @@ impl<
     for Arc<dyn arrow_array::Array>
 where
     Option<T>: ArrayType<T>,
-    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
-    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
-        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
-    <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-        <T as LogicalArrayType<T>>::ArrayType,
-    >>::Array<Buffer, OffsetItem, UnionLayout>: Into<Arc<dyn arrow_array::Array>>,
+    T::ArrayType: Nullability<
+        NULLABLE,
+        Item: ArrayType<
+            T::ArrayType,
+            Array<Buffer, OffsetItem, UnionLayout>: Into<Arc<dyn arrow_array::Array>>,
+        >,
+    >,
 {
     fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         Arc::new(value.0.into())
@@ -102,14 +96,9 @@ impl<
     for arrow_array::FixedSizeListArray
 where
     Option<T>: ArrayType<T>,
-    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
-    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
-        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
-    arrow_array::FixedSizeListArray: From<
-        <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-            <T as LogicalArrayType<T>>::ArrayType,
-        >>::Array<Buffer, OffsetItem, UnionLayout>,
-    >,
+    T::ArrayType: Nullability<NULLABLE, Item: ArrayType<T::ArrayType>>,
+    arrow_array::FixedSizeListArray:
+        From<NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout>>,
 {
     fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         value.0.into()
@@ -126,14 +115,9 @@ impl<
     for arrow_array::FixedSizeBinaryArray
 where
     Option<T>: ArrayType<T>,
-    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
-    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
-        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
-    arrow_array::FixedSizeBinaryArray: From<
-        <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-            <T as LogicalArrayType<T>>::ArrayType,
-        >>::Array<Buffer, OffsetItem, UnionLayout>,
-    >,
+    T::ArrayType: Nullability<NULLABLE, Item: ArrayType<T::ArrayType>>,
+    arrow_array::FixedSizeBinaryArray:
+        From<NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout>>,
 {
     fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         value.0.into()
@@ -151,14 +135,9 @@ impl<
     for arrow_array::GenericListArray<O>
 where
     Option<T>: ArrayType<T>,
-    <T as LogicalArrayType<T>>::ArrayType: Nullability<NULLABLE>,
-    <<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item:
-        ArrayType<<T as LogicalArrayType<T>>::ArrayType>,
-    arrow_array::GenericListArray<O>: From<
-        <<<T as LogicalArrayType<T>>::ArrayType as Nullability<NULLABLE>>::Item as ArrayType<
-            <T as LogicalArrayType<T>>::ArrayType,
-        >>::Array<Buffer, OffsetItem, UnionLayout>,
-    >,
+    T::ArrayType: Nullability<NULLABLE, Item: ArrayType<T::ArrayType>>,
+    arrow_array::GenericListArray<O>:
+        From<NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout>>,
 {
     fn from(value: LogicalArray<T, NULLABLE, Buffer, OffsetItem, UnionLayout>) -> Self {
         value.0.into()

--- a/src/arrow/array/logical.rs
+++ b/src/arrow/array/logical.rs
@@ -28,7 +28,6 @@ where
         Item: ArrayType<T::ArrayType, Array<Buffer, OffsetItem, UnionLayout>: crate::arrow::Array>,
     >,
 {
-    // ArrayTypeOf<T::ArrayType, Buffer, OffsetItem, UnionLayout, NullableItem<NULLABLE, T::ArrayType>>
     type Array = <NullableArrayTypeOf<NULLABLE, T::ArrayType, Buffer, OffsetItem, UnionLayout> as crate::arrow::Array>::Array;
 
     fn as_field(name: &str) -> arrow_schema::Field {


### PR DESCRIPTION
I added 3 type aliases for commonly used complex types, greatly simplifying the type signatures making use of them.