### PR TITLE
chore: `doc_auto_cfg` is now `doc_cfg`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
     html_logo_url = "https://raw.githubusercontent.com/mbrobbel/narrow/main/narrow.svg",
     html_favicon_url = "https://raw.githubusercontent.com/mbrobbel/narrow/main/narrow.svg"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 // The goal of the list of lints here is to help reduce complexity and improve consistency
 #![deny(
     // Rustc


### PR DESCRIPTION
Fixes:
```
error[E0557]: feature has been removed
 --> src/lib.rs:7:29
  |
7 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
  |                             ^^^^^^^^^^^^ feature has been removed
  |
  = note: removed in 1.58.0; see <https://github.com/rust-lang/rust/pull/138907> for more information
  = note: merged into `doc_cfg`
```