### PR TITLE
fix: keep `Validity` consistent across panicking extensions

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -28,13 +28,14 @@ pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
 /// A collection of bits.
 ///
 /// The validity bits are stored LSB-first in the bytes of a buffer.
-/// A prefix committed before a panicking extension remains readable. If a
-/// packed batch was interrupted, subsequent extensions panic.
+/// A panicking extension leaves its committed prefix visible. The next
+/// extension overwrites any uncommitted bits.
 pub struct Bitmap<Storage: Buffer = VecBuffer> {
     /// The bits of the bitmap are stored in this buffer of bytes.
     ///
     /// Invariant: the buffer stores at least `bytes_for_bits(offset + bits)`
-    /// bytes. Padding bits and bytes beyond the logical end are unspecified.
+    /// bytes. Padding bits and bytes beyond the logical end are unspecified
+    /// and overwritten by extensions.
     buffer: Storage::For<u8>,
 
     /// The number of bits stored in the bitmap.
@@ -43,9 +44,6 @@ pub struct Bitmap<Storage: Buffer = VecBuffer> {
     /// An offset (in number of bits) in the buffer. This enables zero-copy
     /// slicing of the bitmap on non-byte boundaries.
     offset: usize,
-
-    /// Whether a packed extension was interrupted.
-    poisoned: bool,
 }
 
 impl<Storage: Buffer<For<u8>: Debug>> Debug for Bitmap<Storage> {
@@ -54,7 +52,6 @@ impl<Storage: Buffer<For<u8>: Debug>> Debug for Bitmap<Storage> {
             .field("buffer", &self.buffer)
             .field("bits", &self.bits)
             .field("offset", &self.offset)
-            .field("poisoned", &self.poisoned)
             .finish()
     }
 }
@@ -106,7 +103,6 @@ impl<Storage: Buffer<For<u8>: Clone>> Clone for Bitmap<Storage> {
             buffer: self.buffer.clone(),
             bits: self.bits,
             offset: self.offset,
-            poisoned: self.poisoned,
         }
     }
 }
@@ -117,7 +113,6 @@ impl<Storage: Buffer<For<u8>: Default>> Default for Bitmap<Storage> {
             buffer: Default::default(),
             bits: 0,
             offset: 0,
-            poisoned: false,
         }
     }
 }
@@ -160,11 +155,6 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
     for Bitmap<Storage>
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
-        assert!(
-            !self.poisoned,
-            "cannot extend Bitmap after an interrupted packed extension"
-        );
-
         // Fuse to prevent a resumable iterator from writing at positions
         // beyond the first `None`.
         let mut items = iter.into_iter().fuse();
@@ -190,9 +180,8 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
 
         // Use bit packed iterator for the remainder. The bit count is
         // committed only when the extension completes; a panic leaves the
-        // committed prefix readable and prevents subsequent extensions.
+        // written bytes beyond the logical end to be overwritten later.
         if let Some(first) = items.next() {
-            self.poisoned = true;
             let mut consumed: usize = 0;
             let mut packed = iter::once(first)
                 .chain(items)
@@ -213,7 +202,6 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
 
             self.buffer.extend(packed);
             self.bits = self.bits.strict_add(consumed);
-            self.poisoned = false;
         }
     }
 }
@@ -234,7 +222,6 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: CollectionAlloc>> FromIterator<T>
             buffer,
             bits,
             offset: 0,
-            poisoned: false,
         }
     }
 }
@@ -276,7 +263,6 @@ impl<Storage: Buffer<For<u8>: CollectionAlloc>> CollectionAlloc for Bitmap<Stora
             buffer: Storage::For::<u8>::with_capacity(bytes_for_bits(capacity)),
             bits: 0,
             offset: 0,
-            poisoned: false,
         }
     }
 }
@@ -384,7 +370,6 @@ mod tests {
             buffer: slice,
             bits: 3,
             offset: 4,
-            poisoned: false,
         };
         assert_eq!(bitmap.len(), 3);
         assert_eq!(bitmap.leading_bits(), 4);
