### PR TITLE
ci: remove redundant stable check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,8 +59,6 @@ jobs:
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
-      - name: Check
-        run: cargo check --workspace --all-targets --all-features
       - name: Test
         run: cargo test --workspace --all-targets --all-features
       - name: Doctest


### PR DESCRIPTION
## Summary
- remove the standalone cargo check from the stable Check job
- retain all-target testing and Clippy validation, which compile/check the same feature set

## Validation
- workflow YAML parsed successfully
- cargo test --workspace --all-targets --all-features
- cargo clippy --workspace --all-targets --all-features -- -Dwarnings