### PR TITLE
feat: allocate bitmap and flatten with handles

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 /// Returns the number of bytes required to store the given number of bits.
 #[inline]
 pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
-    bits.saturating_add(7) / 8
+    bits.div_ceil(8)
 }
 
 /// Error returned by [`Bitmap::try_from_parts`].
@@ -362,6 +362,11 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::*;
+
+    #[test]
+    fn bytes_for_bits_does_not_saturate_before_rounding() {
+        assert_eq!(bytes_for_bits(usize::MAX), usize::MAX / 8 + 1);
+    }
 
     #[test]
     fn from_iter() {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -15,7 +15,7 @@ use unpacked::{BitUnpacked, BitUnpackedExt};
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     length::Length,
 };
 
@@ -333,6 +333,61 @@ impl<Storage: Buffer<For<u8>: CollectionAlloc>> CollectionAlloc for Bitmap<Stora
             bits: 0,
             offset: 0,
         }
+    }
+}
+
+impl<Storage: Buffer<For<u8>: CollectionAllocIn>> CollectionAllocIn for Bitmap<Storage> {
+    type Alloc = <Storage::For<u8> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self {
+            buffer: Storage::For::<u8>::with_capacity_in(bytes_for_bits(capacity), alloc),
+            bits: 0,
+            offset: 0,
+        }
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        let mut bits: usize = 0;
+        let buffer = Storage::For::<u8>::from_iter_in(
+            iter.into_iter()
+                .inspect(|_| bits = bits.strict_add(1))
+                .bit_packed(),
+            alloc,
+        );
+        Self {
+            buffer,
+            bits,
+            offset: 0,
+        }
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        Storage::For::<u8>::try_with_capacity_in(bytes_for_bits(capacity), alloc).map(|buffer| {
+            Self {
+                buffer,
+                bits: 0,
+                offset: 0,
+            }
+        })
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        let mut bits: usize = 0;
+        let buffer = Storage::For::<u8>::try_from_iter_in(
+            iter.into_iter()
+                .inspect(|_| bits = bits.strict_add(1))
+                .bit_packed(),
+            alloc,
+        )?;
+        Ok(Self {
+            buffer,
+            bits,
+            offset: 0,
+        })
     }
 }
 

--- a/src/bitmap/packed.rs
+++ b/src/bitmap/packed.rs
@@ -117,15 +117,15 @@ mod tests {
         assert_eq!((1, Some(1)), [false; 8].iter().bit_packed().size_hint());
         assert_eq!((2, Some(2)), [false; 9].iter().bit_packed().size_hint());
         assert_eq!(
-            (usize::MAX / 8, None),
+            (usize::MAX / 8 + 1, None),
             (0..).map(|_| true).bit_packed().size_hint()
         );
         assert_eq!(
-            (usize::MAX / 8, None),
+            (usize::MAX / 8 + 1, None),
             (0..=usize::MAX).map(|_| true).bit_packed().size_hint()
         );
         assert_eq!(
-            (usize::MAX / 8, Some(usize::MAX / 8)),
+            (usize::MAX / 8 + 1, Some(usize::MAX / 8 + 1)),
             (0..usize::MAX).map(|_| true).bit_packed().size_hint()
         );
         assert_eq!((1, Some(1)), (0..3).map(|_| true).bit_packed().size_hint());

--- a/src/collection/box.rs
+++ b/src/collection/box.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use core::{iter::Map, slice};
 
-use crate::collection::{Collection, CollectionAlloc, view::AsView};
+use crate::collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, view::AsView};
 
 impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
     type View<'collection>
@@ -36,5 +36,28 @@ impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
 impl<T: for<'any> AsView<'any>> CollectionAlloc for Box<[T]> {
     fn with_capacity(capacity: usize) -> Self {
         Vec::with_capacity(capacity).into_boxed_slice()
+    }
+}
+
+impl<T: for<'any> AsView<'any>> CollectionAllocIn for Box<[T]> {
+    type Alloc = ();
+
+    fn with_capacity_in(capacity: usize, (): Self::Alloc) -> Self {
+        Vec::with_capacity(capacity).into_boxed_slice()
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, (): Self::Alloc) -> Self {
+        iter.into_iter().collect::<Vec<_>>().into_boxed_slice()
+    }
+
+    fn try_with_capacity_in(capacity: usize, (): Self::Alloc) -> Result<Self, AllocError> {
+        <Vec<T> as CollectionAllocIn>::try_with_capacity_in(capacity, ()).map(Vec::into_boxed_slice)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        (): Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        <Vec<T> as CollectionAllocIn>::try_from_iter_in(iter, ()).map(Vec::into_boxed_slice)
     }
 }

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -7,7 +7,10 @@ use core::{
 };
 
 use crate::{
-    collection::{Collection, CollectionAlloc, CollectionRealloc, owned::IntoOwned},
+    collection::{
+        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        owned::IntoOwned,
+    },
     length::Length,
 };
 