@@ -435,7 +420,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_panic_prevents_packed_extension() {
+    fn extend_panic_discards_uncommitted_packed_bits() {
         extern crate std;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -457,10 +442,12 @@ mod tests {
         assert_eq!(bitmap.len(), 0);
         assert_eq!(bitmap.view(0), None);
 
-        // The committed prefix remains readable, but the interrupted packed
-        // batch prevents further extension.
-        assert!(catch_unwind(AssertUnwindSafe(|| bitmap.extend([false, true, false]))).is_err());
-        assert_eq!(bitmap.len(), 0);
+        bitmap.extend([false, true, false]);
+        assert_eq!(bitmap.len(), 3);
+        assert_eq!(
+            bitmap.iter_views().collect::<Vec<_>>(),
+            [false, true, false]
+        );
     }
 
     #[test]
@@ -493,7 +480,6 @@ mod tests {
             buffer: alloc::vec![0b1111_1111],
             bits: 4,
             offset: 0,
-            poisoned: false,
         };
         bitmap.extend([false, true]);
         assert_eq!(bitmap.len(), 6);
@@ -538,7 +524,6 @@ mod tests {
             buffer: &[0b1010_0000, 0b0000_0101],
             bits: 7,
             offset: 4,
-            poisoned: false,
         };
         let mut iter = bitmap.into_iter_owned();
         let mut remaining = 7;

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -28,13 +28,13 @@ pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
 /// A collection of bits.
 ///
 /// The validity bits are stored LSB-first in the bytes of a buffer.
+/// A prefix committed before a panicking extension remains readable. If a
+/// packed batch was interrupted, subsequent extensions panic.
 pub struct Bitmap<Storage: Buffer = VecBuffer> {
     /// The bits of the bitmap are stored in this buffer of bytes.
     ///
     /// Invariant: the buffer stores at least `bytes_for_bits(offset + bits)`
-    /// bytes. The values of padding bits and bytes beyond the logical end of
-    /// the bitmap (e.g. left behind by a panicking extension) are
-    /// unspecified; extensions overwrite them.
+    /// bytes. Padding bits and bytes beyond the logical end are unspecified.
     buffer: Storage::For<u8>,
 
     /// The number of bits stored in the bitmap.
@@ -43,6 +43,9 @@ pub struct Bitmap<Storage: Buffer = VecBuffer> {
     /// An offset (in number of bits) in the buffer. This enables zero-copy
     /// slicing of the bitmap on non-byte boundaries.
     offset: usize,
+
+    /// Whether a packed extension was interrupted.
+    poisoned: bool,
 }
 
 impl<Storage: Buffer<For<u8>: Debug>> Debug for Bitmap<Storage> {
@@ -51,6 +54,7 @@ impl<Storage: Buffer<For<u8>: Debug>> Debug for Bitmap<Storage> {
             .field("buffer", &self.buffer)
             .field("bits", &self.bits)
             .field("offset", &self.offset)
+            .field("poisoned", &self.poisoned)
             .finish()
     }
 }
@@ -102,6 +106,7 @@ impl<Storage: Buffer<For<u8>: Clone>> Clone for Bitmap<Storage> {
             buffer: self.buffer.clone(),
             bits: self.bits,
             offset: self.offset,
+            poisoned: self.poisoned,
         }
     }
 }
@@ -112,6 +117,7 @@ impl<Storage: Buffer<For<u8>: Default>> Default for Bitmap<Storage> {
             buffer: Default::default(),
             bits: 0,
             offset: 0,
+            poisoned: false,
         }
     }
 }
@@ -154,6 +160,11 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
     for Bitmap<Storage>
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        assert!(
+            !self.poisoned,
+            "cannot extend Bitmap after an interrupted packed extension"
+        );
+
         // Fuse to prevent a resumable iterator from writing at positions
         // beyond the first `None`.
         let mut items = iter.into_iter().fuse();
@@ -178,10 +189,10 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
         }
 
         // Use bit packed iterator for the remainder. The bit count is
-        // committed only when the extension completes: a panicking iterator
-        // leaves the bytes already written as unspecified data beyond the
-        // logical end, overwritten by subsequent extensions.
+        // committed only when the extension completes; a panic leaves the
+        // committed prefix readable and prevents subsequent extensions.
         if let Some(first) = items.next() {
+            self.poisoned = true;
             let mut consumed: usize = 0;
             let mut packed = iter::once(first)
                 .chain(items)
@@ -202,6 +213,7 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionReall
 
             self.buffer.extend(packed);
             self.bits = self.bits.strict_add(consumed);
+            self.poisoned = false;
         }
     }
 }
@@ -222,6 +234,7 @@ impl<T: Borrow<bool>, Storage: Buffer<For<u8>: CollectionAlloc>> FromIterator<T>
             buffer,
             bits,
             offset: 0,
