### PR TITLE
ci: switch to `arm64` hosted runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,4 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-      - dependency-name: "dtolnay/install"
       - dependency-name: "dtolnay/rust-toolchain"

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   run:
     name: Bench
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -40,7 +40,7 @@ jobs:
   deploy:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: run
     environment:
       name: benchmark-results

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   rustdoc:
     name: Rustdoc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       RUSTDOCFLAGS: -Dwarnings
     steps:
@@ -31,7 +31,7 @@ jobs:
   deploy:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     needs: rustdoc
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         id: rust-toolchain
-      - uses: dtolnay/install@cargo-docs-rs
+      - run: cargo install --locked cargo-docs-rs
       - run: cargo docs-rs
       - run: mv "target/$(rustc -vV | awk '/^host/ { print $2 }')/doc" "target/doc"
       - run: chmod -c -R +rX "target/doc"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     environment:
       name: crates-io
     steps:
@@ -35,7 +35,7 @@ jobs:
 
   pr:
     name: PR
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install --locked cargo-expand
       - uses: dtolnay/rust-toolchain@1.79.0
         id: rust-toolchain
-      - uses: dtolnay/install@master
-        with:
-          crate: cargo-expand
       - uses: actions/cache@v4
         with:
           path: |
@@ -40,13 +39,12 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install --locked cargo-expand
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
           components: clippy, rustfmt
-      - uses: dtolnay/install@master
-        with:
-          crate: cargo-expand
       - uses: actions/cache@v4
         with:
           path: |
@@ -102,13 +100,12 @@ jobs:
       RUSTDOCFLAGS: "-C instrument-coverage"
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+      - run: cargo install --locked cargo-expand
       - uses: dtolnay/rust-toolchain@stable
         id: rust-toolchain
         with:
           components: llvm-tools-preview
-      - uses: dtolnay/install@master
-        with:
-          crate: cargo-expand
       - uses: actions/cache@v4
         with:
           path: |
@@ -127,7 +124,7 @@ jobs:
         env:
           LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"
       - name: Install grcov
-        run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-x86_64-unknown-linux-gnu.tar.bz2 | tar jxf -
+        run: curl -L https://github.com/mozilla/grcov/releases/latest/download/grcov-aarch64-unknown-linux-gnu.tar.bz2 | tar jxf -
       - name: grcov
         run: ./grcov --branch --binary-path ./target/debug/ --source-dir . --output-type lcov --output-path lcov.info .
       - uses: codecov/codecov-action@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   msrv:
     name: Minimum supported Rust version
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@1.79.0
@@ -37,7 +37,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -72,7 +72,7 @@ jobs:
 
   miri:
     name: Miri
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@miri
@@ -96,7 +96,7 @@ jobs:
 
   coverage:
     name: Coverage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     env:
       RUSTFLAGS: "-C instrument-coverage"
       RUSTDOCFLAGS: "-C instrument-coverage"


### PR DESCRIPTION
These have better power-efficiency.