### PR TITLE
feat: add `Boolean` layout

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -121,6 +121,10 @@ mod tests {
 
     #[test]
     fn collection() {
+        // Boolean
+        round_trip::<Array<_>, _>([true, false, true, true]);
+        round_trip::<Array<_>, _>([Some(true), None, Some(false), Some(true)]);
+
         // Fixed size primitive
         round_trip::<Array<_>, _>([1, 2, 3, 4]);
         round_trip::<Array<_>, _>([Some(1), None, Some(3), Some(4)]);

--- a/src/collection/view.rs
+++ b/src/collection/view.rs
@@ -12,6 +12,14 @@ pub trait AsView<'collection>: Sized {
     fn as_view(&'collection self) -> Self::View;
 }
 
+impl<'a> AsView<'a> for bool {
+    type View = bool;
+
+    fn as_view(&'a self) -> bool {
+        *self
+    }
+}
+
 #[diagnostic::do_not_recommend]
 impl<'a, T: FixedSize> AsView<'a> for T {
     type View = T;

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -1,0 +1,121 @@
+use core::fmt::Debug;
+
+use crate::{
+    bitmap::Bitmap,
+    buffer::{Buffer, VecBuffer},
+    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    layout::MemoryLayout,
+    length::Length,
+    nullability::{NonNullable, Nullability},
+};
+
+/// A collection of booleans, stored as bits in a [`Bitmap`].
+///
+/// <https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout>
+pub struct Boolean<Nulls: Nullability = NonNullable, Storage: Buffer = VecBuffer>(
+    Nulls::Collection<Bitmap<Storage>, Storage>,
+);
+
+impl<Nulls: Nullability, Storage: Buffer> MemoryLayout for Boolean<Nulls, Storage> {}
+
+impl<Nulls: Nullability, Storage: Buffer> Debug for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: Debug,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_tuple("Boolean").field(&self.0).finish()
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> Default for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: Default,
+{
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> Length for Boolean<Nulls, Storage> {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> FromIterator<Nulls::Item<bool>>
+    for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: FromIterator<Nulls::Item<bool>>,
+{
+    fn from_iter<I: IntoIterator<Item = Nulls::Item<bool>>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> Extend<Nulls::Item<bool>> for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: Extend<Nulls::Item<bool>>,
+{
+    fn extend<I: IntoIterator<Item = Nulls::Item<bool>>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> Collection for Boolean<Nulls, Storage> {
+    type View<'collection>
+        = <Nulls::Collection<Bitmap<Storage>, Storage> as Collection>::View<'collection>
+    where
+        Self: 'collection;
+
+    type Owned = <Nulls::Collection<Bitmap<Storage>, Storage> as Collection>::Owned;
+
+    fn view(&self, index: usize) -> Option<Self::View<'_>> {
+        self.0.view(index)
+    }
+
+    type Iter<'collection>
+        = <Nulls::Collection<Bitmap<Storage>, Storage> as Collection>::Iter<'collection>
+    where
+        Self: 'collection;
+
+    fn iter_views(&self) -> Self::Iter<'_> {
+        self.0.iter_views()
+    }
+
+    type IntoIter = <Nulls::Collection<Bitmap<Storage>, Storage> as Collection>::IntoIter;
+
+    fn into_iter_owned(self) -> Self::IntoIter {
+        self.0.into_iter_owned()
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> CollectionAlloc for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: CollectionAlloc,
+{
+    fn with_capacity(capacity: usize) -> Self {
+        Self(Nulls::Collection::with_capacity(capacity))
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> CollectionRealloc for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: CollectionRealloc,
+{
+    fn reserve(&mut self, additional: usize) {
+        self.0.reserve(additional);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{collection::tests::round_trip, nullability::Nullable};
+
+    use super::*;
+
+    #[test]
+    fn collection() {
+        round_trip::<Boolean, _>([true, false, true, true]);
+        round_trip::<Boolean<Nullable>, _>([Some(true), None, Some(false), Some(true)]);
+    }
+}

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -9,12 +9,13 @@ use crate::{
     collection::Collection,
     fixed_size::FixedSize,
     layout::{
-        fixed_size_list::FixedSizeList, fixed_size_primitive::FixedSizePrimitive,
+        boolean::Boolean, fixed_size_list::FixedSizeList, fixed_size_primitive::FixedSizePrimitive,
         variable_size_list::VariableSizeList,
     },
     nullability::{NonNullable, Nullable},
 };
 
+pub mod boolean;
 pub mod fixed_size_list;
 pub mod fixed_size_primitive;
 pub mod variable_size_binary;
@@ -27,6 +28,14 @@ pub trait MemoryLayout: Collection {}
 pub trait Layout {
     /// The Arrow physical memory layout of this type.
     type Memory<Storage: Buffer>: MemoryLayout<Owned = Self>;
+}
+
+impl Layout for bool {
+    type Memory<Storage: Buffer> = Boolean<NonNullable, Storage>;
+}
+
+impl Layout for Option<bool> {
+    type Memory<Storage: Buffer> = Boolean<Nullable, Storage>;
 }
 
 impl<T: FixedSize> Layout for T {


### PR DESCRIPTION
Adds the `Boolean` memory layout backed by a `Bitmap`, with `Layout` impls for `bool` and `Option<bool>`, and an `AsView` impl for `bool`.