+            poisoned: false,
         }
     }
 }
@@ -263,6 +276,7 @@ impl<Storage: Buffer<For<u8>: CollectionAlloc>> CollectionAlloc for Bitmap<Stora
             buffer: Storage::For::<u8>::with_capacity(bytes_for_bits(capacity)),
             bits: 0,
             offset: 0,
+            poisoned: false,
         }
     }
 }
@@ -362,6 +376,7 @@ mod tests {
             buffer: slice,
             bits: 3,
             offset: 4,
+            poisoned: false,
         };
         assert_eq!(bitmap.len(), 3);
         assert_eq!(bitmap.leading_bits(), 4);
@@ -412,7 +427,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_panic_safety_packed() {
+    fn extend_panic_prevents_packed_extension() {
         extern crate std;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -434,14 +449,10 @@ mod tests {
         assert_eq!(bitmap.len(), 0);
         assert_eq!(bitmap.view(0), None);
 
-        // A subsequent extension observes a consistent state and overwrites
-        // the bytes left behind by the interrupted extension.
-        bitmap.extend([false, true, false]);
-        assert_eq!(bitmap.len(), 3);
-        assert_eq!(
-            bitmap.iter_views().collect::<Vec<_>>(),
-            [false, true, false]
-        );
+        // The committed prefix remains readable, but the interrupted packed
+        // batch prevents further extension.
+        assert!(catch_unwind(AssertUnwindSafe(|| bitmap.extend([false, true, false]))).is_err());
+        assert_eq!(bitmap.len(), 0);
     }
 
     #[test]
@@ -474,6 +485,7 @@ mod tests {
             buffer: alloc::vec![0b1111_1111],
             bits: 4,
             offset: 0,
+            poisoned: false,
         };
         bitmap.extend([false, true]);
         assert_eq!(bitmap.len(), 6);
@@ -501,6 +513,7 @@ mod tests {
             buffer: &[0b1010_0000, 0b0000_0101],
             bits: 7,
             offset: 4,
+            poisoned: false,
         };
         let mut iter = bitmap.into_iter_owned();
         let mut remaining = 7;

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -61,7 +61,8 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 /// implementations must leave the collection in a state where
 /// [`Length::len`] counts only fully committed items. Consumers (e.g.
 /// [`crate::validity::Validity`]) rely on this to recover from interrupted
-/// extensions.
+/// extensions. If a later extension surfaces recovered items, they must
+/// precede the items supplied by the new iterator.
 pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -56,6 +56,12 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 }
 
 /// A re-allocatable collection of items.
+///
+/// When an extension is interrupted by a panicking iterator,
+/// implementations must leave the collection in a state where
+/// [`Length::len`] counts only fully committed items. Consumers (e.g.
+/// [`crate::validity::Validity`]) rely on this to recover from interrupted
+/// extensions.
 pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -56,13 +56,6 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 }
 
 /// A re-allocatable collection of items.
-///
-/// When an extension is interrupted by a panicking iterator,
-/// implementations must leave the collection in a state where
-/// [`Length::len`] counts only fully committed items. Consumers (e.g.
-/// [`crate::validity::Validity`]) rely on this to recover from interrupted
-/// extensions. If a later extension surfaces recovered items, they must
-/// precede the items supplied by the new iterator.
 pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -183,6 +183,7 @@ impl<
         loop {
             let mut validity = [false; VALIDITY_CHUNK];
             let mut count: usize = 0;
+            let collection_len = self.collection.len();
             self.collection.extend(
                 items
                     .by_ref()
@@ -193,7 +194,18 @@ impl<
                     })
                     .map(Option::unwrap_or_default),
             );
