### PR TITLE
ci: cancel superseded test and docs runs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: write
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   actions: write
   contents: read


### PR DESCRIPTION
## Summary
- cancel obsolete Test workflow runs for the same pull request or branch
- cancel obsolete Docs workflow runs using the same key

## Validation
- parsed both workflow YAML files successfully
- git diff --check