### PR TITLE
feat: add `Bitmap` collection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,9 @@ num-traits = { version = "0.2.19" }
 lto = true
 codegen-units = 1
 
-# [[bench]]
-# name = "narrow"
-# harness = false
+[[bench]]
+name = "narrow"
+harness = false
 # required-features = ["arrow-rs"]
 
 # [[example]]

--- a/benches/narrow/bitmap/iter.rs
+++ b/benches/narrow/bitmap/iter.rs
@@ -1,5 +1,5 @@
 use criterion::{BenchmarkId, Criterion, Throughput};
-use narrow::{bitmap::Bitmap, buffer::BoxBuffer};
+use narrow::{bitmap::Bitmap, buffer::BoxBuffer, collection::Collection};
 use rand::{Rng, SeedableRng, prelude::SmallRng};
 use std::time::Duration;
 
@@ -40,7 +40,7 @@ pub(super) fn bench(c: &mut Criterion) {
                 group.bench_with_input(
                     BenchmarkId::new("narrow", format!("{size}/{null_fraction}")),
                     &(),
-                    |b, _| b.iter(|| Vec::<bool>::from_iter(&narrow_bitmap)),
+                    |b, _| b.iter(|| Vec::<bool>::from_iter(narrow_bitmap.iter())),
                 );
             }
         }

--- a/benches/narrow/main.rs
+++ b/benches/narrow/main.rs
@@ -1,13 +1,13 @@
-// use criterion::{Criterion, criterion_group, criterion_main};
+use criterion::{Criterion, criterion_group, criterion_main};
 
-// mod bitmap;
+mod bitmap;
 // mod versus;
 