-            self.bitmap.extend(validity.iter().take(count));
+
+            // A nested collection can surface items left by its own
+            // interrupted extension before committing this chunk. Mark those
+            // recovered items as null before appending this chunk's validity.
+            let recovered = self
+                .collection
+                .len()
+                .strict_sub(collection_len)
+                .strict_sub(count);
+            self.bitmap.extend(
+                iter::repeat_n(false, recovered).chain(validity.iter().copied().take(count)),
+            );
             if count < VALIDITY_CHUNK {
                 break;
             }

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -20,8 +20,8 @@ use crate::{
 /// collection.
 ///
 /// `Storage` is the [`Buffer`] of the [`Bitmap`].
-/// A prefix committed before a panicking extension remains readable, but an
-/// uncommitted suffix prevents subsequent extensions.
+/// A panicking extension leaves committed chunks visible. The next extension
+/// discards any uncommitted suffix.
 pub struct Validity<T: Collection, Storage: Buffer = VecBuffer> {
     /// Collection that may contain null elements.
     collection: T,
@@ -166,11 +166,7 @@ impl<
 > Extend<Option<U>> for Validity<T, Storage>
 {
     fn extend<I: IntoIterator<Item = Option<U>>>(&mut self, iter: I) {
-        assert_eq!(
-            self.collection.len(),
-            self.bitmap.len(),
-            "cannot extend Validity after an interrupted extension"
-        );
+        self.collection.truncate(self.bitmap.len());
 
         // Buffer validity and flush it to the bitmap per chunk, instead of
         // extending the bitmap bit by bit: bulk bitmap extension uses the bit
@@ -314,7 +310,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_panic_preserves_prefix() {
+    fn extend_panic_discards_uncommitted_suffix() {
         extern crate std;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -334,8 +330,11 @@ mod tests {
         assert_eq!(validity.len(), 2);
         assert_eq!(validity.view(2), None);
 
-        assert!(catch_unwind(AssertUnwindSafe(|| validity.extend([Some(5)]))).is_err());
-        assert_eq!(validity.iter_views().collect::<Vec<_>>(), [Some(1), None]);
+        validity.extend([Some(5)]);
+        assert_eq!(
+            validity.iter_views().collect::<Vec<_>>(),
+            [Some(1), None, Some(5)]
+        );
     }
 
     #[test]
@@ -361,10 +360,17 @@ mod tests {
             validity.view(VALIDITY_CHUNK - 1),
             Some(Some(VALIDITY_CHUNK - 1))
         );
+
+        validity.extend([Some(VALIDITY_CHUNK + 3)]);
+        assert_eq!(validity.len(), VALIDITY_CHUNK + 1);
+        assert_eq!(
+            validity.view(VALIDITY_CHUNK),
+            Some(Some(VALIDITY_CHUNK + 3))
+        );
     }
 
     #[test]
-    fn extend_panic_prevents_nested_extension() {
+    fn extend_panic_discards_nested_suffix() {
         extern crate std;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -381,7 +387,7 @@ mod tests {
         );
 
         assert_eq!(validity.len(), 0);
-        assert!(catch_unwind(AssertUnwindSafe(|| validity.extend([Some(Some(3))]))).is_err());
-        assert_eq!(validity.len(), 0);
+        validity.extend([Some(Some(3))]);
+        assert_eq!(validity.iter_views().collect::<Vec<_>>(), [Some(Some(3))]);
     }
 }

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -20,6 +20,8 @@ use crate::{
 /// collection.
 ///
 /// `Storage` is the [`Buffer`] of the [`Bitmap`].
+/// A prefix committed before a panicking extension remains readable, but an
+/// uncommitted suffix prevents subsequent extensions.
 pub struct Validity<T: Collection, Storage: Buffer = VecBuffer> {
     /// Collection that may contain null elements.
     collection: T,
@@ -164,15 +166,11 @@ impl<
 > Extend<Option<U>> for Validity<T, Storage>
 {
     fn extend<I: IntoIterator<Item = Option<U>>>(&mut self, iter: I) {
-        // The bitmap length is the length of this collection, so items added
-        // to the collection by an extension that panicked before their
-        // validity was flushed to the bitmap are not exposed. Surface such
-        // items as null to realign the bitmap with the collection before
-        // extending.
-        let stray = self.collection.len().strict_sub(self.bitmap.len());
-        if stray != 0 {
-            self.bitmap.extend(iter::repeat_n(false, stray));
-        }
+        assert_eq!(
+            self.collection.len(),
+            self.bitmap.len(),
+            "cannot extend Validity after an interrupted extension"
+        );
 
         // Buffer validity and flush it to the bitmap per chunk, instead of
         // extending the bitmap bit by bit: bulk bitmap extension uses the bit
@@ -183,7 +181,6 @@ impl<
         loop {
             let mut validity = [false; VALIDITY_CHUNK];
             let mut count: usize = 0;
-            let collection_len = self.collection.len();
             self.collection.extend(
                 items
                     .by_ref()
@@ -194,18 +191,7 @@ impl<
                     })
                     .map(Option::unwrap_or_default),
             );
-
-            // A nested collection can surface items left by its own
-            // interrupted extension before committing this chunk. Mark those
-            // recovered items as null before appending this chunk's validity.
-            let recovered = self
-                .collection
-                .len()
-                .strict_sub(collection_len)
-                .strict_sub(count);
-            self.bitmap.extend(
-                iter::repeat_n(false, recovered).chain(validity.iter().copied().take(count)),
-            );
+            self.bitmap.extend(validity.iter().take(count));
             if count < VALIDITY_CHUNK {
                 break;
             }
@@ -311,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn extend_panic_realigns() {
+    fn extend_panic_preserves_prefix() {
         extern crate std;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -327,21 +313,41 @@ mod tests {
             .is_err()
         );
 
-        // The items of the interrupted extension are not exposed.
+        // Only the prefix committed before this extension remains visible.
         assert_eq!(validity.len(), 2);
         assert_eq!(validity.view(2), None);
 
-        // A subsequent extension surfaces them as null.
-        validity.extend([Some(5)]);
-        assert_eq!(validity.len(), 5);
+        assert!(catch_unwind(AssertUnwindSafe(|| validity.extend([Some(5)]))).is_err());
+        assert_eq!(validity.iter_views().collect::<Vec<_>>(), [Some(1), None]);
+    }
+
+    #[test]
+    fn extend_panic_preserves_committed_chunks() {
+        extern crate std;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut validity = Validity::<Vec<usize>>::default();
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                validity.extend(
+                    (0..(VALIDITY_CHUNK + 2))
+                        .map(Some)
+                        .chain(iter::once_with(|| panic!("boom"))),
+                );
+            }))
+            .is_err()
+        );
+
+        assert_eq!(validity.len(), VALIDITY_CHUNK);
+        assert_eq!(validity.view(0), Some(Some(0)));
         assert_eq!(
-            validity.iter_views().collect::<Vec<_>>(),
-            [Some(1), None, None, None, Some(5)]
+            validity.view(VALIDITY_CHUNK - 1),
+            Some(Some(VALIDITY_CHUNK - 1))
         );
     }
 
     #[test]
-    fn extend_panic_realigns_nested() {
+    fn extend_panic_prevents_nested_extension() {
         extern crate std;
         use std::panic::{AssertUnwindSafe, catch_unwind};
 
@@ -358,17 +364,7 @@ mod tests {
         );
 
         assert_eq!(validity.len(), 0);
-        validity.extend([Some(Some(3))]);
-        assert_eq!(validity.len(), 3);
-        assert_eq!(
-            validity.iter_views().collect::<Vec<_>>(),
-            [None, None, Some(Some(3))]
-        );
-
-        validity.extend([Some(Some(4))]);
-        assert_eq!(
-            validity.iter_views().collect::<Vec<_>>(),
-            [None, None, Some(Some(3)), Some(Some(4))]
-        );
+        assert!(catch_unwind(AssertUnwindSafe(|| validity.extend([Some(Some(3))]))).is_err());
+        assert_eq!(validity.len(), 0);
     }
 }

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -327,4 +327,36 @@ mod tests {
             [Some(1), None, None, None, Some(5)]
         );
     }
+
+    #[test]
+    fn extend_panic_realigns_nested() {
+        extern crate std;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut validity = Validity::<Validity<Vec<u32>>>::default();
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                validity.extend(
+                    [Some(Some(1)), Some(Some(2))]
+                        .into_iter()
+                        .chain(iter::once_with(|| panic!("boom"))),
+                );
+            }))
+            .is_err()
+        );
+
+        assert_eq!(validity.len(), 0);
+        validity.extend([Some(Some(3))]);
+        assert_eq!(validity.len(), 3);
+        assert_eq!(
+            validity.iter_views().collect::<Vec<_>>(),
+            [None, None, Some(Some(3))]
+        );
+
+        validity.extend([Some(Some(4))]);
+        assert_eq!(
+            validity.iter_views().collect::<Vec<_>>(),
+            [None, None, Some(Some(3)), Some(Some(4))]
+        );
+    }
 }

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -153,6 +153,10 @@ impl<
     }
 }
 
