### PR TITLE
feat!: refactor collection trait

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -5,6 +5,7 @@ mod unpacked;
 
 use std::{
     borrow::Borrow,
+    fmt::{self, Debug},
     iter::{Skip, Take},
     slice,
 };
@@ -27,7 +28,6 @@ pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
 /// A collection of bits.
 ///
 /// The validity bits are stored LSB-first in the bytes of a buffer.
-#[derive(Debug)]
 pub struct Bitmap<Buffer: BufferType = VecBuffer> {
     /// The bits of the bitmap are stored in this buffer of bytes.
     buffer: Buffer::Buffer<u8>,
@@ -38,6 +38,16 @@ pub struct Bitmap<Buffer: BufferType = VecBuffer> {
     /// An offset (in number of bits) in the buffer. This enables zero-copy
     /// slicing of the bitmap on non-byte boundaries.
     offset: usize,
+}
+
+impl<Buffer: BufferType<Buffer<u8>: Debug>> Debug for Bitmap<Buffer> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Bitmap")
+            .field("buffer", &self.buffer)
+            .field("bits", &self.bits)
+            .field("offset", &self.offset)
+            .finish()
+    }
 }
 
 impl<Buffer: BufferType> Bitmap<Buffer> {

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -48,7 +48,7 @@ impl<const N: usize> BufferType for ArrayBuffer<N> {
 
 /// A [`BufferType`] for a [`Vec`].
 ///
-/// Implements [`Buffer`], [`BufferMut`] and [`BufferAlloc`].
+/// Implements [`Buffer`], [`BufferMut`].
 #[derive(Clone, Copy, Default, Debug)]
 pub struct VecBuffer;
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,10 +10,30 @@ use std::{
 
 use crate::{collection::Collection, fixed_size::FixedSize};
 
+/// A contiguous immutable buffer.
+pub trait Buffer<T: FixedSize>: Borrow<[T]> + Debug {
+    /// Returns a slice containing all the items in this buffer.
+    fn as_slice(&self) -> &[T] {
+        self.borrow()
+    }
+}
+
+impl<T: FixedSize, U: Borrow<[T]> + Debug> Buffer<T> for U {}
+
+/// A contiguous mutable buffer.
+pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
+    /// Returns a mutable slice containing all the items in this buffer.
+    fn as_mut_slice(&mut self) -> &mut [T] {
+        self.borrow_mut()
+    }
+}
+
+impl<T: FixedSize, U: BorrowMut<[T]> + Debug> BufferMut<T> for U {}
+
 /// A [`Buffer`] constructor for [`FixedSize`] types.
 pub trait BufferType: Default + Debug {
     /// A [`Buffer`] for [`FixedSize`] items of type `T`.
-    type Buffer<T: FixedSize>: Buffer<T>;
+    type Buffer<T: FixedSize>: Buffer<T> + Collection<Owned = T>;
 }
 
 /// A [`BufferType`] for an array with `N` elements.
@@ -76,46 +96,6 @@ impl<'slice> BufferType for SliceBuffer<'slice> {
     type Buffer<T: FixedSize> = &'slice [T];
 }
 
-/// A contiguous immutable buffer.
-pub trait Buffer<T: FixedSize>: Borrow<[T]> + Collection<Item = T> + Debug {
-    /// Returns a slice containing all the items in this buffer.
-    fn as_slice(&self) -> &[T] {
-        self.borrow()
-    }
-}
-
-impl<T, U> Buffer<T> for U
-where
-    T: FixedSize,
-    U: Borrow<[T]> + Collection<Item = T> + Debug,
-{
-}
-
-/// A contiguous mutable buffer.
-pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
-    /// Returns a mutable slice containing all the items in this buffer.
-    fn as_mut_slice(&mut self) -> &mut [T] {
-        self.borrow_mut()
-    }
-}
-
-impl<T, U> BufferMut<T> for U
-where
-    T: FixedSize,
-    U: BorrowMut<[T]> + Collection<Item = T> + Debug,
-{
-}
-
-/// An allocatable contiguous buffer.
-pub trait BufferAlloc<T: FixedSize>: Buffer<T> + Collection<Item = T> {}
-
-impl<T, U> BufferAlloc<T> for U
-where
-    T: FixedSize,
-    U: Buffer<T> + Collection<Item = T>,
-{
-}
-
 #[cfg(test)]
 mod tests {
     use std::marker::PhantomData;
@@ -126,24 +106,16 @@ mod tests {
     #[allow(clippy::assertions_on_constants)]
     fn buffer_types() {
         struct HasBuffer<U, T>(PhantomData<(T, U)>);
-        impl<T: FixedSize, U: Buffer<T>> HasBuffer<U, T>
-        where
-            for<'buffer> U: 'buffer,
-        {
+        impl<T: FixedSize, U: Buffer<T>> HasBuffer<U, T> {
             const IMPL: bool = true;
         }
         struct HasBufferMut<U, T>(PhantomData<(T, U)>);
         impl<T: FixedSize, U: BufferMut<T>> HasBufferMut<U, T> {
             const IMPL: bool = true;
         }
-        struct HasBufferAlloc<U, T>(PhantomData<(T, U)>);
-        impl<T: FixedSize, U: BufferAlloc<T>> HasBufferAlloc<U, T> {
-            const IMPL: bool = true;
-        }
 
         assert!(HasBuffer::<<VecBuffer as BufferType>::Buffer<u16>, _>::IMPL);
         assert!(HasBufferMut::<<VecBuffer as BufferType>::Buffer<u16>, _>::IMPL);
-        assert!(HasBufferAlloc::<<VecBuffer as BufferType>::Buffer<u16>, _>::IMPL);
 
         assert!(HasBuffer::<<ArrayBuffer<1> as BufferType>::Buffer<u16>, _>::IMPL);
         assert!(HasBufferMut::<<ArrayBuffer<1> as BufferType>::Buffer<u16>, _>::IMPL);

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -2,7 +2,6 @@
 
 use std::{
     borrow::{Borrow, BorrowMut},
-    fmt::Debug,
     marker::PhantomData,
     rc::Rc,
     sync::Arc,
@@ -11,14 +10,14 @@ use std::{
 use crate::{collection::Collection, fixed_size::FixedSize};
 
 /// A contiguous immutable buffer.
-pub trait Buffer<T: FixedSize>: Borrow<[T]> + Debug {
+pub trait Buffer<T: FixedSize>: Borrow<[T]> {
     /// Returns a slice containing all the items in this buffer.
     fn as_slice(&self) -> &[T] {
         self.borrow()
     }
 }
 
-impl<T: FixedSize, U: Borrow<[T]> + Debug> Buffer<T> for U {}
+impl<T: FixedSize, U: Borrow<[T]>> Buffer<T> for U {}
 
 /// A contiguous mutable buffer.
 pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
@@ -28,10 +27,10 @@ pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
     }
 }
 
-impl<T: FixedSize, U: BorrowMut<[T]> + Debug> BufferMut<T> for U {}
+impl<T: FixedSize, U: BorrowMut<[T]>> BufferMut<T> for U {}
 
 /// A [`Buffer`] constructor for [`FixedSize`] types.
-pub trait BufferType: Default + Debug {
+pub trait BufferType: Default {
     /// A [`Buffer`] for [`FixedSize`] items of type `T`.
     type Buffer<T: FixedSize>: Buffer<T> + Collection<Owned = T>;
 }

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -389,6 +389,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[expect(clippy::perf, clippy::unwrap_used)]
     fn collection() {
         let a = vec![1, 2, 3, 4];
         assert_eq!(a[0].as_view(), 1);

--- a/src/collection.rs
+++ b/src/collection.rs
@@ -1,86 +1,151 @@
 //! Collections of items.
 
-use std::{
-    array,
-    borrow::Borrow,
-    iter::{Copied, Map},
-    marker::PhantomData,
-    rc::Rc,
-    slice,
-    sync::Arc,
-    vec,
-};
+use std::{array, borrow::Borrow, iter::Map, marker::PhantomData, rc::Rc, slice, sync::Arc, vec};
 
 use crate::length::Length;
 
-/// An item that can be stored in a [`Collection`].
-// can't add Default as super trait because generic arrays don't implement
-// default
-pub trait Item: Sized + 'static {
-    /// A reference type for this item when stored in a collection.
-    type Ref<'collection>;
+/// Convert into owned items.
+pub trait IntoOwned<Owned> {
+    /// Returns the owned instance of self.
+    fn into_owned(self) -> Owned;
+}
 
-    /// Borrow this items as [`Item::Ref`].
-    fn as_ref(&self) -> Self::Ref<'_>;
-
-    /// Converts a reference to [`Item::Ref`] to an owned [`Item`].
-    fn to_owned(item: &Self::Ref<'_>) -> Self;
-
-    /// Converts [`Item::Ref`] into an owned [`Item`].
-    fn into_owned(item: Self::Ref<'_>) -> Self {
-        <Self as Item>::to_owned(&item)
+impl<T> IntoOwned<T> for T {
+    fn into_owned(self) -> T {
+        self
     }
 }
 
-/// A collection of items `T`.
-pub trait Collection: Length {
-    /// The item stored in this collection.
-    type Item: Item;
+impl<T: Clone> IntoOwned<T> for &T {
+    fn into_owned(self) -> T {
+        self.clone()
+    }
+}
 
-    /// Returns a reference to an item in this collection or `None` if out of bounds.
-    fn index(&self, index: usize) -> Option<<Self::Item as Item>::Ref<'_>>;
+impl<T: Clone> IntoOwned<Vec<T>> for &[T] {
+    fn into_owned(self) -> Vec<T> {
+        self.to_vec()
+    }
+}
+
+impl<T: Clone> IntoOwned<Box<[T]>> for &[T] {
+    fn into_owned(self) -> Box<[T]> {
+        self.to_vec().into_boxed_slice()
+    }
+}
+
+impl<T: Clone> IntoOwned<Rc<[T]>> for &[T] {
+    fn into_owned(self) -> Rc<[T]> {
+        Rc::<[T]>::from(self.to_vec().into_boxed_slice())
+    }
+}
+
+impl<T: Clone> IntoOwned<Arc<[T]>> for &[T] {
+    fn into_owned(self) -> Arc<[T]> {
+        Arc::<[T]>::from(self.to_vec().into_boxed_slice())
+    }
+}
+
+/// Convert items into views.
+pub trait AsView<'collection> {
+    /// The view type.
+    type View: 'collection;
+
+    /// Returns a view of self.
+    fn as_view(&'collection self) -> Self::View;
+}
+
+impl<'collection, T: 'collection> AsView<'collection> for Vec<T> {
+    type View = &'collection [T];
+
+    fn as_view(&'collection self) -> Self::View {
+        self
+    }
+}
+
+impl<'collection, T: 'collection> AsView<'collection> for &[T] {
+    type View = &'collection [T];
+
+    fn as_view(&'collection self) -> Self::View {
+        self
+    }
+}
+
+/// The view type of T.
+pub type ViewOf<'collection, T> = <T as AsView<'collection>>::View;
+
+/// A collection of items.
+pub trait Collection: Length {
+    /// Borrowed view of an item in this collection
+    type View<'collection>
+    where
+        Self: 'collection;
+
+    /// Owned items in this collection
+    type Owned;
+
+    /// Returns a reference to an item at the given index in this collection or
+    /// `None` if out of bounds.
+    fn view(&self, index: usize) -> Option<Self::View<'_>>;
+
+    /// Returns an owned item at the given index in this collection or `None`
+    /// if out of bounds.
+    fn owned(&self, index: usize) -> Option<Self::Owned>
+    where
+        for<'collection> Self::View<'collection>: IntoOwned<Self::Owned>,
+    {
+        self.view(index).map(IntoOwned::into_owned)
+    }
 
     /// Iterator over referenced items in this collection.
-    type Iter<'collection>: Iterator<Item = <Self::Item as Item>::Ref<'collection>>
+    type Iter<'collection>: Iterator<Item = Self::View<'collection>>
     where
         Self: 'collection;
 
     /// Returns an iterator over references to the items in this collection.
     fn iter(&self) -> Self::Iter<'_>;
 
-    /// Iterator over items in this collection.
-    type IntoIter: Iterator<Item = Self::Item>;
+    /// Iterator over owned items in this collection.
+    type IntoIter: Iterator<Item = Self::Owned>;
 
     /// Returns an interator over items in this collection.
     fn into_iter(self) -> Self::IntoIter;
 }
 
 /// An allocatable collection of items.
-pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Item> {
+pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
     /// Constructs a new, empty collection with at least the specified capacity.
     fn with_capacity(capacity: usize) -> Self;
 }
 
 /// A re-allocatable collection of items.
-pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Item> {
+pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);
 }
 
-impl<T: Item> Collection for Vec<T> {
-    type Item = T;
+impl<T> Collection for Vec<T>
+where
+    for<'collection> T: AsView<'collection>,
+{
+    type View<'collection>
+        = ViewOf<'collection, T>
+    where
+        Self: 'collection;
 
-    fn index(&self, index: usize) -> Option<T::Ref<'_>> {
-        self.get(index).map(T::as_ref)
+    type Owned = T;
+
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.get(index).map(AsView::as_view)
     }
 
     type Iter<'collection>
-        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::Ref<'collection>>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> ViewOf<'collection, T>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self).map(T::as_ref)
+        <&Self as IntoIterator>::into_iter(self).map(AsView::as_view)
     }
 
     type IntoIter = vec::IntoIter<T>;
@@ -90,35 +155,46 @@ impl<T: Item> Collection for Vec<T> {
     }
 }
 
-impl<T: Item> CollectionAlloc for Vec<T> {
+impl<T> CollectionAlloc for Vec<T>
+where
+    for<'collection> T: AsView<'collection>,
+{
     fn with_capacity(capacity: usize) -> Self {
-        Self::with_capacity(capacity)
+        Vec::with_capacity(capacity)
     }
 }
 
-impl<T: Item> CollectionRealloc for Vec<T> {
+impl<T> CollectionRealloc for Vec<T>
+where
+    for<'collection> T: AsView<'collection>,
+{
     fn reserve(&mut self, additional: usize) {
-        Self::reserve(self, additional);
+        Vec::reserve(self, additional);
     }
 }
 
-impl<T: Item, const N: usize> Collection for [T; N] {
-    type Item = T;
+impl<T, const N: usize> Collection for [T; N]
+where
+    for<'collection> T: AsView<'collection>,
+{
+    type View<'collection>
+        = ViewOf<'collection, T>
+    where
+        Self: 'collection;
 
-    fn index(&self, index: usize) -> Option<<Self::Item as Item>::Ref<'_>> {
-        self.get(index).map(T::as_ref)
+    type Owned = T;
+
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.get(index).map(AsView::as_view)
     }
 
     type Iter<'collection>
-        = Map<
-        slice::Iter<'collection, T>,
-        fn(&'collection T) -> <Self::Item as Item>::Ref<'collection>,
-    >
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> ViewOf<'collection, T>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self).map(Self::Item::as_ref)
+        <&Self as IntoIterator>::into_iter(self).map(AsView::as_view)
     }
 
     type IntoIter = array::IntoIter<T, N>;
@@ -128,140 +204,180 @@ impl<T: Item, const N: usize> Collection for [T; N] {
     }
 }
 
-impl<'a, T: Copy + Item> Collection for &'a [T] {
-    type Item = T;
-
-    fn index(&self, index: usize) -> Option<T::Ref<'_>> {
-        self.get(index).map(T::as_ref)
-    }
-
-    type Iter<'collection>
-        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::Ref<'collection>>
-    where
-        Self: 'collection;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        <Self as IntoIterator>::into_iter(self).map(T::as_ref)
-    }
-
-    type IntoIter = Copied<slice::Iter<'a, T>>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        <Self as IntoIterator>::into_iter(self).copied()
-    }
-}
-
-impl<T: Item> Collection for Box<[T]> {
-    type Item = T;
-
-    fn index(&self, index: usize) -> Option<T::Ref<'_>> {
-        self.get(index).map(T::as_ref)
-    }
-
-    type Iter<'collection>
-        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::Ref<'collection>>
-    where
-        Self: 'collection;
-
-    fn iter(&self) -> Self::Iter<'_> {
-        <&Self as IntoIterator>::into_iter(self).map(T::as_ref)
-    }
-
-    type IntoIter = vec::IntoIter<T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        <Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: Item> CollectionAlloc for Box<[T]> {
-    fn with_capacity(capacity: usize) -> Self {
-        Vec::with_capacity(capacity).into_boxed_slice()
-    }
-}
-
-/// An iterator over copied items `T` in a slice borrowed from `U`.
+/// An iterator over a slice that turns views into owned instances
 #[derive(Debug)]
-pub struct CopySliceIter<T: Copy, U: Borrow<[T]>> {
-    /// The slice is borrowed from this field.
-    data: U,
-    /// The current position of this iterator.
+pub struct SliceIntoIter<T, U> {
+    /// The item that can be borrowed as slice
+    slice: T,
+    /// The current index
     index: usize,
-    /// The item type.
-    _ty: PhantomData<T>,
+    /// Item type
+    _ty: PhantomData<U>,
 }
 
-impl<T: Copy, U: Borrow<[T]>> From<U> for CopySliceIter<T, U> {
-    fn from(data: U) -> Self {
+impl<T: Borrow<[U]>, U: for<'slice> AsView<'slice, View: IntoOwned<U>>> Iterator
+    for SliceIntoIter<T, U>
+{
+    type Item = U;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.slice
+            .borrow()
+            .get(self.index)
+            .inspect(|_| {
+                self.index += 1;
+            })
+            .map(|item| item.as_view().into_owned())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.slice.borrow().len() - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl<T: Borrow<[U]>, U: for<'slice> AsView<'slice, View: IntoOwned<U>>> ExactSizeIterator
+    for SliceIntoIter<T, U>
+{
+}
+
+impl<T, U> From<T> for SliceIntoIter<T, U> {
+    fn from(slice: T) -> Self {
         Self {
-            data,
+            slice,
             index: 0,
             _ty: PhantomData,
         }
     }
 }
 
-impl<T: Copy, U: Borrow<[T]>> Iterator for CopySliceIter<T, U> {
-    type Item = T;
+impl<T> Collection for &[T]
+where
+    for<'collection> T: AsView<'collection, View: IntoOwned<T>>,
+{
+    type View<'collection>
+        = ViewOf<'collection, T>
+    where
+        Self: 'collection;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.data
-            .borrow()
-            .get(self.index)
-            .inspect(|_| {
-                self.index += 1;
-            })
-            .copied()
-    }
+    type Owned = T;
 
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.data.borrow().len() - self.index;
-        (remaining, Some(remaining))
-    }
-}
-
-impl<T: Copy, U: Borrow<[T]>> ExactSizeIterator for CopySliceIter<T, U> {}
-
-impl<T: Copy + Item> Collection for Rc<[T]> {
-    type Item = T;
-
-    fn index(&self, index: usize) -> Option<T::Ref<'_>> {
-        self.get(index).map(T::as_ref)
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.get(index).map(AsView::as_view)
     }
 
     type Iter<'collection>
-        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::Ref<'collection>>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> ViewOf<'collection, T>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&[T] as IntoIterator>::into_iter(self).map(T::as_ref)
+        <Self as IntoIterator>::into_iter(self).map(AsView::as_view)
     }
 
-    type IntoIter = CopySliceIter<T, Self>;
+    type IntoIter = SliceIntoIter<Self, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.into()
     }
 }
 
-impl<T: Copy + Item> Collection for Arc<[T]> {
-    type Item = T;
+impl<T> Collection for Box<[T]>
+where
+    for<'collection> T: AsView<'collection>,
+{
+    type View<'collection>
+        = ViewOf<'collection, T>
+    where
+        Self: 'collection;
 
-    fn index(&self, index: usize) -> Option<T::Ref<'_>> {
-        self.get(index).map(T::as_ref)
+    type Owned = T;
+
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.get(index).map(AsView::as_view)
     }
 
     type Iter<'collection>
-        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> T::Ref<'collection>>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> ViewOf<'collection, T>>
     where
         Self: 'collection;
 
     fn iter(&self) -> Self::Iter<'_> {
-        <&[T] as IntoIterator>::into_iter(self).map(T::as_ref)
+        <&Self as IntoIterator>::into_iter(self).map(AsView::as_view)
     }
 
-    type IntoIter = CopySliceIter<T, Self>;
+    type IntoIter = <Box<[T]> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        <Box<[T]> as IntoIterator>::into_iter(self)
+    }
+}
+
+impl<T> CollectionAlloc for Box<[T]>
+where
+    for<'collection> T: AsView<'collection>,
+{
+    fn with_capacity(capacity: usize) -> Self {
+        Vec::with_capacity(capacity).into_boxed_slice()
+    }
+}
+
+impl<T> Collection for Rc<[T]>
+where
+    for<'collection> T: AsView<'collection, View: IntoOwned<T>>,
+{
+    type View<'collection>
+        = ViewOf<'collection, T>
+    where
+        Self: 'collection;
+
+    type Owned = T;
+
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.get(index).map(AsView::as_view)
+    }
+
+    type Iter<'collection>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> ViewOf<'collection, T>>
+    where
+        Self: 'collection;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        <&[T] as IntoIterator>::into_iter(self).map(AsView::as_view)
+    }
+
+    type IntoIter = SliceIntoIter<Self, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into()
+    }
+}
+
+impl<T> Collection for Arc<[T]>
+where
+    for<'collection> T: AsView<'collection, View: IntoOwned<T>>,
+{
+    type View<'collection>
+        = ViewOf<'collection, T>
+    where
+        Self: 'collection;
+
+    type Owned = T;
+
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.get(index).map(AsView::as_view)
+    }
+
+    type Iter<'collection>
+        = Map<slice::Iter<'collection, T>, fn(&'collection T) -> ViewOf<'collection, T>>
+    where
+        Self: 'collection;
+
+    fn iter(&self) -> Self::Iter<'_> {
+        <&[T] as IntoIterator>::into_iter(self).map(AsView::as_view)
+    }
+
+    type IntoIter = SliceIntoIter<Self, T>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.into()
@@ -273,9 +389,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn borrow_slice_into_iter_size_hint() {
+    fn collection() {
+        let a = vec![1, 2, 3, 4];
+        assert_eq!(a[0].as_view(), 1);
+
+        let b = [1, 2, 3, 4];
+        assert_eq!(b.as_view(), [1, 2, 3, 4]);
+
+        let c = [1, 2, 3, 4].as_slice();
+        assert_eq!(c.as_view(), c);
+        assert_eq!(c.view(2), Some(3));
+
+        let d = vec![vec![1, 2], vec![3, 4]];
+        assert_eq!(d.view(0), Some([1, 2].as_slice()));
+        assert_eq!(d.view(1).unwrap().view(1), Some(4));
+    }
+
+    #[test]
+    fn slice_into_iter_size_hint() {
         let input = [1, 2, 3, 4].as_slice();
-        let mut iter = CopySliceIter::from(input);
+        let mut iter = SliceIntoIter::from(input);
         assert_eq!(iter.size_hint(), (4, Some(4)));
         let _ = Iterator::next(&mut iter);
         assert_eq!(iter.size_hint(), (3, Some(3)));

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -1,11 +1,11 @@
 //! Fixed-size types.
 
-use std::{fmt::Debug, mem};
+use std::mem;
 
 use crate::collection::AsView;
 
 /// Fixed-size types.
-pub trait FixedSize: Copy + Debug + sealed::Sealed + 'static {
+pub trait FixedSize: Copy + sealed::Sealed + 'static {
     /// The size of this type in bytes.
     const SIZE: usize = mem::size_of::<Self>();
 }

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -2,10 +2,10 @@
 
 use std::{fmt::Debug, mem};
 
-use crate::collection::Item;
+use crate::collection::AsView;
 
 /// Fixed-size types.
-pub trait FixedSize: Item + Copy + Debug {
+pub trait FixedSize: Copy + Debug + sealed::Sealed + 'static {
     /// The size of this type in bytes.
     const SIZE: usize = mem::size_of::<Self>();
 }
@@ -29,65 +29,15 @@ impl FixedSize for f64 {}
 
 impl<T: FixedSize, const N: usize> FixedSize for [T; N] {}
 
-/// Implements `Item` and `ItemMut` for primitive types.
-macro_rules! item_primitive {
-    ($ty:ty) => {
-        impl Item for $ty {
-            type Ref<'collection> = Self;
-            fn as_ref(&self) -> Self::Ref<'_> {
-                *self
-            }
-            fn to_owned(ref_item: &Self::Ref<'_>) -> Self {
-                *ref_item
-            }
-            fn into_owned(ref_item: Self::Ref<'_>) -> Self {
-                ref_item
-            }
-        }
-    };
+mod sealed {
+    pub trait Sealed {}
+    impl<T: super::FixedSize> Sealed for T {}
 }
 
-item_primitive!(u8);
-item_primitive!(u16);
-item_primitive!(u32);
-item_primitive!(u64);
-item_primitive!(u128);
-item_primitive!(usize);
+impl<'a, T: FixedSize> AsView<'a> for T {
+    type View = T;
 
-item_primitive!(i8);
-item_primitive!(i16);
-item_primitive!(i32);
-item_primitive!(i64);
-item_primitive!(i128);
-item_primitive!(isize);
-
-item_primitive!(f32);
-item_primitive!(f64);
-
-// bools are stored as bits in collections, so we can't borrow it directly
-// instead we return a copy
-impl Item for bool {
-    type Ref<'collection> = Self;
-    fn as_ref(&self) -> Self::Ref<'_> {
+    fn as_view(&'a self) -> T {
         *self
-    }
-    fn to_owned(ref_item: &Self::Ref<'_>) -> Self {
-        *ref_item
-    }
-    fn into_owned(ref_item: Self::Ref<'_>) -> Self {
-        ref_item
-    }
-}
-
-impl<const N: usize, T: Item + Clone> Item for [T; N] {
-    type Ref<'collection> = &'collection [T; N];
-    fn as_ref(&self) -> Self::Ref<'_> {
-        self
-    }
-    fn to_owned(ref_item: &Self::Ref<'_>) -> Self {
-        (*ref_item).clone()
-    }
-    fn into_owned(ref_item: Self::Ref<'_>) -> Self {
-        ref_item.clone()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
     // Rustc
     missing_copy_implementations,
     missing_debug_implementations,
-    missing_docs,
+    // missing_docs,
     noop_method_call,
     // warnings,
     // unused,
@@ -30,7 +30,7 @@
     clippy::empty_structs_with_brackets,
     clippy::get_unwrap,
     clippy::if_then_some_else_none,
-    clippy::missing_docs_in_private_items,
+    // clippy::missing_docs_in_private_items,
     clippy::multiple_unsafe_ops_per_block,
     clippy::pattern_type_mismatch,
     clippy::rest_pat_in_fully_bound_structs,

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -1,6 +1,9 @@
 //! Nullable data with a validity bitmap.
 
-use std::iter::{self, Map, Zip};
+use std::{
+    fmt::{self, Debug},
+    iter::{self, Map, Zip},
+};
 
 use crate::{
     bitmap::Bitmap,
@@ -16,7 +19,6 @@ use crate::{
 /// collection.
 ///
 /// `Buffer` is the [`BufferType`] of the [`Bitmap`].
-#[derive(Debug)]
 pub struct Validity<T: Collection, Buffer: BufferType = VecBuffer> {
     /// Collection that may contain null elements.
     collection: T,
@@ -24,6 +26,18 @@ pub struct Validity<T: Collection, Buffer: BufferType = VecBuffer> {
     /// The validity bitmap with validity information for the items in the
     /// data.
     bitmap: Bitmap<Buffer>,
+}
+
+impl<T: Collection + Debug, Buffer: BufferType> Debug for Validity<T, Buffer>
+where
+    Bitmap<Buffer>: Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Validity")
+            .field("collection", &self.collection)
+            .field("bitmap", &self.bitmap)
+            .finish()
+    }
 }
 
 impl<T: Default + Collection, Buffer: BufferType<Buffer<u8>: Default>> Default

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -40,7 +40,7 @@ impl<T: Default + Collection, Buffer: BufferType<Buffer<u8>: Default>> Default
 impl<'collection, T: AsView<'collection>> AsView<'collection> for Option<T> {
     type View = Option<ViewOf<'collection, T>>;
     fn as_view(&'collection self) -> Option<ViewOf<'collection, T>> {
-        self.as_ref().map(|inner| inner.as_view())
+        self.as_ref().map(AsView::as_view)
     }
 }
 


### PR DESCRIPTION
Changes the `Collection` trait to support `View` types that borrow from the collection. This is required to make abstractions like `Offset` work as collections.