-// criterion_group! {
-//   name = narrow;
-//   config = Criterion::default();
-//   targets =
-//     bitmap::bench,
+criterion_group! {
+  name = narrow;
+  config = Criterion::default();
+  targets =
+    bitmap::bench,
 //     versus::arrow::primitive::bench,
-// }
-// criterion_main!(narrow);
+}
+criterion_main!(narrow);

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -1,0 +1,272 @@
+//! A collection of bits.
+
+mod packed;
+mod unpacked;
+
+use std::{
+    borrow::Borrow,
+    iter::{Skip, Take},
+};
+
+use packed::BitPackedExt;
+use unpacked::{BitUnpacked, BitUnpackedExt};
+
+use crate::{
+    buffer::{BufferType, VecBuffer},
+    collection::{self, Collection, CollectionAlloc, CollectionRealloc, Item},
+    length::Length,
+};
+
+/// Returns the number of bytes required to store the given number of bits.
+#[inline]
+pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
+    bits.saturating_add(7) / 8
+}
+
+/// A collection of bits.
+///
+/// The validity bits are stored LSB-first in the bytes of a buffer.
+pub struct Bitmap<Buffer: BufferType = VecBuffer> {
+    /// The bits of the bitmap are stored in this buffer of bytes.
+    buffer: Buffer::Buffer<u8>,
+
+    /// The number of bits stored in the bitmap.
+    bits: usize,
+
+    /// An offset (in number of bits) in the buffer. This enables zero-copy
+    /// slicing of the bitmap on non-byte boundaries.
+    offset: usize,
+}
+
+impl<Buffer: BufferType> Bitmap<Buffer> {
+    /// Returns the bit index for the element at the provided index.
+    /// See [`Bitmap::byte_index`].
+    // TODO: clippy cast
+    #[inline]
+    #[allow(clippy::as_conversions, clippy::cast_possible_truncation)]
+    pub fn bit_index(&self, index: usize) -> u8 {
+        ((self.offset + index) % 8) as u8
+    }
+
+    /// Returns the byte index for the element at the provided index.
+    /// See [`Bitmap::bit_index`].
+    #[inline]
+    pub fn byte_index(&self, index: usize) -> usize {
+        (self.offset + index) / 8
+    }
+
+    /// Returns the number of leading padding bits in the first byte(s) of the
+    /// buffer that contain no meaningful bits. These bits should be ignored
+    /// when inspecting the raw byte buffer.
+    #[inline]
+    pub fn leading_bits(&self) -> usize {
+        self.offset
+    }
+
+    /// Returns the number of trailing padding bits in the last byte of the
+    /// buffer that contain no meaningful bits. These bits should be ignored when
+    /// inspecting the raw byte buffer.
+    // TODO: clippy cast
+    #[inline]
+    #[allow(clippy::as_conversions)]
+    pub fn trailing_bits(&self) -> usize {
+        let trailing_bits = self.bit_index(self.bits) as usize;
+        if trailing_bits == 0 {
+            0
+        } else {
+            8 - trailing_bits
+        }
+    }
+}
+
+impl<Buffer: BufferType<Buffer<u8>: Clone>> Clone for Bitmap<Buffer> {
+    fn clone(&self) -> Self {
+        Self {
+            buffer: self.buffer.clone(),
+            bits: self.bits,
+            offset: self.offset,
+        }
+    }
+}
+
+impl<Buffer: BufferType<Buffer<u8>: Default>> Default for Bitmap<Buffer> {
+    fn default() -> Self {
+        Self {
+            buffer: Default::default(),
+            bits: 0,
+            offset: 0,
+        }
+    }
+}
+
+impl<Buffer: BufferType> Length for Bitmap<Buffer> {
+    fn len(&self) -> usize {
+        self.bits
+    }
+}
+
+impl<Buffer: BufferType> IntoIterator for Bitmap<Buffer> {
+    type Item = bool;
+    type IntoIter = Take<
+        Skip<BitUnpacked<<<Buffer as BufferType>::Buffer<u8> as Collection<u8>>::IntoIter, u8>>,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.buffer
+            .into_iter()
+            .bit_unpacked()
+            .skip(self.offset)
+            .take(self.bits)
+    }
+}
+
+impl<'bitmap, Buffer: BufferType> IntoIterator for &'bitmap Bitmap<Buffer> {
+    type Item = bool;
+    type IntoIter = Take<
+        Skip<
+            BitUnpacked<<<Buffer as BufferType>::Buffer<u8> as Collection<u8>>::Iter<'bitmap>, u8>,
+        >,
+    >;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.buffer
+            .iter()
+            .bit_unpacked()
+            .skip(self.offset)
+            .take(self.bits)
+    }
+}
+
+impl<T: Borrow<bool>, Buffer: BufferType<Buffer<u8>: CollectionRealloc<u8>>> Extend<T>
+    for Bitmap<Buffer>
+{
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        let mut additional = 0;
+        self.buffer.extend(
+            iter.into_iter()
+                .inspect(|_| {
+                    additional += 1;
+                })
+                .bit_packed(),
+        );
+        self.bits += additional;
+    }
+}
+
+impl<T: Borrow<bool>, Buffer: BufferType<Buffer<u8>: CollectionAlloc<u8>>> FromIterator<T>
+    for Bitmap<Buffer>
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut bits = 0;
+        let buffer = iter
+            .into_iter()
+            .inspect(|_| {
+                bits += 1;
+            })
+            .bit_packed()
+            .collect();
+        Self {
+            buffer,
+            bits,
+            offset: 0,
+        }
+    }
+}
+
+impl<Buffer: BufferType> Collection<bool> for Bitmap<Buffer> {
+    fn index(&self, index: usize) -> Option<<bool as collection::Item>::RefItem<'_>> {
+        (index < self.len())
+            .then(|| self.buffer.index(self.byte_index(index)))
+            .flatten()
+            .map(|byte| byte & (1 << self.bit_index(index)) != 0)
+            .map(|bool| bool.as_ref_item())
+    }
+
+    type Iter<'collection>
+        = <&'collection Self as IntoIterator>::IntoIter
+    where
+        Self: 'collection;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        <&Self as IntoIterator>::into_iter(self)
+    }
+
+    type IntoIter = <Self as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <Self as IntoIterator>::into_iter(self)
+    }
+}
+
+impl<Buffer: BufferType<Buffer<u8>: CollectionAlloc<u8>>> CollectionAlloc<bool> for Bitmap<Buffer> {
+    fn with_capacity(capacity: usize) -> Self {
+        Self {
+            buffer: Buffer::Buffer::<u8>::with_capacity(bytes_for_bits(capacity)),
+            bits: 0,
+            offset: 0,
+        }
+    }
+}
+
+impl<Buffer: BufferType<Buffer<u8>: CollectionRealloc<u8>>> CollectionRealloc<bool>
+    for Bitmap<Buffer>
+{
+    fn reserve(&mut self, additional: usize) {
+        self.buffer.reserve(bytes_for_bits(additional));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{buffer::SliceBuffer, collection::Collection};
+
+    use super::*;
+
+    #[test]
+    fn from_iter() {
+        let input = [true, false, true, true];
+        let bitmap = Bitmap::<VecBuffer>::from_iter(input);
+        assert_eq!(
+            input,
+            IntoIterator::into_iter(bitmap)
+                .collect::<Vec<_>>()
+                .as_slice()
+        );
+    }
+
+    #[test]
+    fn extend() {
+        let input = [true, false, true, true];
+        let mut bitmap = Bitmap::<VecBuffer>::from_iter(input);
+        bitmap.extend([false, false, false]);
+        assert_eq!(bitmap.len(), 7);
+    }
+
+    #[test]
+    fn slice_buffer() {
+        let slice = &[0b1010_0000];
+        let bitmap: Bitmap<SliceBuffer> = Bitmap {
+            buffer: slice,
+            bits: 3,
+            offset: 4,
+        };
+        assert_eq!(bitmap.len(), 3);
+        assert_eq!(bitmap.leading_bits(), 4);
+        assert_eq!(bitmap.trailing_bits(), 1);
+        assert_eq!(bitmap.index(0), Some(false));
+        assert_eq!(bitmap.index(1), Some(true));
+        assert_eq!(bitmap.index(2), Some(false));
+        assert_eq!((&bitmap).into_iter().filter(|x| !*x).count(), 2);
+        assert_eq!((&bitmap).into_iter().filter(|x| *x).count(), 1);
+        assert_eq!(
+            IntoIterator::into_iter(bitmap).collect::<Vec<_>>(),
+            [false, true, false]
+        );
+    }
+
+    #[test]
+    fn alloc() {
+        let bitmap = Bitmap::<VecBuffer>::with_capacity(15);
+        assert_eq!(bitmap.buffer.capacity(), 2);
+    }
+}

--- a/src/bitmap/packed.rs
+++ b/src/bitmap/packed.rs
@@ -1,0 +1,129 @@
+//! An iterator that packs boolean values.
+
+use std::borrow::Borrow;
+
+use super::bytes_for_bits;
+
+/// An iterator that packs boolean values as bits in bytes using
+/// least-significant bit (LSB) numbering.
+///
+/// Wraps around an iterator (`I`) over items (`T`) that can be borrowed as
+/// boolean values.
+pub struct BitPacked<I, T>
+where
+    I: Iterator<Item = T>,
+    T: Borrow<bool>,
+{
+    /// The inner iterator with boolean values.
+    iter: I,
+}
+
+impl<I, T> Iterator for BitPacked<I, T>
+where
+    I: Iterator<Item = T>,
+    T: Borrow<bool>,
+{
+    type Item = u8;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        // Get the next item from the inner iterator or return None if the inner
+        // iterator is finished.
+        self.iter.next().map(|next| {
+            // Set the least significant bit based on the first boolean value.
+            let mut byte = u8::from(*next.borrow());
+            for bit_position in 1..8 {
+                // If the inner iterator has more boolean values and they are set
+                // (`true`), set the corresponding bit in the output byte.
+                if let Some(x) = self.iter.next() {
+                    if *x.borrow() {
+                        byte |= 1 << bit_position;
+                    }
+                }
+            }
+            byte
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+
+        // One item is returned per 8 items in the inner iterator.
+        (bytes_for_bits(lower), upper.map(bytes_for_bits))
+    }
+
+    // todo(mb): advance_by, nth
+}
+
+// If the inner iterator is [`ExactSizeIterator`], the bounds reported by
+// the size hint of this iterator are exact.
+impl<I, T> ExactSizeIterator for BitPacked<I, T>
+where
+    I: ExactSizeIterator<Item = T>,
+    T: Borrow<bool>,
+{
+}
+
+/// An [`Iterator`] extension trait for [`BitPacked`].
+pub trait BitPackedExt<T>: Iterator<Item = T>
+where
+    T: Borrow<bool>,
+{
+    /// Packs the items in this iterator that can be borrowed as boolean values
+    /// as bits in bytes using least-significant bit (LSB) numbering.
+    fn bit_packed(self) -> BitPacked<Self, T>
+    where
+        Self: Sized,
+    {
+        BitPacked { iter: self }
+    }
+}
+
+impl<I, T> BitPackedExt<T> for I
+where
+    I: Iterator<Item = T>,
+    T: Borrow<bool>,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iter() {
+        let mut iter = [false, true, false, true, false, true].iter().bit_packed();
+        assert_eq!(iter.next(), Some(0x2a));
+        assert!(iter.next().is_none());
+        let mut iter_byte = [false, true, false, true, false, true, false, true]
+            .iter()
+            .bit_packed();
+        assert_eq!(iter_byte.next(), Some(0xaa));
+        assert!(iter_byte.next().is_none());
+        let iter_two = [true; 16].iter().bit_packed();
+        assert_eq!(iter_two.collect::<Vec<u8>>(), [0xff, 0xff]);
+    }
+
+    #[test]
+    fn size_hint() {
+        assert_eq!((0, Some(0)), [].iter().bit_packed().size_hint());
+        assert_eq!((1, Some(1)), [false].iter().bit_packed().size_hint());
+        assert_eq!((1, Some(1)), [false; 7].iter().bit_packed().size_hint());
+        assert_eq!((1, Some(1)), [false; 8].iter().bit_packed().size_hint());
+        assert_eq!((2, Some(2)), [false; 9].iter().bit_packed().size_hint());
+        assert_eq!(
+            (usize::MAX / 8, None),
+            (0..).map(|_| true).bit_packed().size_hint()
+        );
+        assert_eq!(
+            (usize::MAX / 8, None),
+            (0..=usize::MAX).map(|_| true).bit_packed().size_hint()
+        );
+        assert_eq!(
+            (usize::MAX / 8, Some(usize::MAX / 8)),
+            (0..usize::MAX).map(|_| true).bit_packed().size_hint()
+        );
+        assert_eq!((1, Some(1)), (0..3).map(|_| true).bit_packed().size_hint());
+    }
+}

--- a/src/bitmap/unpacked.rs
+++ b/src/bitmap/unpacked.rs
@@ -1,0 +1,119 @@
+//! An iterator that unpacks boolean values.
+
+use std::borrow::Borrow;
+
+/// An iterator that unpacks boolean values from an iterator (`I`) over items
+/// (`T`) that can be borrowed as bytes, by interpreting the bits of these bytes
+/// with least-significant bit (LSB) numbering as boolean values i.e. `1` maps
+/// to `true` and `0` maps to `false`.
+///
+// note: add to docs that users should combine this with std::iter::skip and
+// std::iter::take if needed for padding
+pub struct BitUnpacked<I, T>
+where
+    I: Iterator<Item = T>,
+    T: Borrow<u8>,
+{
+    /// The iterator over the bytes storing packed bits.
+    iter: I,
+    /// The popped byte yielding bits.
+    byte: Option<u8>,
+    /// The mask selecting bits from the popped byte.
+    mask: u8,
+}
+
+impl<I, T> Iterator for BitUnpacked<I, T>
+where
+    I: Iterator<Item = T>,
+    T: Borrow<u8>,
+{
+    type Item = bool;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        // Check if we need to fetch the next byte from the inner iterator.
+        if self.mask == 0x01 {
+            self.byte = self.iter.next().map(|item| *item.borrow());
+        }
+
+        // If we have a byte there are still boolean values to yield.
+        self.byte.map(|byte| {
+            let next = (byte & self.mask) != 0;
+            self.mask = self.mask.rotate_left(1);
+            next
+        })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (lower, upper) = self.iter.size_hint();
+
+        // 8 items are returned per one item in the inner iterator.
+        (
+            lower.saturating_mul(8),
+            upper.and_then(|bound| bound.checked_mul(8)),
+        )
+    }
+
+    // todo(mb): advance_by, nth
+}
+
+// If the inner iterator is ExactSizeIterator, the bounds reported by
+// the size hint of this iterator are exact.
+impl<I, T> ExactSizeIterator for BitUnpacked<I, T>
+where
+    I: ExactSizeIterator<Item = T>,
+    T: Borrow<u8>,
+{
+}
+
+/// An [`Iterator`] extension trait for [`BitUnpacked`].
+pub trait BitUnpackedExt<T>: IntoIterator<Item = T>
+where
+    T: Borrow<u8>,
+{
+    /// Returns an iterator that unpacks bits from the bytes in the iterator.
+    fn bit_unpacked(self) -> BitUnpacked<Self::IntoIter, T>
+    where
+        Self: Sized,
+    {
+        BitUnpacked {
+            iter: self.into_iter(),
+            byte: None,
+            mask: 0x01,
+        }
+    }
+}
+
+impl<I, T> BitUnpackedExt<T> for I
+where
+    I: IntoIterator<Item = T>,
+    T: Borrow<u8>,
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iter() {
+        let iter = [u8::MAX, 1].iter().bit_unpacked();
+        assert_eq!(
+            iter.collect::<Vec<_>>(),
+            vec![
+                true, true, true, true, true, true, true, true, true, false, false, false, false,
+                false, false, false
+            ]
+        );
+    }
+
+    #[test]
+    fn size_hint() {
+        let input = [u8::MAX, 1, 2, 3];
+        assert_eq!(
+            input.iter().bit_unpacked().size_hint(),
+            (input.len() * 8, Some(input.len() * 8))
+        );
+    }
+}

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,26 +1,42 @@
 //! Collections of items.
 
 use std::{
-    array, borrow::Borrow, iter::Copied, marker::PhantomData, rc::Rc, slice, sync::Arc, vec,
+    array,
+    borrow::Borrow,
+    iter::{Copied, Map},
+    marker::PhantomData,
+    rc::Rc,
+    slice,
+    sync::Arc,
+    vec,
 };
 
 use crate::length::Length;
 
