### PR TITLE
feat: add `CollectionRealloc::truncate`

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -107,6 +107,10 @@ where
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
 }
 
 #[cfg(test)]

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -275,6 +275,14 @@ impl<Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>> CollectionRe
             self.buffer.reserve(bytes_for_bits(bits));
         }
     }
+
+    fn truncate(&mut self, len: usize) {
+        if len < self.bits {
+            // Bits beyond the logical end are unspecified; a subsequent
+            // extension overwrites them (see the buffer invariant).
+            self.bits = len;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -493,6 +501,23 @@ mod tests {
             assert_eq!(iter.len(), remaining);
         }
         assert_eq!(remaining, 0);
+    }
+
+    #[test]
+    fn truncate() {
+        let mut bitmap = Bitmap::<VecBuffer>::from_iter([true, false, true, true]);
+        bitmap.truncate(2);
+        assert_eq!(bitmap.len(), 2);
+        assert_eq!(bitmap.iter_views().collect::<Vec<_>>(), [true, false]);
+        // Truncating beyond the length is a no-op.
+        bitmap.truncate(5);
+        assert_eq!(bitmap.len(), 2);
+        // A subsequent extension overwrites the stale bits.
+        bitmap.extend([false, false]);
+        assert_eq!(
+            bitmap.iter_views().collect::<Vec<_>>(),
+            [true, false, false, false]
+        );
     }
 
     #[test]

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -84,6 +84,12 @@ impl<C: CollectionRealloc, const N: usize> CollectionRealloc for Flatten<C, N> {
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional.strict_mul(N));
     }
+
+    fn truncate(&mut self, len: usize) {
+        if len < self.len() {
+            self.0.truncate(len.strict_mul(N));
+        }
+    }
 }
 
 /// A view of `Flatten`. This is an array with N views of the inner collection.
@@ -178,6 +184,28 @@ mod tests {
                 .map(|items| items.map(|item| *item)),
             Some([[5, 6], [7, 8]])
         );
+    }
+
+    #[test]
+    fn truncate() {
+        let mut flatten = [[1, 2], [3, 4], [5, 6]]
+            .into_iter()
+            .collect::<Flatten<Vec<i32>, 2>>();
+        assert_eq!(flatten.len(), 3);
+        flatten.truncate(1);
+        assert_eq!(flatten.len(), 1);
+        assert_eq!(flatten.owned(0), Some([1, 2]));
+    }
+
+    #[test]
+    fn truncate_beyond_len_is_noop() {
+        let mut flatten = [[1, 2], [3, 4]]
+            .into_iter()
+            .collect::<Flatten<Vec<i32>, 2>>();
+        // Must not overflow `len * N`.
+        flatten.truncate(usize::MAX);
+        assert_eq!(flatten.len(), 2);
+        assert_eq!(flatten.owned(1), Some([3, 4]));
     }
 
     #[test]

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -59,6 +59,12 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);
+
+    /// Shortens this collection to `len` items, dropping the rest.
+    ///
+    /// If `len` is greater than or equal to the current length, this has no
+    /// effect.
+    fn truncate(&mut self, len: usize);
 }
 
 #[cfg(test)]

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -43,4 +43,8 @@ impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
     fn reserve(&mut self, additional: usize) {
         Vec::reserve(self, additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        Vec::truncate(self, len);
+    }
 }

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -105,6 +105,10 @@ where
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
 }
 
 #[cfg(test)]

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -131,6 +131,10 @@ where
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
 }
 
 #[cfg(test)]

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -119,6 +119,10 @@ where
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
 }
 
 #[cfg(test)]

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -123,6 +123,10 @@ where
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        self.0.truncate(len);
+    }
 }
 
 #[cfg(test)]

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -227,6 +227,15 @@ where
         self.data.reserve(additional);
         self.offsets.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        if len < self.len() {
+            // Keep `len` lists: `len + 1` offsets and the data they reference.
+            let data_len = self.offsets.owned(len).expect("offset in range").as_usize();
+            self.offsets.truncate(len.strict_add(1));
+            self.data.truncate(data_len);
+        }
+    }
 }
 
 #[expect(missing_debug_implementations)]
@@ -417,6 +426,18 @@ mod tests {
             end: 1,
         };
         assert!(<_ as PartialEq<Vec<_>>>::eq(&view, &vec![42]));
+    }
+
+    #[test]
+    fn truncate() {
+        let mut offsets = [vec![1, 2], vec![3], vec![4, 5, 6]]
+            .into_iter()
+            .collect::<Offsets<Vec<i32>>>();
+        assert_eq!(offsets.len(), 3);
+        offsets.truncate(1);
+        assert_eq!(offsets.len(), 1);
+        assert_eq!(offsets.owned(0), Some(vec![1, 2]));
+        assert_eq!(offsets.owned(1), None);
     }
 
     #[test]

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -190,6 +190,11 @@ impl<
         self.bitmap.reserve(additional);
         self.collection.reserve(additional);
     }
+
+    fn truncate(&mut self, len: usize) {
+        self.bitmap.truncate(len);
+        self.collection.truncate(len);
+    }
 }
 
 #[cfg(test)]
@@ -229,6 +234,18 @@ mod tests {
         let validity = IntoIterator::into_iter(input).collect::<Validity<Vec<_>>>();
         assert_eq!(validity.len(), 4);
         assert_eq!(Collection::iter_views(&validity).collect::<Vec<_>>(), input);
+    }
+
+    #[test]
+    fn truncate() {
+        let mut validity = [Some(1), None, Some(3), Some(4)]
+            .into_iter()
+            .collect::<Validity<Vec<_>>>();
+        validity.truncate(2);
+        assert_eq!(validity.len(), 2);
+        assert_eq!(validity.view(0), Some(Some(1)));
+        assert_eq!(validity.view(1), Some(None));
+        assert_eq!(validity.view(2), None);
     }
 
     #[test]


### PR DESCRIPTION
Add a `truncate(len)` method to `CollectionRealloc` that shortens a collection to `len` items (a no-op when `len` is not smaller than the current length), implemented for every collection and layout.