### PR TITLE
ci: use slim runners for release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-slim
     environment:
       name: crates-io
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   pr:
     name: PR
-    runs-on: ubuntu-26.04-arm
+    runs-on: ubuntu-slim
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false


### PR DESCRIPTION
## Summary
- run both release-plz jobs on ubuntu-slim
- retain the existing Rust toolchain and cache setup

## Rationale
Recent Release jobs complete in 22–43 seconds. The pinned release-plz action downloads its tools and may compile as a fallback; ubuntu-slim includes the required Git, curl, compiler, and Node tooling while using fewer runner resources.

## Validation
- workflow YAML parsed successfully
- git diff --check