-/// A collection of items.
-pub trait Collection: Length {
-    /// The items in this collection.
-    type Item;
+/// An item that can be stored in a [`Collection`].
+pub trait Item: Sized + 'static {
+    /// A reference type for this item when stored in a collection.
+    type RefItem<'collection>;
 
-    /// Reference type of items in this collection.
-    type RefItem<'collection>
-    where
-        Self: 'collection;
+    /// Borrow this items as [`Item::RefItem`].
+    fn as_ref_item(&self) -> Self::RefItem<'_>;
 
+    /// Converts a reference to [`Item::RefItem`] to an owned [`Item`].
+    fn to_owned(item: &Self::RefItem<'_>) -> Self;
+
+    /// Converts [`Item::RefItem`] into an owned [`Item`].
+    fn into_owned(item: Self::RefItem<'_>) -> Self {
+        <Self as Item>::to_owned(&item)
+    }
+}
+
+/// A collection of items `T`.
+pub trait Collection<T: Item>: Length {
     /// Returns a reference to an item in this collection or `None` if out of bounds.
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>>;
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>>;
 
     /// Iterator over referenced items in this collection.
-    type Iter<'collection>: Iterator<Item = Self::RefItem<'collection>>
+    type Iter<'collection>: Iterator<Item = T::RefItem<'collection>>
     where
         Self: 'collection;
 
@@ -28,61 +44,36 @@ pub trait Collection: Length {
     fn iter(&self) -> Self::Iter<'_>;
 
     /// Iterator over items in this collection.
-    type IntoIter: Iterator<Item = Self::Item>;
+    type IntoIter: Iterator<Item = T>;
 
     /// Returns an interator over items in this collection.
     fn into_iter(self) -> Self::IntoIter;
 }
 
-/// A mutable collection of items.
-pub trait CollectionMut: Collection {
-    /// Reference type of mutable items in this collection.
-    type RefItemMut<'collection>
-    where
-        Self: 'collection;
-
-    /// Returns a mutable reference to an item in this collection or `None` if out of bounds.
-    fn index_mut(&mut self, index: usize) -> Option<Self::RefItemMut<'_>>;
-
-    /// Iterator over referenced mutable items in this collection.
-    type IterMut<'collection>: Iterator<Item = Self::RefItemMut<'collection>>
-    where
-        Self: 'collection;
-
-    /// Returns an iterator over mutable references to the items in this collection.
-    fn iter_mut(&mut self) -> Self::IterMut<'_>;
-}
-
 /// An allocatable collection of items.
-pub trait CollectionAlloc:
-    Collection + Default + Extend<Self::Item> + FromIterator<Self::Item>
-{
+pub trait CollectionAlloc<T: Item>: Collection<T> + Default + FromIterator<T> {
     /// Constructs a new, empty collection with at least the specified capacity.
     fn with_capacity(capacity: usize) -> Self;
+}
 
+/// A re-allocatable collection of items.
+pub trait CollectionRealloc<T: Item>: CollectionAlloc<T> + Extend<T> {
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);
 }
 
-impl<T> Collection for Vec<T> {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
+impl<T: Item> Collection<T> for Vec<T> {
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>> {
+        self.get(index).map(T::as_ref_item)
     }
 
     type Iter<'collection>
-        = slice::Iter<'collection, T>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::RefItem<'collection>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self)
+        <&Self as IntoIterator>::into_iter(self).map(T::as_ref_item)
     }
 
     type IntoIter = vec::IntoIter<T>;
@@ -92,55 +83,30 @@ impl<T> Collection for Vec<T> {
     }
 }
 
-impl<T> CollectionMut for Vec<T> {
-    type RefItemMut<'collection>
-        = &'collection mut T
-    where
-        Self: 'collection;
-
-    fn index_mut(&mut self, index: usize) -> Option<Self::RefItemMut<'_>> {
-        self.get_mut(index)
-    }
-
-    type IterMut<'collection>
-        = slice::IterMut<'collection, T>
-    where
-        Self: 'collection;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        <&mut Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T> CollectionAlloc for Vec<T> {
+impl<T: Item> CollectionAlloc<T> for Vec<T> {
     fn with_capacity(capacity: usize) -> Self {
         Self::with_capacity(capacity)
     }
+}
 
+impl<T: Item> CollectionRealloc<T> for Vec<T> {
     fn reserve(&mut self, additional: usize) {
         Self::reserve(self, additional);
     }
 }
 
-impl<T, const N: usize> Collection for [T; N] {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
+impl<T: Item, const N: usize> Collection<T> for [T; N] {
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>> {
+        self.get(index).map(T::as_ref_item)
     }
 
     type Iter<'collection>
-        = slice::Iter<'collection, T>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::RefItem<'collection>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self)
+        <&Self as IntoIterator>::into_iter(self).map(T::as_ref_item)
     }
 
     type IntoIter = array::IntoIter<T, N>;
@@ -150,45 +116,18 @@ impl<T, const N: usize> Collection for [T; N] {
     }
 }
 
