### PR TITLE
refactor!: require `Collection::View` to impl `IntoOwned`

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -10,14 +10,14 @@ use std::{
 use crate::{collection::Collection, fixed_size::FixedSize};
 
 /// A contiguous immutable buffer.
-pub trait Buffer<T: FixedSize>: Borrow<[T]> {
+pub trait Buffer<T: FixedSize>: Borrow<[T]> + Collection<Owned = T> {
     /// Returns a slice containing all the items in this buffer.
     fn as_slice(&self) -> &[T] {
         self.borrow()
     }
 }
 
-impl<T: FixedSize, U: Borrow<[T]>> Buffer<T> for U {}
+impl<T: FixedSize, U: Borrow<[T]> + Collection<Owned = T>> Buffer<T> for U {}
 
 /// A contiguous mutable buffer.
 pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
@@ -27,7 +27,7 @@ pub trait BufferMut<T: FixedSize>: Buffer<T> + BorrowMut<[T]> {
     }
 }
 
-impl<T: FixedSize, U: BorrowMut<[T]>> BufferMut<T> for U {}
+impl<T: FixedSize, U: Buffer<T> + BorrowMut<[T]>> BufferMut<T> for U {}
 
 /// A [`Buffer`] constructor for [`FixedSize`] types.
 pub trait BufferType: Default {


### PR DESCRIPTION
This removes the `where for<'collection> Self::View<'collection>: IntoOwned<Self::Owned>` from `Collection::owned`, so that we don't have to repeat these bounds where we want to use a collection like this.