### PR TITLE
ci: run coverage on main only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -87,6 +87,7 @@ jobs:
 
   coverage:
     name: Coverage
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-26.04-arm
     env:
       RUSTFLAGS: "-C instrument-coverage"
@@ -106,7 +107,6 @@ jobs:
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - run: cargo build --workspace --all-targets --all-features
       - run: cargo test --workspace --all-targets --all-features
         env:
           LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"


### PR DESCRIPTION
## Summary
- run the instrumentation and Codecov job only for pushes to main
- remove the redundant build before the coverage test command

## Validation
- YAML parsed successfully
- cargo test --workspace --all-targets --all-features