-impl<T, const N: usize> CollectionMut for [T; N] {
-    type RefItemMut<'collection>
-        = &'collection mut T
-    where
-        Self: 'collection;
-
-    fn index_mut(&mut self, index: usize) -> Option<Self::RefItemMut<'_>> {
-        self.get_mut(index)
-    }
-
-    type IterMut<'collection>
-        = slice::IterMut<'collection, T>
-    where
-        Self: 'collection;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        <&mut Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<'a, T: Copy> Collection for &'a [T] {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
+impl<'a, T: Copy + Item> Collection<T> for &'a [T] {
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>> {
+        self.get(index).map(T::as_ref_item)
     }
 
     type Iter<'collection>
-        = slice::Iter<'collection, T>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::RefItem<'collection>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <Self as IntoIterator>::into_iter(self)
+        <Self as IntoIterator>::into_iter(self).map(T::as_ref_item)
     }
 
     type IntoIter = Copied<slice::Iter<'a, T>>;
@@ -198,73 +137,18 @@ impl<'a, T: Copy> Collection for &'a [T] {
     }
 }
 
-impl<'a, T: Copy> Collection for &'a mut [T] {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
+impl<T: Item> Collection<T> for Box<[T]> {
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>> {
+        self.get(index).map(T::as_ref_item)
     }
 
     type Iter<'collection>
-        = slice::Iter<'collection, T>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::RefItem<'collection>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&[T] as IntoIterator>::into_iter(self)
-    }
-
-    type IntoIter = Copied<slice::Iter<'a, T>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        <&[T] as IntoIterator>::into_iter(self).copied()
-    }
-}
-
-impl<T: Copy> CollectionMut for &mut [T] {
-    type RefItemMut<'collection>
-        = &'collection mut T
-    where
-        Self: 'collection;
-
-    fn index_mut(&mut self, index: usize) -> Option<Self::RefItemMut<'_>> {
-        self.get_mut(index)
-    }
-
-    type IterMut<'collection>
-        = slice::IterMut<'collection, T>
-    where
-        Self: 'collection;
-
-    fn iter_mut(&mut self) -> Self::IterMut<'_> {
-        <&mut [T] as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T> Collection for Box<[T]> {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
-    }
-
-    type Iter<'collection>
-        = slice::Iter<'collection, T>
-    where
-        Self: 'collection;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self)
+        <&Self as IntoIterator>::into_iter(self).map(T::as_ref_item)
     }
 
     type IntoIter = vec::IntoIter<T>;