@@ -131,6 +134,30 @@ impl<C: Collection, const N: usize> Collection for Flatten<C, N> {
 impl<C: CollectionAlloc, const N: usize> CollectionAlloc for Flatten<C, N> {
     fn with_capacity(capacity: usize) -> Self {
         Self(C::with_capacity(capacity.strict_mul(N)))
+    }
+}
+
+impl<C: CollectionAllocIn, const N: usize> CollectionAllocIn for Flatten<C, N> {
+    type Alloc = C::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(C::with_capacity_in(capacity.strict_mul(N), alloc))
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(C::from_iter_in(iter.into_iter().flatten(), alloc))
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        let child_capacity = capacity.checked_mul(N).ok_or(AllocError)?;
+        C::try_with_capacity_in(child_capacity, alloc).map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        C::try_from_iter_in(iter.into_iter().flatten(), alloc).map(Self)
     }
 }
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -79,9 +79,19 @@ pub trait CollectionAllocIn: Collection + Sized {
     fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self;
 
     /// Tries to construct an empty collection with the requested capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when the requested capacity cannot be
+    /// reserved.
     fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError>;
 
     /// Tries to construct a collection from `iter`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when storage for the items cannot be
+    /// reserved.
     fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
         iter: I,
         alloc: Self::Alloc,

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -12,6 +12,8 @@ pub mod vec;
 
 pub mod flatten;
 
+use core::fmt;
+
 use crate::{collection::owned::IntoOwned, length::Length};
 
 /// A collection of items.
@@ -47,6 +49,43 @@ pub trait Collection: Length {
 
     /// Returns an interator over items in this collection.
     fn into_iter_owned(self) -> Self::IntoIter;
+}
+
+/// Error returned when storage for a collection cannot be reserved.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AllocError;
+
+impl fmt::Display for AllocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "collection capacity could not be reserved")
+    }
+}
+
+impl core::error::Error for AllocError {}
+
+/// An allocatable collection of items using a caller-provided allocator.
+pub trait CollectionAllocIn: Collection + Sized {
+    /// Allocator used to construct this collection.
+    type Alloc: Clone;
+
+    /// Constructs a new, empty collection with at least the specified capacity
+    /// using `alloc` and its native infallible failure handling.
+    #[must_use]
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self;
+
+    /// Constructs a collection from `iter` using `alloc` and its native
+    /// infallible failure handling.
+    #[must_use]
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self;
+
+    /// Tries to construct an empty collection with the requested capacity.
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError>;
+
+    /// Tries to construct a collection from `iter`.
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError>;
 }
 
 /// An allocatable collection of items.

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -41,6 +41,10 @@ impl<T: for<'any> AsView<'any>> CollectionAlloc for Vec<T> {
     }
 }
 
+// The analogous fallible and allocator-aware `Vec` constructors are nightly-only:
+// https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.try_with_capacity
+// https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.with_capacity_in
+// This stable implementation represents the global allocator as `()`.
 impl<T: for<'any> AsView<'any>> CollectionAllocIn for Vec<T> {
     type Alloc = ();
 

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -3,7 +3,9 @@ extern crate alloc;
 use alloc::vec::{self, Vec};
 use core::{iter::Map, slice};
 
-use crate::collection::{Collection, CollectionAlloc, CollectionRealloc, view::AsView};
+use crate::collection::{
+    AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
+};
 
 impl<T: for<'any> AsView<'any>> Collection for Vec<T> {
     type View<'collection>
@@ -39,6 +41,40 @@ impl<T: for<'any> AsView<'any>> CollectionAlloc for Vec<T> {
     }
 }
 
+impl<T: for<'any> AsView<'any>> CollectionAllocIn for Vec<T> {
+    type Alloc = ();
+
+    fn with_capacity_in(capacity: usize, (): Self::Alloc) -> Self {
+        Vec::with_capacity(capacity)
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, (): Self::Alloc) -> Self {
+        iter.into_iter().collect()
+    }
+
+    fn try_with_capacity_in(capacity: usize, (): Self::Alloc) -> Result<Self, AllocError> {
+        let mut collection = Vec::new();
+        collection
+            .try_reserve_exact(capacity)
+            .map_err(|_| AllocError)?;
+        Ok(collection)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        (): Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        let mut items = iter.into_iter();
+        let (capacity, _) = items.size_hint();
+        let mut collection = <Self as CollectionAllocIn>::try_with_capacity_in(capacity, ())?;
+        for item in items.by_ref() {
+            collection.try_reserve(1).map_err(|_| AllocError)?;
+            collection.push(item);
+        }
+        Ok(collection)
+    }
+}
+
 impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
     fn reserve(&mut self, additional: usize) {
         Vec::reserve(self, additional);
@@ -46,5 +82,28 @@ impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
 
     fn truncate(&mut self, len: usize) {
         Vec::truncate(self, len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alloc_in() {
+        let collection = <Vec<u32> as CollectionAllocIn>::try_from_iter_in([1, 2, 3, 4], ())
+            .expect("allocation succeeds");
+        assert_eq!(collection, [1, 2, 3, 4]);
+
+        let infallible = <Vec<u32> as CollectionAllocIn>::from_iter_in([5, 6, 7, 8], ());
+        assert_eq!(infallible, [5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn alloc_in_capacity_overflow() {
+        assert_eq!(
+            <Vec<u32> as CollectionAllocIn>::try_with_capacity_in(usize::MAX, ()),
+            Err(AllocError)
+        );
     }
 }


### PR DESCRIPTION
Add allocator-aware construction for Bitmap and Flatten.

Stacked on #544.