### PR TITLE
fix: include buffered bits in `BitUnpacked::size_hint`

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -353,4 +353,34 @@ mod tests {
         let bitmap = Bitmap::<VecBuffer>::with_capacity(15);
         assert_eq!(bitmap.buffer.capacity(), 2);
     }
+
+    #[test]
+    fn into_iter_len() {
+        let bitmap = Bitmap::<VecBuffer>::from_iter([true, false, true, true]);
+        let mut iter = bitmap.into_iter_owned();
+        let mut remaining = 4;
+        assert_eq!(iter.len(), remaining);
+        while iter.next().is_some() {
+            remaining -= 1;
+            assert_eq!(iter.len(), remaining);
+        }
+        assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn into_iter_len_offset() {
+        let bitmap: Bitmap<SliceBuffer> = Bitmap {
+            buffer: &[0b1010_0000, 0b0000_0101],
+            bits: 7,
+            offset: 4,
+        };
+        let mut iter = bitmap.into_iter_owned();
+        let mut remaining = 7;
+        assert_eq!(iter.len(), remaining);
+        while iter.next().is_some() {
+            remaining -= 1;
+            assert_eq!(iter.len(), remaining);
+        }
+        assert_eq!(remaining, 0);
+    }
 }

--- a/src/bitmap/unpacked.rs
+++ b/src/bitmap/unpacked.rs
@@ -49,10 +49,27 @@ where
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, upper) = self.iter.size_hint();
 
-        // 8 items are returned per one item in the inner iterator.
+        // Bits not yet yielded from the currently buffered byte. The mask
+        // rotates back to the least-significant bit when a byte is exhausted,
+        // so a rotated mask indicates bits remaining in the buffered byte.
+        let buffered = if self.mask == 0x01 {
+            0
+        } else {
+            8_usize.strict_sub(
+                self.mask
+                    .trailing_zeros()
+                    .try_into()
+                    .expect("bit count fits in usize"),
+            )
+        };
+
+        // 8 items are returned per one item in the inner iterator, plus the
+        // bits buffered from a partially yielded byte.
         (
-            lower.saturating_mul(8),
-            upper.and_then(|bound| bound.checked_mul(8)),
+            lower.saturating_mul(8).saturating_add(buffered),
+            upper
+                .and_then(|bound| bound.checked_mul(8))
+                .and_then(|bound| bound.checked_add(buffered)),
         )
     }
 
@@ -120,5 +137,17 @@ mod tests {
             input.iter().bit_unpacked().size_hint(),
             (input.len() * 8, Some(input.len() * 8))
         );
+    }
+
+    #[test]
+    fn size_hint_partially_yielded_byte() {
+        let mut iter = [u8::MAX, 1].iter().bit_unpacked();
+        let mut remaining = 16;
+        assert_eq!(iter.size_hint(), (remaining, Some(remaining)));
+        while iter.next().is_some() {
+            remaining -= 1;
+            assert_eq!(iter.size_hint(), (remaining, Some(remaining)));
+        }
+        assert_eq!(iter.size_hint(), (0, Some(0)));
     }
 }


### PR DESCRIPTION
The size hint only counted bytes remaining in the inner iterator, ignoring bits not yet yielded from the partially consumed byte. This violated the `ExactSizeIterator` contract of `Bitmap` iterators mid-iteration.