+/// Number of items buffered before flushing their validity to the bitmap in
+/// [`Extend::extend`] for [`Validity`].
+const VALIDITY_CHUNK: usize = 1024;
+
 impl<
     U: Default,
     T: CollectionRealloc<Owned = U>,
@@ -160,11 +164,40 @@ impl<
 > Extend<Option<U>> for Validity<T, Storage>
 {
     fn extend<I: IntoIterator<Item = Option<U>>>(&mut self, iter: I) {
-        self.collection.extend(
-            iter.into_iter()
-                .inspect(|opt| self.bitmap.extend(iter::once(opt.is_some())))
-                .map(Option::unwrap_or_default),
-        );
+        // The bitmap length is the length of this collection, so items added
+        // to the collection by an extension that panicked before their
+        // validity was flushed to the bitmap are not exposed. Surface such
+        // items as null to realign the bitmap with the collection before
+        // extending.
+        let stray = self.collection.len().strict_sub(self.bitmap.len());
+        if stray != 0 {
+            self.bitmap.extend(iter::repeat_n(false, stray));
+        }
+
+        // Buffer validity and flush it to the bitmap per chunk, instead of
+        // extending the bitmap bit by bit: bulk bitmap extension uses the bit
+        // packing fast path. The bitmap is extended after the items of a
+        // chunk are committed to the collection, so a panicking iterator can
+        // not add validity for items that never arrive.
+        let mut items = iter.into_iter();
+        loop {
+            let mut validity = [false; VALIDITY_CHUNK];
+            let mut count: usize = 0;
+            self.collection.extend(
+                items
+                    .by_ref()
+                    .take(VALIDITY_CHUNK)
+                    .inspect(|opt| {
+                        validity[count] = opt.is_some();
+                        count = count.strict_add(1);
+                    })
+                    .map(Option::unwrap_or_default),
+            );
+            self.bitmap.extend(validity.iter().take(count));
+            if count < VALIDITY_CHUNK {
+                break;
+            }
+        }
     }
 }
 
