### PR TITLE
feat: add `Buffer` traits

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,0 +1,169 @@
+//! Buffers for data.
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    marker::PhantomData,
+    rc::Rc,
+    sync::Arc,
+};
+
+use crate::{
+    collection::{Collection, CollectionAlloc, CollectionMut},
+    fixed_size::FixedSize,
+};
+
+/// A [`Buffer`] constructor for [`FixedSize`] types.
+pub trait BufferType {
+    /// A [`Buffer`] for [`FixedSize`] items of type `T`.
+    type Buffer<T: FixedSize>: Buffer<T>;
+}
+
+/// A [`BufferType`] for [`[T; N]`].
+///
+/// Implements [`Buffer`] and [`BufferMut`].
+#[derive(Clone, Copy, Default)]
+pub struct ArrayBuffer<const N: usize>;
+
+impl<const N: usize> BufferType for ArrayBuffer<N> {
+    type Buffer<T: FixedSize> = [T; N];
+}
+
+/// A [`BufferType`] for [`Vec<T>`].
+///
+/// Implements [`Buffer`], [`BufferMut`] and [`BufferAlloc`].
+#[derive(Clone, Copy, Default)]
+pub struct VecBuffer;
+
+impl BufferType for VecBuffer {
+    type Buffer<T: FixedSize> = Vec<T>;
+}
+
+/// A [`BufferType`] for [`&[T]`].
+///
+/// Implements [`Buffer`].
+#[derive(Clone, Copy, Default)]
+pub struct SliceBuffer<'slice>(PhantomData<&'slice ()>);
+
+impl<'slice> BufferType for SliceBuffer<'slice> {
+    type Buffer<T: FixedSize> = &'slice [T];
+}
+
+/// A [`BufferType`] for [`&mut [T]`].
+///
+/// Implements [`Buffer`] and [`BufferMut`].
+#[derive(Clone, Copy, Default)]
+pub struct SliceMutBuffer<'slice>(PhantomData<&'slice ()>);
+
+impl<'slice> BufferType for SliceMutBuffer<'slice> {
+    type Buffer<T: FixedSize> = &'slice mut [T];
+}
+
+/// A [`BufferType`] for [`Box<[T]>`].
+///
+/// Implements [`Buffer`].
+#[derive(Clone, Copy, Default)]
+pub struct BoxBuffer;
+
+impl BufferType for BoxBuffer {
+    type Buffer<T: FixedSize> = Box<[T]>;
+}
+
+/// A [`BufferType`] for [`Rc<[T]>`].
+///
+/// Implements [`Buffer`].
+#[derive(Clone, Copy, Default)]
+pub struct RcBuffer;
+
+impl BufferType for RcBuffer {
+    type Buffer<T: FixedSize> = Rc<[T]>;
+}
+
+/// A [`BufferType`] for [`Arc<[T]>`].
+///
+/// Implements [`Buffer`].
+#[derive(Clone, Copy, Default)]
+pub struct ArcBuffer;
+
+impl BufferType for ArcBuffer {
+    type Buffer<T: FixedSize> = Arc<[T]>;
+}
+
+/// A contiguous immutable buffer.
+pub trait Buffer<T: FixedSize>: Borrow<[T]> + Collection<Item = T> {
+    /// Returns a slice containing all the items in this buffer.
+    fn as_slice(&self) -> &[T] {
+        self.borrow()
+    }
+}
+
+impl<T, U> Buffer<T> for U
+where
+    T: FixedSize,
+    U: Borrow<[T]> + Collection<Item = T>,
+{
+}
+
+/// A contiguous mutable buffer.
+pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> + CollectionMut<Item = T> {
+    /// Returns a mutable slice containing all the items in this buffer.
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        self.borrow_mut()
+    }
+}
+
+impl<T, U> BufferMut<T> for U
+where
+    T: FixedSize,
+    U: BorrowMut<[T]> + CollectionMut<Item = T>,
+{
+}
+
+/// An allocatable contiguous buffer.
+pub trait BufferAlloc<T: FixedSize>: Buffer<T> + CollectionAlloc<Item = T> {}
+
+impl<T, U> BufferAlloc<T> for U
+where
+    T: FixedSize,
+    U: Buffer<T> + CollectionAlloc<Item = T>,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[allow(clippy::assertions_on_constants)]
+    fn buffer_types() {
+        struct HasBuffer<U, T>(PhantomData<(T, U)>);
+        impl<T: FixedSize, U: Buffer<T>> HasBuffer<U, T> {
+            const IMPL: bool = true;
+        }
+        struct HasBufferMut<U, T>(PhantomData<(T, U)>);
+        impl<T: FixedSize, U: BufferMut<T>> HasBufferMut<U, T> {
+            const IMPL: bool = true;
+        }
+        struct HasBufferAlloc<U, T>(PhantomData<(T, U)>);
+        impl<T: FixedSize, U: BufferAlloc<T>> HasBufferAlloc<U, T> {
+            const IMPL: bool = true;
+        }
+
+        assert!(HasBuffer::<<VecBuffer as BufferType>::Buffer<u16>, _>::IMPL);
+        assert!(HasBufferMut::<<VecBuffer as BufferType>::Buffer<u16>, _>::IMPL);
+        assert!(HasBufferAlloc::<<VecBuffer as BufferType>::Buffer<u16>, _>::IMPL);
+
+        assert!(HasBuffer::<<ArrayBuffer<1> as BufferType>::Buffer<u16>, _>::IMPL);
+        assert!(HasBufferMut::<<ArrayBuffer<1> as BufferType>::Buffer<u16>, _>::IMPL);
+
+        assert!(HasBuffer::<<SliceMutBuffer<'_> as BufferType>::Buffer<u16>, _>::IMPL);
+        assert!(HasBufferMut::<<SliceMutBuffer<'_> as BufferType>::Buffer<u16>, _>::IMPL);
+
+        assert!(HasBuffer::<<SliceBuffer<'_> as BufferType>::Buffer<u16>, _>::IMPL);
+
+        assert!(HasBuffer::<<BoxBuffer as BufferType>::Buffer<u16>, _>::IMPL);
+
+        assert!(HasBuffer::<<RcBuffer as BufferType>::Buffer<u16>, _>::IMPL);
+
+        assert!(HasBuffer::<<ArcBuffer as BufferType>::Buffer<u16>, _>::IMPL);
+    }
+}

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,15 +1,7 @@
 //! Collections of items.
 
 use std::{
-    array,
-    borrow::Borrow,
-    collections::{VecDeque, vec_deque},
-    iter::Copied,
-    marker::PhantomData,
-    rc::Rc,
-    slice,
-    sync::Arc,
-    vec,
+    array, borrow::Borrow, iter::Copied, marker::PhantomData, rc::Rc, slice, sync::Arc, vec,
 };
 
 use crate::length::Length;
@@ -62,7 +54,9 @@ pub trait CollectionMut: Collection {
 }
 
 /// An allocatable collection of items.
-pub trait CollectionAlloc: Collection + Default + Extend<Self::Item> {
+pub trait CollectionAlloc:
+    Collection + Default + Extend<Self::Item> + FromIterator<Self::Item>
+{
     /// Constructs a new, empty collection with at least the specified capacity.
     fn with_capacity(capacity: usize) -> Self;
 
@@ -374,64 +368,6 @@ impl<T: Copy> Collection for Arc<[T]> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.into()
-    }
-}
-
-impl<T: Copy> Collection for VecDeque<T> {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
-    }
-
-    type Iter<'collection>
-        = vec_deque::Iter<'collection, T>
-    where
-        Self: 'collection;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self)
-    }
-
-    type IntoIter = vec_deque::IntoIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        <Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: Copy> CollectionMut for VecDeque<T> {
-    type RefItemMut<'collection>
-        = &'collection mut T
-    where
-        Self: 'collection;
-
-    fn index_mut(&mut self, index: usize) -> Option<Self::RefItemMut<'_>> {
-        self.get_mut(index)
-    }
-
-    type IterMut<'collection>
-        = vec_deque::IterMut<'collection, T>
-    where
-        Self: 'collection;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        <&mut Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: Copy> CollectionAlloc for VecDeque<T> {
-    fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
-    }
-
-    fn reserve(&mut self, additional: usize) {
-        Self::reserve(self, additional);
     }
 }
 

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -1,0 +1,28 @@
+//! Fixed-size types.
+
+use std::mem;
+
+/// Fixed-size types.
+pub trait FixedSize: Copy + 'static {
+    /// The size of this type in bytes.
+    const SIZE: usize = mem::size_of::<Self>();
+}
+
+impl FixedSize for u8 {}
+impl FixedSize for u16 {}
+impl FixedSize for u32 {}
+impl FixedSize for u64 {}
+impl FixedSize for u128 {}
+impl FixedSize for usize {}
+
+impl FixedSize for i8 {}
+impl FixedSize for i16 {}
+impl FixedSize for i32 {}
+impl FixedSize for i64 {}
+impl FixedSize for i128 {}
+impl FixedSize for isize {}
+
+impl FixedSize for f32 {}
+impl FixedSize for f64 {}
+
+impl<T: FixedSize, const N: usize> FixedSize for [T; N] {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,7 @@
     unsafe_op_in_unsafe_fn
 )]
 
+pub mod buffer;
 pub mod collection;
+pub mod fixed_size;
 pub mod length;


### PR DESCRIPTION
Adds buffer traits: `Buffer`, `BufferMut`, and `BufferAlloc`, and the `FixedSize` trait. Buffer are contiguous (in memory) collections (`Borrow<[T]>` for `T: FixedSize`).