@@ -274,8 +158,14 @@ impl<T> Collection for Box<[T]> {
     }
 }
 
+impl<T: Item> CollectionAlloc<T> for Box<[T]> {
+    fn with_capacity(capacity: usize) -> Self {
+        Vec::with_capacity(capacity).into_boxed_slice()
+    }
+}
+
 /// An iterator over copied items `T` in a slice borrowed from `U`.
-pub struct BorrowSliceIntoIter<T: Copy, U: Borrow<[T]>> {
+pub struct CopySliceIter<T: Copy, U: Borrow<[T]>> {
     /// The slice is borrowed from this field.
     data: U,
     /// The current position of this iterator.
@@ -284,7 +174,7 @@ pub struct BorrowSliceIntoIter<T: Copy, U: Borrow<[T]>> {
     _ty: PhantomData<T>,
 }
 
-impl<T: Copy, U: Borrow<[T]>> From<U> for BorrowSliceIntoIter<T, U> {
+impl<T: Copy, U: Borrow<[T]>> From<U> for CopySliceIter<T, U> {
     fn from(data: U) -> Self {
         Self {
             data,
@@ -294,7 +184,7 @@ impl<T: Copy, U: Borrow<[T]>> From<U> for BorrowSliceIntoIter<T, U> {
     }
 }
 
-impl<T: Copy, U: Borrow<[T]>> Iterator for BorrowSliceIntoIter<T, U> {
+impl<T: Copy, U: Borrow<[T]>> Iterator for CopySliceIter<T, U> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -313,58 +203,44 @@ impl<T: Copy, U: Borrow<[T]>> Iterator for BorrowSliceIntoIter<T, U> {
     }
 }
 
-impl<T: Copy, U: Borrow<[T]>> ExactSizeIterator for BorrowSliceIntoIter<T, U> {}
+impl<T: Copy, U: Borrow<[T]>> ExactSizeIterator for CopySliceIter<T, U> {}
 
-impl<T: Copy> Collection for Rc<[T]> {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
+impl<T: Copy + Item> Collection<T> for Rc<[T]> {
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>> {
+        self.get(index).map(T::as_ref_item)
     }
 
     type Iter<'collection>
-        = slice::Iter<'collection, T>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::RefItem<'collection>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&[T] as IntoIterator>::into_iter(self)
+        <&[T] as IntoIterator>::into_iter(self).map(T::as_ref_item)
     }
 
-    type IntoIter = BorrowSliceIntoIter<T, Self>;
+    type IntoIter = CopySliceIter<T, Self>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.into()
     }
 }
 
-impl<T: Copy> Collection for Arc<[T]> {
-    type Item = T;
-
-    type RefItem<'collection>
-        = &'collection T
-    where
-        Self: 'collection;
-
-    fn index(&self, index: usize) -> Option<Self::RefItem<'_>> {
-        self.get(index)
+impl<T: Copy + Item> Collection<T> for Arc<[T]> {
+    fn index(&self, index: usize) -> Option<T::RefItem<'_>> {
+        self.get(index).map(T::as_ref_item)
     }
 
     type Iter<'collection>
-        = slice::Iter<'collection, T>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::RefItem<'collection>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&[T] as IntoIterator>::into_iter(self)
+        <&[T] as IntoIterator>::into_iter(self).map(T::as_ref_item)
     }
 
-    type IntoIter = BorrowSliceIntoIter<T, Self>;
+    type IntoIter = CopySliceIter<T, Self>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.into()
@@ -378,13 +254,13 @@ mod tests {
     #[test]
     fn borrow_slice_into_iter_size_hint() {
         let input = [1, 2, 3, 4].as_slice();
-        let mut iter = BorrowSliceIntoIter::from(input);
+        let mut iter = CopySliceIter::from(input);
         assert_eq!(iter.size_hint(), (4, Some(4)));
-        let _ = iter.next();
+        let _ = Iterator::next(&mut iter);
         assert_eq!(iter.size_hint(), (3, Some(3)));
         let _ = iter.nth(2);
         assert_eq!(iter.size_hint(), (0, Some(0)));
-        let _ = iter.next();
+        let _ = Iterator::next(&mut iter);
         assert_eq!(iter.size_hint(), (0, Some(0)));
     }
 }

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -2,8 +2,10 @@
 
 use std::mem;
 
+use crate::collection::Item;
+
 /// Fixed-size types.
-pub trait FixedSize: Copy + 'static {
+pub trait FixedSize: Item + Copy {
     /// The size of this type in bytes.
     const SIZE: usize = mem::size_of::<Self>();
 }
@@ -26,3 +28,66 @@ impl FixedSize for f32 {}
 impl FixedSize for f64 {}
 
 impl<T: FixedSize, const N: usize> FixedSize for [T; N] {}
+
+/// Implements `Item` and `ItemMut` for primitive types.
+macro_rules! item_primitive {
+    ($ty:ty) => {
+        impl Item for $ty {
+            type RefItem<'collection> = Self;
+            fn as_ref_item(&self) -> Self::RefItem<'_> {
+                *self
+            }
+            fn to_owned(ref_item: &Self::RefItem<'_>) -> Self {
+                *ref_item
+            }
+            fn into_owned(ref_item: Self::RefItem<'_>) -> Self {
+                ref_item
+            }
+        }
+    };
+}
+
+item_primitive!(u8);
+item_primitive!(u16);
+item_primitive!(u32);
+item_primitive!(u64);
+item_primitive!(u128);
+item_primitive!(usize);
+
+item_primitive!(i8);
+item_primitive!(i16);
+item_primitive!(i32);
+item_primitive!(i64);
+item_primitive!(i128);
+item_primitive!(isize);
+
+item_primitive!(f32);
+item_primitive!(f64);
+
+// bools are stored as bits in collections, so we can't borrow it directly
+// instead we return a copy
+impl Item for bool {
+    type RefItem<'collection> = Self;
+    fn as_ref_item(&self) -> Self::RefItem<'_> {
+        *self
+    }
+    fn to_owned(ref_item: &Self::RefItem<'_>) -> Self {
+        *ref_item
+    }
+    fn into_owned(ref_item: Self::RefItem<'_>) -> Self {
+        ref_item
+    }
+}
+
+impl<const N: usize, T: Item + Clone> Item for [T; N] {
+    type RefItem<'collection> = &'collection [T; N];
+    fn as_ref_item(&self) -> Self::RefItem<'_> {
+        self
+    }
+    fn to_owned(ref_item: &Self::RefItem<'_>) -> Self {
+        (*ref_item).clone()
+    }
+    fn into_owned(ref_item: Self::RefItem<'_>) -> Self {
+        ref_item.clone()
+    }
+}

--- a/src/length.rs
+++ b/src/length.rs
@@ -25,6 +25,12 @@ impl<T, const N: usize> Length for [T; N] {
     }
 }
 
+impl<T> Length for [T] {
+    fn len(&self) -> usize {
+        <[T]>::len(self)
+    }
+}
+
 impl<T> Length for &[T] {
     fn len(&self) -> usize {
         <[T]>::len(self)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,14 @@
     // rustdoc::all
 )]
 #![allow(
+    clippy::into_iter_without_iter,
+    clippy::iter_not_returning_iterator,
     clippy::module_name_repetitions,
     clippy::pub_use,
     unsafe_op_in_unsafe_fn
 )]
 
+pub mod bitmap;
 pub mod buffer;
 pub mod collection;
 pub mod fixed_size;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
     // Rustdoc
     // rustdoc::all
 )]
+#![forbid(unsafe_code)]
 #![allow(
     clippy::into_iter_without_iter,
     clippy::iter_not_returning_iterator,


### PR DESCRIPTION
Adds `Bitmap` collection, storing 8 bits per byte. Removes mutable collection support, because supporting mutable iteration over a `Bitmap` requires streaming iterators, which I want to avoid for now.