### PR TITLE
feat: add `Validity::try_from_parts` and `into_parts`

### DIFF
--- a/src/validity.rs
+++ b/src/validity.rs
@@ -29,6 +29,59 @@ pub struct Validity<T: Collection, Storage: Buffer = VecBuffer> {
     bitmap: Bitmap<Storage>,
 }
 
+/// Error returned by [`Validity::try_from_parts`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ValidityError {
+    /// The collection and the validity bitmap have different lengths.
+    LengthMismatch {
+        /// The length of the collection.
+        collection: usize,
+        /// The length of the validity bitmap.
+        bitmap: usize,
+    },
+}
+
+impl fmt::Display for ValidityError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::LengthMismatch { collection, bitmap } => write!(
+                f,
+                "collection length ({collection}) does not match bitmap length ({bitmap})"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for ValidityError {}
+
+impl<T: Collection, Storage: Buffer> Validity<T, Storage> {
+    /// Constructs a [`Validity`] from a `collection` and its validity `bitmap`.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ValidityError`] when the length of the collection does not
+    /// match the length of the bitmap.
+    pub fn try_from_parts(collection: T, bitmap: Bitmap<Storage>) -> Result<Self, ValidityError> {
+        let (collection_len, bitmap_len) = (collection.len(), bitmap.len());
+        if collection_len == bitmap_len {
+            Ok(Self { collection, bitmap })
+        } else {
+            Err(ValidityError::LengthMismatch {
+                collection: collection_len,
+                bitmap: bitmap_len,
+            })
+        }
+    }
+
+    /// Returns the collection and validity bitmap of this [`Validity`].
+    ///
+    /// This is the inverse of [`Validity::try_from_parts`].
+    #[must_use]
+    pub fn into_parts(self) -> (T, Bitmap<Storage>) {
+        (self.collection, self.bitmap)
+    }
+}
+
 impl<T: Collection + Debug, Storage: Buffer> Debug for Validity<T, Storage>
 where
     Bitmap<Storage>: Debug,
@@ -229,6 +282,33 @@ mod tests {
         let validity = IntoIterator::into_iter(input).collect::<Validity<Vec<_>>>();
         assert_eq!(validity.len(), 4);
         assert_eq!(Collection::iter_views(&validity).collect::<Vec<_>>(), input);
+    }
+
+    #[test]
+    fn try_from_parts() {
+        let collection = alloc::vec![1, 0, 3, 4];
+        let bitmap = Bitmap::<VecBuffer>::from_iter([true, false, true, true]);
+        let validity = Validity::try_from_parts(collection, bitmap).expect("valid parts");
+        assert_eq!(validity.len(), 4);
+        assert_eq!(validity.view(0), Some(Some(1)));
+        assert_eq!(validity.view(1), Some(None));
+        let (values, restored) = validity.into_parts();
+        assert_eq!(values, alloc::vec![1, 0, 3, 4]);
+        assert_eq!(restored.len(), 4);
+    }
+
+    #[test]
+    fn try_from_parts_length_mismatch() {
+        let bitmap = Bitmap::<VecBuffer>::from_iter([true, false]);
+        let error = Validity::<Vec<i32>>::try_from_parts(alloc::vec![1, 2, 3], bitmap)
+            .expect_err("length mismatch");
+        assert_eq!(
+            error,
+            ValidityError::LengthMismatch {
+                collection: 3,
+                bitmap: 2,
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Add a fallible `Validity::try_from_parts(collection, bitmap)` constructor (validating that the collection and bitmap lengths match) and an `into_parts` inverse, plus a `ValidityError` type.