@@ -241,6 +274,57 @@ mod tests {
         assert_eq!(
             validity.iter_views().collect::<Vec<_>>(),
             [Some(1), None, Some(3), Some(4), Some(5)]
+        );
+    }
+
+    #[test]
+    fn from_iter_across_chunks() {
+        let input = (0..2500_u32)
+            .map(|index| (index % 3 != 0).then_some(index))
+            .collect::<Vec<_>>();
+        let validity = input.clone().into_iter().collect::<Validity<Vec<_>>>();
+        assert_eq!(validity.len(), input.len());
+        assert_eq!(validity.iter_views().collect::<Vec<_>>(), input);
+    }
+
+    #[test]
+    fn extend_across_chunks() {
+        let input = (0..2500_u32)
+            .map(|index| (index % 3 != 0).then_some(index))
+            .collect::<Vec<_>>();
+        let mut validity = Validity::<Vec<u32>>::default();
+        validity.extend(input.clone());
+        assert_eq!(validity.len(), input.len());
+        assert_eq!(validity.iter_views().collect::<Vec<_>>(), input);
+    }
+
+    #[test]
+    fn extend_panic_realigns() {
+        extern crate std;
+        use std::panic::{AssertUnwindSafe, catch_unwind};
+
+        let mut validity = IntoIterator::into_iter([Some(1), None]).collect::<Validity<Vec<_>>>();
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                validity.extend(
+                    [Some(3), Some(4)]
+                        .into_iter()
+                        .chain(iter::once_with(|| panic!("boom"))),
+                );
+            }))
+            .is_err()
+        );
+
+        // The items of the interrupted extension are not exposed.
+        assert_eq!(validity.len(), 2);
+        assert_eq!(validity.view(2), None);
+
+        // A subsequent extension surfaces them as null.
+        validity.extend([Some(5)]);
+        assert_eq!(validity.len(), 5);
+        assert_eq!(
+            validity.iter_views().collect::<Vec<_>>(),
+            [Some(1), None, None, None, Some(5)]
         );
     }
 }


### PR DESCRIPTION
## Problem

`Validity::extend` updated the bitmap before committing each value. If the source iterator panicked and the collection was reused, the bitmap could point past the committed values, causing null fabrication or index misalignment.

## Change

Validity bits are buffered in chunks of 1024 and committed after the corresponding values.

After a panic:

- completed chunks remain visible;
- the incomplete chunk remains hidden;
- the next extension discards its uncommitted value suffix using `CollectionRealloc::truncate`;
- nested `Validity` collections recover recursively.

`Bitmap` follows the same partial-prefix semantics: committed bits remain visible, while subsequent extensions overwrite uncommitted packed bits.

`FromIterator` remains unchanged because a partially constructed collection cannot escape on panic.

## Tests

Covers incomplete chunks, completed chunks, nested validity, packed bitmap recovery, and chunk-boundary round trips.
