### PR TITLE
chore: remove `doc_cfg` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://raw.githubusercontent.com/mbrobbel/narrow/main/narrow.svg",
     html_favicon_url = "https://raw.githubusercontent.com/mbrobbel/narrow/main/narrow.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg, doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 // The goal of the list of lints here is to help reduce complexity and improve consistency
 #![deny(
     // Rustc


### PR DESCRIPTION
We don't need it because we use `doc_auto_cfg`.