### PR TITLE
fix: make `Bitmap::extend` panic-safe

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -5,6 +5,7 @@ mod unpacked;
 
 use core::{
     borrow::{Borrow, BorrowMut},
+    cell::Cell,
     fmt::{self, Debug},
     iter::{self, Skip, Take},
     slice,
@@ -30,6 +31,11 @@ pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
 /// The validity bits are stored LSB-first in the bytes of a buffer.
 pub struct Bitmap<Storage: Buffer = VecBuffer> {
     /// The bits of the bitmap are stored in this buffer of bytes.
+    ///
+    /// Invariant: the buffer stores at least `bytes_for_bits(offset + bits)`
+    /// bytes. The values of padding bits and bytes beyond the logical end of
+    /// the bitmap (e.g. left behind by a panicking extension) are
+    /// unspecified; extensions overwrite them.
     buffer: Storage::For<u8>,
 
     /// The number of bits stored in the bitmap.
@@ -149,22 +155,54 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
     for Bitmap<Storage>
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        // Commit every item together with the bit count before pulling the
-        // next item from the iterator: a panicking iterator must not leave
-        // bits in the buffer that are not accounted for by the bit count,
-        // because a subsequent extension could otherwise expose them.
-        for item in iter {
-            let value = u8::from(*item.borrow());
+        // Fuse to prevent a resumable iterator from writing at positions
+        // beyond the first `None`.
+        let mut items = iter.into_iter().fuse();
+
+        // Fill remaining bits in the byte at the logical end of the bitmap,
+        // committing the bit count per item: a panicking iterator must not
+        // leave bits in the buffer that are not accounted for by the bit
+        // count, because a subsequent extension could otherwise expose them.
+        let bit_index = self.bit_index(self.bits);
+        if bit_index != 0 {
             let byte_index = self.byte_index(self.bits);
-            let bit_index = self.bit_index(self.bits);
             if let Some(byte) = self.buffer.borrow_mut().get_mut(byte_index) {
-                // Clear the bit before setting it: it may hold stale data
-                // e.g. when a previous extension panicked.
-                *byte = (*byte & !(1 << bit_index)) | (value << bit_index);
-            } else {
-                self.buffer.extend(iter::once(value << bit_index));
+                for index in bit_index..8 {
+                    if let Some(next) = items.next() {
+                        // Clear the bit before setting it: bits beyond the
+                        // logical end of the bitmap are unspecified.
+                        *byte = (*byte & !(1 << index)) | (u8::from(*next.borrow()) << index);
+                        self.bits = self.bits.strict_add(1);
+                    }
+                }
             }
-            self.bits = self.bits.strict_add(1);
+        }
+
+        // Use bit packed iterator for the remainder. The bit count is
+        // committed only when the extension completes: a panicking iterator
+        // leaves the bytes already written as unspecified data beyond the
+        // logical end, overwritten by subsequent extensions.
+        if let Some(first) = items.next() {
+            let consumed = Cell::new(0_usize);
+            let mut packed = iter::once(first)
+                .chain(items)
+                .inspect(|_| consumed.set(consumed.get().strict_add(1)))
+                .bit_packed();
+
+            // Overwrite bytes beyond the logical end before appending.
+            let mut byte_index = self.byte_index(self.bits);
+            while let Some(byte) = self.buffer.borrow_mut().get_mut(byte_index) {
+                match packed.next() {
+                    Some(packed_byte) => {
+                        *byte = packed_byte;
+                        byte_index = byte_index.strict_add(1);
+                    }
+                    None => break,
+                }
+            }
+
+            self.buffer.extend(packed);
+            self.bits = self.bits.strict_add(consumed.get());
         }
     }
 }
@@ -355,7 +393,8 @@ mod tests {
         let mut bitmap = Bitmap::<VecBuffer>::from_iter([true]);
         assert!(
             catch_unwind(AssertUnwindSafe(|| {
-                bitmap.extend(iter::once(true).chain(iter::once_with(|| panic!("boom"))));
+                bitmap
+                    .extend(core::iter::once(true).chain(core::iter::once_with(|| panic!("boom"))));
             }))
             .is_err()
         );
@@ -371,6 +410,61 @@ mod tests {
             bitmap.iter_views().collect::<Vec<_>>(),
             [true, true, false, true]
         );
+    }
+
+    #[test]
+    fn extend_panic_safety_packed() {
+        extern crate std;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut bitmap = Bitmap::<VecBuffer>::default();
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                // Panics after yielding 10 items: the interrupted extension
+                // is not committed, the bytes it wrote are unspecified data
+                // beyond the logical end of the bitmap.
+                bitmap.extend(
+                    (0..10)
+                        .map(|i| i % 2 == 0)
+                        .chain(core::iter::once_with(|| panic!("boom"))),
+                );
+            }))
+            .is_err()
+        );
+
+        assert_eq!(bitmap.len(), 0);
+        assert_eq!(bitmap.view(0), None);
+
+        // A subsequent extension observes a consistent state and overwrites
+        // the bytes left behind by the interrupted extension.
+        bitmap.extend([false, true, false]);
+        assert_eq!(bitmap.len(), 3);
+        assert_eq!(
+            bitmap.iter_views().collect::<Vec<_>>(),
+            [false, true, false]
+        );
+    }
+
+    #[test]
+    fn extend_non_fused_iterator() {
+        /// Yields `Some(true)` again after the first `None`.
+        struct Resumable(usize);
+        impl Iterator for Resumable {
+            type Item = bool;
+            fn next(&mut self) -> Option<bool> {
+                self.0 = self.0.strict_add(1);
+                match self.0 {
+                    1 => Some(false),
+                    2 => None,
+                    _ => Some(true),
+                }
+            }
+        }
+
+        let mut bitmap = Bitmap::<VecBuffer>::from_iter([true]);
+        bitmap.extend(Resumable(0));
+        assert_eq!(bitmap.len(), 2);
+        assert_eq!(bitmap.iter_views().collect::<Vec<_>>(), [true, false]);
     }
 
     #[test]

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -5,7 +5,6 @@ mod unpacked;
 
 use core::{
     borrow::{Borrow, BorrowMut},
-    cell::Cell,
     fmt::{self, Debug},
     iter::{self, Skip, Take},
     slice,
@@ -183,10 +182,10 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
         // leaves the bytes already written as unspecified data beyond the
         // logical end, overwritten by subsequent extensions.
         if let Some(first) = items.next() {
-            let consumed = Cell::new(0_usize);
+            let mut consumed: usize = 0;
             let mut packed = iter::once(first)
                 .chain(items)
-                .inspect(|_| consumed.set(consumed.get().strict_add(1)))
+                .inspect(|_| consumed = consumed.strict_add(1))
                 .bit_packed();
 
             // Overwrite bytes beyond the logical end before appending.
@@ -202,7 +201,7 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
             }
 
             self.buffer.extend(packed);
-            self.bits = self.bits.strict_add(consumed.get());
+            self.bits = self.bits.strict_add(consumed);
         }
     }
 }

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -6,7 +6,7 @@ mod unpacked;
 use core::{
     borrow::{Borrow, BorrowMut},
     fmt::{self, Debug},
-    iter::{Skip, Take},
+    iter::{self, Skip, Take},
     slice,
 };
 
