### PR TITLE
refactor: bound-minimal `Debug` impls for list layouts

### DIFF
--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -1,3 +1,5 @@
+use core::fmt::Debug;
+
 use crate::{
     buffer::{Buffer, VecBuffer},
     collection::{Collection, CollectionAlloc, CollectionRealloc, flatten::Flatten},
@@ -6,7 +8,6 @@ use crate::{
     nullability::{NonNullable, Nullability},
 };
 
-#[derive(Debug)]
 pub struct FixedSizeList<
     T: Layout,
     const N: usize,
@@ -17,6 +18,16 @@ pub struct FixedSizeList<
 impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> MemoryLayout
     for FixedSizeList<T, N, Nulls, Storage>
 {
+}
+
+impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Debug
+    for FixedSizeList<T, N, Nulls, Storage>
+where
+    Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("FixedSizeList").field(&self.0).finish()
+    }
 }
 
 impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Clone

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
+use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
@@ -11,7 +12,6 @@ use crate::{
     offset::{Offset, Offsets},
 };
 
-#[derive(Debug)]
 pub struct VariableSizeList<
     T: Layout,
     Nulls: Nullability = NonNullable,
@@ -22,6 +22,16 @@ pub struct VariableSizeList<
 impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> MemoryLayout
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 {
+}
+
+impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Debug
+    for VariableSizeList<T, Nulls, OffsetItem, Storage>
+where
+    Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("VariableSizeList").field(&self.0).finish()
+    }
 }
 
 impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Default


### PR DESCRIPTION
Derived `Debug` for `FixedSizeList` and `VariableSizeList` added `Debug` bounds on the item type and the `Nullability` and `Buffer` markers. Replace with manual impls that only require `Debug` for the wrapped collection, matching `FixedSizePrimitive`.