### PR TITLE
ci: use slim runner for Pages deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
   deploy:
     name: Deploy
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-slim
     needs: rustdoc
     environment:
       name: github-pages


### PR DESCRIPTION
## Summary
- run the artifact-only Pages deploy job on ubuntu-slim

## Rationale
Recent deploy jobs complete in about 10 seconds and perform only artifact download/upload plus Pages deployment; they do not compile Rust.

## Validation
- workflow YAML parsed successfully
- git diff --check