@@ -149,30 +149,23 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
     for Bitmap<Storage>
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        // Track the number of added bits.
-        let mut additional: usize = 0;
-        let mut items = iter.into_iter().inspect(|_| {
-            additional = additional.strict_add(1);
-        });
-
-        // Fill remaining bits in the last byte of the buffer.
-        let bit_index = self.bit_index(self.bits);
-        if bit_index != 0 {
-            // If there are trailing bits, there must at least be one byte in
-            // the buffer.
-            if let Some(last_byte) = self.buffer.borrow_mut().last_mut() {
-                // Use the remaining bits in this last byte
-                for index in bit_index..8 {
-                    if let Some(next) = items.next() {
-                        *last_byte |= u8::from(*next.borrow()) << index;
-                    }
-                }
+        // Commit every item together with the bit count before pulling the
+        // next item from the iterator: a panicking iterator must not leave
+        // bits in the buffer that are not accounted for by the bit count,
+        // because a subsequent extension could otherwise expose them.
+        for item in iter {
+            let value = u8::from(*item.borrow());
+            let byte_index = self.byte_index(self.bits);
+            let bit_index = self.bit_index(self.bits);
+            if let Some(byte) = self.buffer.borrow_mut().get_mut(byte_index) {
+                // Clear the bit before setting it: it may hold stale data
+                // e.g. when a previous extension panicked.
+                *byte = (*byte & !(1 << bit_index)) | (value << bit_index);
+            } else {
+                self.buffer.extend(iter::once(value << bit_index));
             }
+            self.bits = self.bits.strict_add(1);
         }
-
-        // Use bit packed iterator for the remainder
-        self.buffer.extend(items.bit_packed());
-        self.bits = self.bits.strict_add(additional);
     }
 }
 
@@ -352,5 +345,47 @@ mod tests {
     fn alloc() {
         let bitmap = Bitmap::<VecBuffer>::with_capacity(15);
         assert_eq!(bitmap.buffer.capacity(), 2);
+    }
+
+    #[test]
+    fn extend_panic_safety() {
+        extern crate std;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut bitmap = Bitmap::<VecBuffer>::from_iter([true]);
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                bitmap.extend(iter::once(true).chain(iter::once_with(|| panic!("boom"))));
+            }))
+            .is_err()
+        );
+
+        // The item yielded before the panic is committed.
+        assert_eq!(bitmap.len(), 2);
+        assert_eq!(bitmap.view(1), Some(true));
+
+        // A subsequent extension observes a consistent state.
+        bitmap.extend([false, true]);
+        assert_eq!(bitmap.len(), 4);
+        assert_eq!(
+            bitmap.iter_views().collect::<Vec<_>>(),
+            [true, true, false, true]
+        );
+    }
+
+    #[test]
+    fn extend_clears_stale_bits() {
+        // Stale bits beyond the bit count, as left behind by an interrupted
+        // extension.
+        let mut bitmap: Bitmap<VecBuffer> = Bitmap {
+            buffer: alloc::vec![0b1111_1111],
+            bits: 4,
+            offset: 0,
+        };
+        bitmap.extend([false, true]);
+        assert_eq!(bitmap.len(), 6);
+        assert_eq!(bitmap.view(4), Some(false));
+        assert_eq!(bitmap.view(5), Some(true));
+        assert_eq!(bitmap.buffer.as_slice(), &[0b1110_1111]);
     }
 }


### PR DESCRIPTION
A panicking iterator could leave bits in the buffer that were not accounted for by the bit count, and a subsequent extension would OR into those stale bits, exposing values that were never added.