### PR TITLE
fix: revert trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release
 permissions:
   pull-requests: write
   contents: write
-  id-token: write
 
 on:
   push:
@@ -27,14 +26,12 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: rust-lang/crates-io-auth-action@v1
-        id: auth
       - uses: MarcoIeni/release-plz-action@v0.5.109
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   pr:
     name: PR
@@ -42,8 +39,6 @@ jobs:
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false
-    environment:
-      name: crates-io
     steps:
       - uses: actions/create-github-app-token@v2
         id: token
@@ -55,11 +50,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.token.outputs.token }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: rust-lang/crates-io-auth-action@v1
-        id: auth
       - uses: MarcoIeni/release-plz-action@v0.5.109
         with:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ steps.token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
It doesn't work with `release-plz`, because the token can't be used to check if the crate is published.