### PR TITLE
ci: scope sccache environment to build jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,15 +14,13 @@ permissions:
   actions: write
   contents: read
 
-env:
-  SCCACHE_GHA_ENABLED: true
-  RUSTC_WRAPPER: sccache
-
 jobs:
   rustdoc:
     name: Rustdoc
     runs-on: ubuntu-26.04-arm
     env:
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,14 +14,13 @@ permissions:
   actions: write
   contents: read
 
-env:
-  SCCACHE_GHA_ENABLED: true
-  RUSTC_WRAPPER: sccache
-
 jobs:
   msrv:
     name: Minimum supported Rust version
     runs-on: ubuntu-26.04-arm
+    env:
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91
@@ -44,6 +43,9 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-26.04-arm
+    env:
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -92,6 +94,8 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-26.04-arm
     env:
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C instrument-coverage"
       RUSTDOCFLAGS: "-C instrument-coverage"
     steps:


### PR DESCRIPTION
## Summary
- set the sccache environment only on jobs that install and use sccache
- prevent Miri and the Pages deploy job from inheriting RUSTC_WRAPPER

## Validation
- parsed the Test and Docs workflow YAML files successfully
- git diff --check