### PR TITLE
chore: use `release-plz`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,83 +1,46 @@
 name: Release
 
-on: workflow_dispatch
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
 
 jobs:
-  changelog:
-    name: Changelog
-    runs-on: ubuntu-latest
-    concurrency: release
-    outputs:
-      skip: ${{ steps.changelog.outputs.skip }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
-            ${{ runner.os }}-cargo-
-      - run: cargo install cargo-smart-release@^0.21 --locked || true
-      - run: cargo check --workspace --all-targets --all-features
-      - id: changelog
-        run: cargo changelog --no-preview narrow narrow-derive || echo "skip=true" >> "$GITHUB_OUTPUT"
-
   release:
     name: Release
-    needs: changelog
     runs-on: ubuntu-latest
-    concurrency: release
-    if: needs.changelog.outputs.skip != 'true'
     environment:
       name: crates-io
-      url: https://crates.io/crates/narrow/${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.PAT }}
       - uses: dtolnay/rust-toolchain@stable
-        id: rust-toolchain
-      - uses: actions/cache@v4
+      - uses: MarcoIeni/release-plz-action@v0.5.83
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-release-
-            ${{ runner.os }}-cargo-${{ steps.rust-toolchain.outputs.cachekey }}-
-            ${{ runner.os }}-cargo-
-      - run: cargo install cargo-smart-release@^0.21 --locked || true
-      - run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-          GH_TOKEN: ${{ secrets.PAT }}
-        run: |
-          cargo smart-release \
-            --update-crates-index \
-            --allow-fully-generated-changelogs \
-            --no-changelog-preview \
-            --verbose \
-            --execute \
-            narrow narrow-derive
-      - id: version
+          command: release
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
-        run: echo "version=$(gh release view --json tagName -t '{{ slice .tagName 1 }}')" >> "$GITHUB_OUTPUT"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+  pr:
+    name: PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: MarcoIeni/release-plz-action@v0.5.83
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace.package]
+version = "0.11.1"
 authors = ["Matthijs Brobbel <m1brobbel@gmail.com>"]
 edition = "2021"
 rust-version = "1.79.0"
@@ -15,7 +16,7 @@ members = ["narrow-derive"]
 
 [package]
 name = "narrow"
-version = "0.11.1"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -48,7 +49,7 @@ arrow-array = { version = "53.2.0", default-features = false, optional = true }
 arrow-buffer = { version = "53.1.0", default-features = false, optional = true }
 arrow-schema = { version = "53.1.0", default-features = false, optional = true }
 chrono = { version = "0.4.38", default-features = false, optional = true }
-narrow-derive = { path = "narrow-derive", version = "^0.7.2", optional = true }
+narrow-derive = { path = "narrow-derive", version = "0.11.1", optional = true }
 uuid = { version = "1.11.0", default-features = false, optional = true }
 
 [dev-dependencies]

--- a/narrow-derive/Cargo.toml
+++ b/narrow-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "narrow-derive"
-version = "0.7.2"
+version.workspace = true
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,11 @@
+[workspace]
+release_always = false
+changelog_path = "./CHANGELOG.md"
+
+[[package]]
+name = "narrow"
+version_group = "narrow"
+
+[[package]]
+name = "narrow-derive"
+version_group = "narrow"


### PR DESCRIPTION
This helps to clean up the release process by using `release-plz`. This allows us to:
- Use a single workspace version for both crates
- Get a release PR that when merged creates a new release
- Setup branch protection and remove PAT secret