### PR TITLE
refactor: use associated type for item types in `Collection`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -76,7 +76,7 @@ impl<'slice> BufferType for SliceBuffer<'slice> {
 }
 
 /// A contiguous immutable buffer.
-pub trait Buffer<T: FixedSize>: Borrow<[T]> + Collection<T> {
+pub trait Buffer<T: FixedSize>: Borrow<[T]> + Collection<Item = T> {
     /// Returns a slice containing all the items in this buffer.
     fn as_slice(&self) -> &[T] {
         self.borrow()
@@ -86,7 +86,7 @@ pub trait Buffer<T: FixedSize>: Borrow<[T]> + Collection<T> {
 impl<T, U> Buffer<T> for U
 where
     T: FixedSize,
-    U: Borrow<[T]> + Collection<T>,
+    U: Borrow<[T]> + Collection<Item = T>,
 {
 }
 
@@ -101,17 +101,17 @@ pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
 impl<T, U> BufferMut<T> for U
 where
     T: FixedSize,
-    U: BorrowMut<[T]> + Collection<T>,
+    U: BorrowMut<[T]> + Collection<Item = T>,
 {
 }
 
 /// An allocatable contiguous buffer.
-pub trait BufferAlloc<T: FixedSize>: Buffer<T> + Collection<T> {}
+pub trait BufferAlloc<T: FixedSize>: Buffer<T> + Collection<Item = T> {}
 
 impl<T, U> BufferAlloc<T> for U
 where
     T: FixedSize,
-    U: Buffer<T> + Collection<T>,
+    U: Buffer<T> + Collection<Item = T>,
 {
 }
 

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -33,14 +33,14 @@ impl<T: FixedSize, const N: usize> FixedSize for [T; N] {}
 macro_rules! item_primitive {
     ($ty:ty) => {
         impl Item for $ty {
-            type RefItem<'collection> = Self;
-            fn as_ref_item(&self) -> Self::RefItem<'_> {
+            type Ref<'collection> = Self;
+            fn as_ref(&self) -> Self::Ref<'_> {
                 *self
             }
-            fn to_owned(ref_item: &Self::RefItem<'_>) -> Self {
+            fn to_owned(ref_item: &Self::Ref<'_>) -> Self {
                 *ref_item
             }
-            fn into_owned(ref_item: Self::RefItem<'_>) -> Self {
+            fn into_owned(ref_item: Self::Ref<'_>) -> Self {
                 ref_item
             }
         }
@@ -67,27 +67,27 @@ item_primitive!(f64);
 // bools are stored as bits in collections, so we can't borrow it directly
 // instead we return a copy
 impl Item for bool {
-    type RefItem<'collection> = Self;
-    fn as_ref_item(&self) -> Self::RefItem<'_> {
+    type Ref<'collection> = Self;
+    fn as_ref(&self) -> Self::Ref<'_> {
         *self
     }
-    fn to_owned(ref_item: &Self::RefItem<'_>) -> Self {
+    fn to_owned(ref_item: &Self::Ref<'_>) -> Self {
         *ref_item
     }
-    fn into_owned(ref_item: Self::RefItem<'_>) -> Self {
+    fn into_owned(ref_item: Self::Ref<'_>) -> Self {
         ref_item
     }
 }
 
 impl<const N: usize, T: Item + Clone> Item for [T; N] {
-    type RefItem<'collection> = &'collection [T; N];
-    fn as_ref_item(&self) -> Self::RefItem<'_> {
+    type Ref<'collection> = &'collection [T; N];
+    fn as_ref(&self) -> Self::Ref<'_> {
         self
     }
-    fn to_owned(ref_item: &Self::RefItem<'_>) -> Self {
+    fn to_owned(ref_item: &Self::Ref<'_>) -> Self {
         (*ref_item).clone()
     }
-    fn into_owned(ref_item: Self::RefItem<'_>) -> Self {
+    fn into_owned(ref_item: Self::Ref<'_>) -> Self {
         ref_item.clone()
     }
 }


### PR DESCRIPTION
A collection has one item type. Also renames the associated `RefItem` type of `Item` to `Ref` (and method to `as_ref`).