### PR TITLE
refactor: make allocator-aware allocation the foundation

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -146,6 +146,17 @@ impl<T: Layout, Storage: Buffer> CollectionRealloc for Array<T, Storage>
 where
     T::Memory<Storage>: CollectionRealloc,
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.0.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        self.0.try_extend(iter)
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }

--- a/src/array.rs
+++ b/src/array.rs
@@ -186,6 +186,24 @@ mod tests {
     }
 
     #[test]
+    fn alloc_in_nested() {
+        type Nested = Array<Option<alloc::vec::Vec<i32>>>;
+
+        let infallible =
+            <Nested as CollectionAllocIn>::from_iter_in([Some(alloc::vec![1, 2]), None], ());
+        assert_eq!(infallible.owned(0), Some(Some(alloc::vec![1, 2])));
+        assert_eq!(infallible.owned(1), Some(None));
+
+        let mut array =
+            <Nested as CollectionAllocIn>::try_from_iter_in([Some(alloc::vec![1, 2]), None], ())
+                .expect("allocation succeeds");
+        array
+            .try_extend([Some(alloc::vec![3, 4, 5])])
+            .expect("allocation succeeds");
+        assert_eq!(array.owned(2), Some(Some(alloc::vec![3, 4, 5])));
+    }
+
+    #[test]
     fn collection() {
         // Boolean
         round_trip::<Array<_>, _>([true, false, true, true]);

--- a/src/array.rs
+++ b/src/array.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::Layout,
     length::Length,
 };
@@ -130,15 +130,6 @@ where
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError> {
         T::Memory::<Storage>::try_from_iter_in(iter, alloc).map(Self)
-    }
-}
-
-impl<T: Layout, Storage: Buffer> CollectionAlloc for Array<T, Storage>
-where
-    T::Memory<Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(T::Memory::<Storage>::with_capacity(capacity))
     }
 }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     layout::Layout,
     length::Length,
 };
@@ -104,6 +104,32 @@ impl<T: Layout, Storage: Buffer> Collection for Array<T, Storage> {
 
     fn into_iter_owned(self) -> Self::IntoIter {
         self.0.into_iter_owned()
+    }
+}
+
+impl<T: Layout, Storage: Buffer> CollectionAllocIn for Array<T, Storage>
+where
+    T::Memory<Storage>: CollectionAllocIn,
+{
+    type Alloc = <T::Memory<Storage> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(T::Memory::<Storage>::with_capacity_in(capacity, alloc))
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(T::Memory::<Storage>::from_iter_in(iter, alloc))
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        T::Memory::<Storage>::try_with_capacity_in(capacity, alloc).map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        T::Memory::<Storage>::try_from_iter_in(iter, alloc).map(Self)
     }
 }
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -326,16 +326,6 @@ impl<Storage: Buffer> Collection for Bitmap<Storage> {
     }
 }
 
-impl<Storage: Buffer<For<u8>: CollectionAlloc>> CollectionAlloc for Bitmap<Storage> {
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            buffer: Storage::For::<u8>::with_capacity(bytes_for_bits(capacity)),
-            bits: 0,
-            offset: 0,
-        }
-    }
-}
-
 impl<Storage: Buffer<For<u8>: CollectionAllocIn>> CollectionAllocIn for Bitmap<Storage> {
     type Alloc = <Storage::For<u8> as CollectionAllocIn>::Alloc;
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -22,7 +22,7 @@ use crate::{
 /// Returns the number of bytes required to store the given number of bits.
 #[inline]
 pub(crate) const fn bytes_for_bits(bits: usize) -> usize {
-    bits.saturating_add(7) / 8
+    bits.div_ceil(8)
 }
 
 /// Error returned by [`Bitmap::try_from_parts`].
@@ -362,6 +362,11 @@ mod tests {
     use alloc::vec::Vec;
 
     use super::*;
+
+    #[test]
+    fn bytes_for_bits_does_not_saturate_before_rounding() {
+        assert_eq!(bytes_for_bits(usize::MAX), usize::MAX / 8 + 1);
+    }
 
     #[test]
     fn from_iter() {

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -15,7 +15,7 @@ use unpacked::{BitUnpacked, BitUnpackedExt};
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     length::Length,
 };
 
@@ -333,6 +333,61 @@ impl<Storage: Buffer<For<u8>: CollectionAlloc>> CollectionAlloc for Bitmap<Stora
             bits: 0,
             offset: 0,
         }
+    }
+}
+
+impl<Storage: Buffer<For<u8>: CollectionAllocIn>> CollectionAllocIn for Bitmap<Storage> {
+    type Alloc = <Storage::For<u8> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self {
+            buffer: Storage::For::<u8>::with_capacity_in(bytes_for_bits(capacity), alloc),
+            bits: 0,
+            offset: 0,
+        }
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        let mut bits: usize = 0;
+        let buffer = Storage::For::<u8>::from_iter_in(
+            iter.into_iter()
+                .inspect(|_| bits = bits.strict_add(1))
+                .bit_packed(),
+            alloc,
+        );
+        Self {
+            buffer,
+            bits,
+            offset: 0,
+        }
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        Storage::For::<u8>::try_with_capacity_in(bytes_for_bits(capacity), alloc).map(|buffer| {
+            Self {
+                buffer,
+                bits: 0,
+                offset: 0,
+            }
+        })
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        let mut bits: usize = 0;
+        let buffer = Storage::For::<u8>::try_from_iter_in(
+            iter.into_iter()
+                .inspect(|_| bits = bits.strict_add(1))
+                .bit_packed(),
+            alloc,
+        )?;
+        Ok(Self {
+            buffer,
+            bits,
+            offset: 0,
+        })
     }
 }
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -394,6 +394,60 @@ impl<Storage: Buffer<For<u8>: CollectionAllocIn>> CollectionAllocIn for Bitmap<S
 impl<Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>> CollectionRealloc
     for Bitmap<Storage>
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        if let Some(bits) = additional.checked_sub(self.trailing_bits()) {
+            self.buffer.try_reserve(bytes_for_bits(bits))?;
+        }
+        Ok(())
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        let original_bits = self.bits;
+        let mut items = iter.into_iter().fuse();
+
+        let bit_index = self.bit_index(self.bits);
+        if bit_index != 0 {
+            let byte_index = self.byte_index(self.bits);
+            if let Some(byte) = self.buffer.borrow_mut().get_mut(byte_index) {
+                for index in bit_index..8 {
+                    if let Some(next) = items.next() {
+                        *byte = (*byte & !(1 << index)) | (u8::from(next) << index);
+                        self.bits = self.bits.strict_add(1);
+                    }
+                }
+            }
+        }
+
+        if let Some(first) = items.next() {
+            let mut consumed: usize = 0;
+            let mut packed = iter::once(first)
+                .chain(items)
+                .inspect(|_| consumed = consumed.strict_add(1))
+                .bit_packed();
+
+            let mut byte_index = self.byte_index(self.bits);
+            while let Some(byte) = self.buffer.borrow_mut().get_mut(byte_index) {
+                match packed.next() {
+                    Some(packed_byte) => {
+                        *byte = packed_byte;
+                        byte_index = byte_index.strict_add(1);
+                    }
+                    None => break,
+                }
+            }
+
+            if let Err(error) = self.buffer.try_extend(packed) {
+                self.bits = original_bits;
+                return Err(error);
+            }
+            self.bits = self.bits.strict_add(consumed);
+        }
+        Ok(())
+    }
+
     fn reserve(&mut self, additional: usize) {
         if let Some(bits) = additional.checked_sub(self.trailing_bits()) {
             self.buffer.reserve(bytes_for_bits(bits));

--- a/src/bitmap/packed.rs
+++ b/src/bitmap/packed.rs
@@ -117,15 +117,15 @@ mod tests {
         assert_eq!((1, Some(1)), [false; 8].iter().bit_packed().size_hint());
         assert_eq!((2, Some(2)), [false; 9].iter().bit_packed().size_hint());
         assert_eq!(
-            (usize::MAX / 8, None),
+            (usize::MAX / 8 + 1, None),
             (0..).map(|_| true).bit_packed().size_hint()
         );
         assert_eq!(
-            (usize::MAX / 8, None),
+            (usize::MAX / 8 + 1, None),
             (0..=usize::MAX).map(|_| true).bit_packed().size_hint()
         );
         assert_eq!(
-            (usize::MAX / 8, Some(usize::MAX / 8)),
+            (usize::MAX / 8 + 1, Some(usize::MAX / 8 + 1)),
             (0..usize::MAX).map(|_| true).bit_packed().size_hint()
         );
         assert_eq!((1, Some(1)), (0..3).map(|_| true).bit_packed().size_hint());

--- a/src/collection/box.rs
+++ b/src/collection/box.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use core::{iter::Map, slice};
 
-use crate::collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, view::AsView};
+use crate::collection::{AllocError, Collection, CollectionAllocIn, view::AsView};
 
 impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
     type View<'collection>
@@ -30,12 +30,6 @@ impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
 
     fn into_iter_owned(self) -> Self::IntoIter {
         <Box<[T]> as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: for<'any> AsView<'any>> CollectionAlloc for Box<[T]> {
-    fn with_capacity(capacity: usize) -> Self {
-        Vec::with_capacity(capacity).into_boxed_slice()
     }
 }
 

--- a/src/collection/box.rs
+++ b/src/collection/box.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use core::{iter::Map, slice};
 
-use crate::collection::{Collection, CollectionAlloc, view::AsView};
+use crate::collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, view::AsView};
 
 impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
     type View<'collection>
@@ -36,5 +36,28 @@ impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
 impl<T: for<'any> AsView<'any>> CollectionAlloc for Box<[T]> {
     fn with_capacity(capacity: usize) -> Self {
         Vec::with_capacity(capacity).into_boxed_slice()
+    }
+}
+
+impl<T: for<'any> AsView<'any>> CollectionAllocIn for Box<[T]> {
+    type Alloc = ();
+
+    fn with_capacity_in(capacity: usize, (): Self::Alloc) -> Self {
+        Vec::with_capacity(capacity).into_boxed_slice()
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, (): Self::Alloc) -> Self {
+        iter.into_iter().collect::<Vec<_>>().into_boxed_slice()
+    }
+
+    fn try_with_capacity_in(capacity: usize, (): Self::Alloc) -> Result<Self, AllocError> {
+        <Vec<T> as CollectionAllocIn>::try_with_capacity_in(capacity, ()).map(Vec::into_boxed_slice)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        (): Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        <Vec<T> as CollectionAllocIn>::try_from_iter_in(iter, ()).map(Vec::into_boxed_slice)
     }
 }

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -162,6 +162,18 @@ impl<C: CollectionAllocIn, const N: usize> CollectionAllocIn for Flatten<C, N> {
 }
 
 impl<C: CollectionRealloc, const N: usize> CollectionRealloc for Flatten<C, N> {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        let child_additional = additional.checked_mul(N).ok_or(AllocError)?;
+        self.0.try_reserve(child_additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        self.0.try_extend(iter.into_iter().flatten())
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional.strict_mul(N));
     }

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -131,12 +131,6 @@ impl<C: Collection, const N: usize> Collection for Flatten<C, N> {
     }
 }
 
-impl<C: CollectionAlloc, const N: usize> CollectionAlloc for Flatten<C, N> {
-    fn with_capacity(capacity: usize) -> Self {
-        Self(C::with_capacity(capacity.strict_mul(N)))
-    }
-}
-
 impl<C: CollectionAllocIn, const N: usize> CollectionAllocIn for Flatten<C, N> {
     type Alloc = C::Alloc;
 

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -7,7 +7,10 @@ use core::{
 };
 
 use crate::{
-    collection::{Collection, CollectionAlloc, CollectionRealloc, owned::IntoOwned},
+    collection::{
+        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        owned::IntoOwned,
+    },
     length::Length,
 };
 
@@ -131,6 +134,30 @@ impl<C: Collection, const N: usize> Collection for Flatten<C, N> {
 impl<C: CollectionAlloc, const N: usize> CollectionAlloc for Flatten<C, N> {
     fn with_capacity(capacity: usize) -> Self {
         Self(C::with_capacity(capacity.strict_mul(N)))
+    }
+}
+
+impl<C: CollectionAllocIn, const N: usize> CollectionAllocIn for Flatten<C, N> {
+    type Alloc = C::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(C::with_capacity_in(capacity.strict_mul(N), alloc))
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(C::from_iter_in(iter.into_iter().flatten(), alloc))
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        let child_capacity = capacity.checked_mul(N).ok_or(AllocError)?;
+        C::try_with_capacity_in(child_capacity, alloc).map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        C::try_from_iter_in(iter.into_iter().flatten(), alloc).map(Self)
     }
 }
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -79,9 +79,19 @@ pub trait CollectionAllocIn: Collection + Sized {
     fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self;
 
     /// Tries to construct an empty collection with the requested capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when the requested capacity cannot be
+    /// reserved.
     fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError>;
 
     /// Tries to construct a collection from `iter`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when storage for the items cannot be
+    /// reserved.
     fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
         iter: I,
         alloc: Self::Alloc,

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -96,6 +96,17 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 
 /// A re-allocatable collection of items.
 pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
+    /// Tries to reserve capacity for at least `additional` more items.
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError>;
+
+    /// Tries to extend this collection with the contents of `iter`.
+    ///
+    /// The collection's logical contents are unchanged when reservation fails.
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError>;
+
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
     fn reserve(&mut self, additional: usize);
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -107,11 +107,20 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 /// A re-allocatable collection of items.
 pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
     /// Tries to reserve capacity for at least `additional` more items.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when the requested capacity cannot be
+    /// reserved.
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError>;
 
     /// Tries to extend this collection with the contents of `iter`.
     ///
-    /// The collection's logical contents are unchanged when reservation fails.
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when storage for the additional items cannot
+    /// be reserved. The collection's logical contents are unchanged when a
+    /// reservation fails.
     fn try_extend<I: IntoIterator<Item = Self::Owned>>(
         &mut self,
         iter: I,

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -95,7 +95,7 @@ pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
 }
 
 /// A re-allocatable collection of items.
-pub trait CollectionRealloc: CollectionAlloc + Extend<Self::Owned> {
+pub trait CollectionRealloc: CollectionAllocIn + Extend<Self::Owned> {
     /// Tries to reserve capacity for at least `additional` more items.
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError>;
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -12,6 +12,8 @@ pub mod vec;
 
 pub mod flatten;
 
+use core::fmt;
+
 use crate::{collection::owned::IntoOwned, length::Length};
 
 /// A collection of items.
@@ -47,6 +49,43 @@ pub trait Collection: Length {
 
     /// Returns an interator over items in this collection.
     fn into_iter_owned(self) -> Self::IntoIter;
+}
+
+/// Error returned when storage for a collection cannot be reserved.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AllocError;
+
+impl fmt::Display for AllocError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "collection capacity could not be reserved")
+    }
+}
+
+impl core::error::Error for AllocError {}
+
+/// An allocatable collection of items using a caller-provided allocator.
+pub trait CollectionAllocIn: Collection + Sized {
+    /// Allocator used to construct this collection.
+    type Alloc: Clone;
+
+    /// Constructs a new, empty collection with at least the specified capacity
+    /// using `alloc` and its native infallible failure handling.
+    #[must_use]
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self;
+
+    /// Constructs a collection from `iter` using `alloc` and its native
+    /// infallible failure handling.
+    #[must_use]
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self;
+
+    /// Tries to construct an empty collection with the requested capacity.
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError>;
+
+    /// Tries to construct a collection from `iter`.
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError>;
 }
 
 /// An allocatable collection of items.

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -98,10 +98,26 @@ pub trait CollectionAllocIn: Collection + Sized {
     ) -> Result<Self, AllocError>;
 }
 
-/// An allocatable collection of items.
-pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
+/// An allocatable collection of items using its default allocator.
+///
+/// This trait is implemented automatically for every [`CollectionAllocIn`]
+/// whose allocator implements [`Default`] and which can be constructed through
+/// [`Default`] and [`FromIterator`].
+pub trait CollectionAlloc:
+    CollectionAllocIn<Alloc: Default> + Default + FromIterator<Self::Owned>
+{
     /// Constructs a new, empty collection with at least the specified capacity.
-    fn with_capacity(capacity: usize) -> Self;
+    #[must_use]
+    fn with_capacity(capacity: usize) -> Self {
+        <Self as CollectionAllocIn>::with_capacity_in(capacity, Default::default())
+    }
+}
+
+impl<C> CollectionAlloc for C
+where
+    C: CollectionAllocIn + Default + FromIterator<C::Owned>,
+    C::Alloc: Default,
+{
 }
 
 /// A re-allocatable collection of items.
@@ -146,6 +162,13 @@ pub(crate) mod tests {
     use crate::collection::view::AsView;
 
     use super::*;
+
+    fn assert_collection_alloc<C: CollectionAlloc>() {}
+
+    #[test]
+    fn collection_alloc_is_blanket_implemented() {
+        assert_collection_alloc::<Vec<u32>>();
+    }
 
     pub(crate) fn round_trip<
         C: for<'any> CollectionAlloc<Owned = T, View<'any>: Debug>,

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -41,6 +41,10 @@ impl<T: for<'any> AsView<'any>> CollectionAlloc for Vec<T> {
     }
 }
 
+// The analogous fallible and allocator-aware `Vec` constructors are nightly-only:
+// https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.try_with_capacity
+// https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.with_capacity_in
+// This stable implementation represents the global allocator as `()`.
 impl<T: for<'any> AsView<'any>> CollectionAllocIn for Vec<T> {
     type Alloc = ();
 

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -3,7 +3,9 @@ extern crate alloc;
 use alloc::vec::{self, Vec};
 use core::{iter::Map, slice};
 
-use crate::collection::{Collection, CollectionAlloc, CollectionRealloc, view::AsView};
+use crate::collection::{
+    AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
+};
 
 impl<T: for<'any> AsView<'any>> Collection for Vec<T> {
     type View<'collection>
@@ -39,6 +41,40 @@ impl<T: for<'any> AsView<'any>> CollectionAlloc for Vec<T> {
     }
 }
 
+impl<T: for<'any> AsView<'any>> CollectionAllocIn for Vec<T> {
+    type Alloc = ();
+
+    fn with_capacity_in(capacity: usize, (): Self::Alloc) -> Self {
+        Vec::with_capacity(capacity)
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, (): Self::Alloc) -> Self {
+        iter.into_iter().collect()
+    }
+
+    fn try_with_capacity_in(capacity: usize, (): Self::Alloc) -> Result<Self, AllocError> {
+        let mut collection = Vec::new();
+        collection
+            .try_reserve_exact(capacity)
+            .map_err(|_| AllocError)?;
+        Ok(collection)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        (): Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        let mut items = iter.into_iter();
+        let (capacity, _) = items.size_hint();
+        let mut collection = <Self as CollectionAllocIn>::try_with_capacity_in(capacity, ())?;
+        for item in items.by_ref() {
+            collection.try_reserve(1).map_err(|_| AllocError)?;
+            collection.push(item);
+        }
+        Ok(collection)
+    }
+}
+
 impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
     fn reserve(&mut self, additional: usize) {
         Vec::reserve(self, additional);
@@ -46,5 +82,28 @@ impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
 
     fn truncate(&mut self, len: usize) {
         Vec::truncate(self, len);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn alloc_in() {
+        let collection = <Vec<u32> as CollectionAllocIn>::try_from_iter_in([1, 2, 3, 4], ())
+            .expect("allocation succeeds");
+        assert_eq!(collection, [1, 2, 3, 4]);
+
+        let infallible = <Vec<u32> as CollectionAllocIn>::from_iter_in([5, 6, 7, 8], ());
+        assert_eq!(infallible, [5, 6, 7, 8]);
+    }
+
+    #[test]
+    fn alloc_in_capacity_overflow() {
+        assert_eq!(
+            <Vec<u32> as CollectionAllocIn>::try_with_capacity_in(usize::MAX, ()),
+            Err(AllocError)
+        );
     }
 }

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -4,7 +4,7 @@ use alloc::vec::{self, Vec};
 use core::{iter::Map, slice};
 
 use crate::collection::{
-    AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
+    AllocError, Collection, CollectionAllocIn, CollectionRealloc, view::AsView,
 };
 
 impl<T: for<'any> AsView<'any>> Collection for Vec<T> {
@@ -32,12 +32,6 @@ impl<T: for<'any> AsView<'any>> Collection for Vec<T> {
 
     fn into_iter_owned(self) -> Self::IntoIter {
         <Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: for<'any> AsView<'any>> CollectionAlloc for Vec<T> {
-    fn with_capacity(capacity: usize) -> Self {
-        Vec::with_capacity(capacity)
     }
 }
 
@@ -117,9 +111,13 @@ impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::collection::CollectionAlloc;
 
     #[test]
     fn alloc_in() {
+        let reserved = <Vec<u32> as CollectionAlloc>::with_capacity(4);
+        assert!(reserved.capacity() >= 4);
+
         let collection = <Vec<u32> as CollectionAllocIn>::try_from_iter_in([1, 2, 3, 4], ())
             .expect("allocation succeeds");
         assert_eq!(collection, [1, 2, 3, 4]);

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -76,6 +76,25 @@ impl<T: for<'any> AsView<'any>> CollectionAllocIn for Vec<T> {
 }
 
 impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        Vec::try_reserve(self, additional).map_err(|_| AllocError)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        let len = self.len();
+        for item in iter {
+            if Vec::try_reserve(self, 1).is_err() {
+                Vec::truncate(self, len);
+                return Err(AllocError);
+            }
+            self.push(item);
+        }
+        Ok(())
+    }
+
     fn reserve(&mut self, additional: usize) {
         Vec::reserve(self, additional);
     }
@@ -101,9 +120,15 @@ mod tests {
 
     #[test]
     fn alloc_in_capacity_overflow() {
+        let mut collection = alloc::vec![1_u32, 2, 3, 4];
         assert_eq!(
             <Vec<u32> as CollectionAllocIn>::try_with_capacity_in(usize::MAX, ()),
             Err(AllocError)
         );
+        assert_eq!(
+            CollectionRealloc::try_reserve(&mut collection, usize::MAX),
+            Err(AllocError)
+        );
+        assert_eq!(collection, [1, 2, 3, 4]);
     }
 }

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 use crate::{
     bitmap::Bitmap,
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::MemoryLayout,
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -128,15 +128,6 @@ where
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError> {
         Nulls::Collection::try_from_iter_in(iter, alloc).map(Self)
-    }
-}
-
-impl<Nulls: Nullability, Storage: Buffer> CollectionAlloc for Boolean<Nulls, Storage>
-where
-    Nulls::Collection<Bitmap<Storage>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::with_capacity(capacity))
     }
 }
 

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -144,6 +144,17 @@ impl<Nulls: Nullability, Storage: Buffer> CollectionRealloc for Boolean<Nulls, S
 where
     Nulls::Collection<Bitmap<Storage>, Storage>: CollectionRealloc,
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.0.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        self.0.try_extend(iter)
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 use crate::{
     bitmap::Bitmap,
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     layout::MemoryLayout,
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -102,6 +102,32 @@ impl<Nulls: Nullability, Storage: Buffer> Collection for Boolean<Nulls, Storage>
 
     fn into_iter_owned(self) -> Self::IntoIter {
         self.0.into_iter_owned()
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> CollectionAllocIn for Boolean<Nulls, Storage>
+where
+    Nulls::Collection<Bitmap<Storage>, Storage>: CollectionAllocIn,
+{
+    type Alloc = <Nulls::Collection<Bitmap<Storage>, Storage> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(Nulls::Collection::with_capacity_in(capacity, alloc))
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(Nulls::Collection::from_iter_in(iter, alloc))
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        Nulls::Collection::try_with_capacity_in(capacity, alloc).map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        Nulls::Collection::try_from_iter_in(iter, alloc).map(Self)
     }
 }
 

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -2,10 +2,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{
-        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
-        flatten::Flatten,
-    },
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc, flatten::Flatten},
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -169,16 +166,6 @@ where
     ) -> Result<Self, AllocError> {
         Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::try_from_iter_in(iter, alloc)
             .map(Self)
-    }
-}
-
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAlloc
-    for FixedSizeList<T, N, Nulls, Storage>
-where
-    Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::with_capacity(capacity))
     }
 }
 

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -187,6 +187,17 @@ impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionR
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionRealloc,
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.0.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        self.0.try_extend(iter)
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -2,7 +2,10 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc, flatten::Flatten},
+    collection::{
+        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        flatten::Flatten,
+    },
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -128,6 +131,44 @@ impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Collection
 
     fn into_iter_owned(self) -> Self::IntoIter {
         self.0.into_iter_owned()
+    }
+}
+
+impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAllocIn
+    for FixedSizeList<T, N, Nulls, Storage>
+where
+    Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionAllocIn,
+{
+    type Alloc =
+        <Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(
+            Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::with_capacity_in(
+                capacity, alloc,
+            ),
+        )
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(
+            Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::from_iter_in(iter, alloc),
+        )
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::try_with_capacity_in(
+            capacity, alloc,
+        )
+        .map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::try_from_iter_in(iter, alloc)
+            .map(Self)
     }
 }
 

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     fixed_size::FixedSize,
     layout::MemoryLayout,
     length::Length,
@@ -114,6 +114,33 @@ impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> Collection
 
     fn into_iter_owned(self) -> Self::IntoIter {
         self.0.into_iter_owned()
+    }
+}
+
+impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> CollectionAllocIn
+    for FixedSizePrimitive<T, Nulls, Storage>
+where
+    Nulls::Collection<Storage::For<T>, Storage>: CollectionAllocIn,
+{
+    type Alloc = <Nulls::Collection<Storage::For<T>, Storage> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(Nulls::Collection::with_capacity_in(capacity, alloc))
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(Nulls::Collection::from_iter_in(iter, alloc))
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        Nulls::Collection::try_with_capacity_in(capacity, alloc).map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        Nulls::Collection::try_from_iter_in(iter, alloc).map(Self)
     }
 }
 

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     fixed_size::FixedSize,
     layout::MemoryLayout,
     length::Length,
@@ -141,16 +141,6 @@ where
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError> {
         Nulls::Collection::try_from_iter_in(iter, alloc).map(Self)
-    }
-}
-
-impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> CollectionAlloc
-    for FixedSizePrimitive<T, Nulls, Storage>
-where
-    Nulls::Collection<Storage::For<T>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::with_capacity(capacity))
     }
 }
 

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -159,6 +159,17 @@ impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> CollectionRealloc
 where
     Nulls::Collection<Storage::For<T>, Storage>: CollectionRealloc,
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.0.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        self.0.try_extend(iter)
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -121,6 +121,47 @@ impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Collect
 
     fn into_iter_owned(self) -> Self::IntoIter {
         self.0.into_iter_owned()
+    }
+}
+
+impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAllocIn
+    for VariableSizeList<T, Nulls, OffsetItem, Storage>
+where
+    Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionAllocIn,
+{
+    type Alloc = <Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage> as CollectionAllocIn>::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        Self(Nulls::Collection::<
+            Offsets<T::Memory<Storage>, OffsetItem, Storage>,
+            Storage,
+        >::with_capacity_in(capacity, alloc))
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        Self(Nulls::Collection::<
+            Offsets<T::Memory<Storage>, OffsetItem, Storage>,
+            Storage,
+        >::from_iter_in(iter, alloc))
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        Nulls::Collection::<
+            Offsets<T::Memory<Storage>, OffsetItem, Storage>,
+            Storage,
+        >::try_with_capacity_in(capacity, alloc)
+        .map(Self)
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        Nulls::Collection::<
+            Offsets<T::Memory<Storage>, OffsetItem, Storage>,
+            Storage,
+        >::try_from_iter_in(iter, alloc)
+        .map(Self)
     }
 }
 

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -162,19 +162,6 @@ where
             Storage,
         >::try_from_iter_in(iter, alloc)
         .map(Self)
-    }
-}
-
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAlloc
-    for VariableSizeList<T, Nulls, OffsetItem, Storage>
-where
-    Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::<
-            Offsets<T::Memory<Storage>, OffsetItem, Storage>,
-            Storage,
-        >::with_capacity(capacity))
     }
 }
 

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionRealloc},
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -142,6 +142,17 @@ impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Collect
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionRealloc,
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.0.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        self.0.try_extend(iter)
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.0.reserve(additional);
     }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -196,7 +196,7 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U> Default
     for Offsets<T, OffsetItem, Storage, U>
 where
     T: Default,
-    Storage::For<OffsetItem>: Default + Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>: Default + CollectionRealloc<Owned = OffsetItem>,
 {
     fn default() -> Self {
         let mut offsets = Storage::For::<OffsetItem>::default();
@@ -216,8 +216,7 @@ impl<
     U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > CollectionAllocIn for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>:
-        Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
+    Storage::For<OffsetItem>: CollectionRealloc<Alloc = T::Alloc>,
 {
     type Alloc = T::Alloc;
 
@@ -269,11 +268,10 @@ impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
+    U: CollectionAlloc<Owned = T::Owned>,
 > Extend<U> for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>:
-        Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
+    Storage::For<OffsetItem>: CollectionRealloc<Owned = OffsetItem>,
 {
     fn extend<I: IntoIterator<Item = U>>(&mut self, iter: I) {
         let mut position = self
@@ -302,12 +300,11 @@ impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
+    U: CollectionAlloc<Owned = T::Owned>,
 > FromIterator<U> for Offsets<T, OffsetItem, Storage, U>
 where
     T: Default,
-    Storage::For<OffsetItem>:
-        Default + Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
+    Storage::For<OffsetItem>: Default + CollectionRealloc<Owned = OffsetItem>,
 {
     fn from_iter<I: IntoIterator<Item = U>>(iter: I) -> Self {
         let mut offsets = Self::default();
@@ -383,8 +380,7 @@ impl<
     U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > CollectionRealloc for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>:
-        Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
+    Storage::For<OffsetItem>: CollectionRealloc<Alloc = T::Alloc>,
 {
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
         // This is only enough for collections with len 1

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -196,7 +196,7 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U> Default
     for Offsets<T, OffsetItem, Storage, U>
 where
     T: Default,
-    Storage::For<OffsetItem>: CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>: Default + Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem>,
 {
     fn default() -> Self {
         let mut offsets = Storage::For::<OffsetItem>::default();
@@ -210,15 +210,14 @@ where
 }
 
 impl<
-    T: CollectionAllocIn + CollectionRealloc,
+    T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
     U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > CollectionAllocIn for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>: Extend<OffsetItem>
-        + CollectionAllocIn<Alloc = T::Alloc>
-        + CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>:
+        Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     type Alloc = T::Alloc;
 
@@ -270,10 +269,11 @@ impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned>,
+    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > Extend<U> for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>: CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>:
+        Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     fn extend<I: IntoIterator<Item = U>>(&mut self, iter: I) {
         let mut position = self
@@ -302,11 +302,12 @@ impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned>,
+    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > FromIterator<U> for Offsets<T, OffsetItem, Storage, U>
 where
     T: Default,
-    Storage::For<OffsetItem>: CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>:
+        Default + Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     fn from_iter<I: IntoIterator<Item = U>>(iter: I) -> Self {
         let mut offsets = Self::default();
@@ -376,13 +377,15 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U: FromIterator<T::Owne
 }
 
 impl<
-    T: CollectionRealloc,
+    T: CollectionAlloc + CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned>,
+    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > CollectionAlloc for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>: CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>: Extend<OffsetItem>
+        + CollectionAlloc<Owned = OffsetItem>
+        + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -400,7 +403,8 @@ impl<
     U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > CollectionRealloc for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>: Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>:
+        Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
         self.data.try_reserve(additional)?;

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -16,7 +16,7 @@ use core::{
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc, owned::IntoOwned},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionRealloc, owned::IntoOwned},
     fixed_size::FixedSize,
     length::Length,
 };
@@ -337,11 +337,56 @@ impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned>,
+    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
 > CollectionRealloc for Offsets<T, OffsetItem, Storage, U>
 where
-    Storage::For<OffsetItem>: CollectionRealloc<Owned = OffsetItem>,
+    Storage::For<OffsetItem>: Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem>,
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.data.try_reserve(additional)?;
+        self.offsets.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        let rows = self.len();
+        let mut position = self
+            .offsets
+            .borrow()
+            .last()
+            .copied()
+            .expect("at least one value in the offsets buffer");
+        let data_len = position.as_usize();
+        self.data.truncate(data_len);
+
+        for collection in iter {
+            let next_result = position
+                .as_usize()
+                .checked_add(collection.len())
+                .and_then(|value| OffsetItem::try_from(value).ok())
+                .ok_or(AllocError);
+            let Ok(next_position) = next_result else {
+                self.offsets.truncate(rows.strict_add(1));
+                self.data.truncate(data_len);
+                return Err(AllocError);
+            };
+            if let Err(error) = self.data.try_extend(collection.into_iter_owned()) {
+                self.offsets.truncate(rows.strict_add(1));
+                self.data.truncate(data_len);
+                return Err(error);
+            }
+            if let Err(error) = self.offsets.try_extend(iter::once(next_position)) {
+                self.offsets.truncate(rows.strict_add(1));
+                self.data.truncate(data_len);
+                return Err(error);
+            }
+            position = next_position;
+        }
+        Ok(())
+    }
+
     fn reserve(&mut self, additional: usize) {
         // This is only enough for collections with len 1
         self.data.reserve(additional);

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -377,26 +377,6 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U: FromIterator<T::Owne
 }
 
 impl<
-    T: CollectionAlloc + CollectionRealloc,
-    OffsetItem: Offset,
-    Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
-> CollectionAlloc for Offsets<T, OffsetItem, Storage, U>
-where
-    Storage::For<OffsetItem>: Extend<OffsetItem>
-        + CollectionAlloc<Owned = OffsetItem>
-        + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            data: T::with_capacity(capacity),
-            offsets: Storage::For::<OffsetItem>::with_capacity(capacity),
-            _collection: PhantomData,
-        }
-    }
-}
-
-impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
@@ -407,6 +387,7 @@ where
         Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        // This is only enough for collections with len 1
         self.data.try_reserve(additional)?;
         self.offsets.try_reserve(additional)
     }

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -16,7 +16,10 @@ use core::{
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionRealloc, owned::IntoOwned},
+    collection::{
+        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        owned::IntoOwned,
+    },
     fixed_size::FixedSize,
     length::Length,
 };
@@ -203,6 +206,63 @@ where
             offsets,
             _collection: PhantomData,
         }
+    }
+}
+
+impl<
+    T: CollectionAllocIn + CollectionRealloc,
+    OffsetItem: Offset,
+    Storage: Buffer,
+    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
+> CollectionAllocIn for Offsets<T, OffsetItem, Storage, U>
+where
+    Storage::For<OffsetItem>: Extend<OffsetItem>
+        + CollectionAllocIn<Alloc = T::Alloc>
+        + CollectionRealloc<Owned = OffsetItem>,
+{
+    type Alloc = T::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        let data = T::with_capacity_in(capacity, alloc.clone());
+        let mut offsets =
+            Storage::For::<OffsetItem>::with_capacity_in(capacity.strict_add(1), alloc);
+        offsets.extend(iter::once(OffsetItem::default()));
+        Self {
+            data,
+            offsets,
+            _collection: PhantomData,
+        }
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        let items = iter.into_iter();
+        let (lower_bound, upper_bound) = items.size_hint();
+        let mut offsets = Self::with_capacity_in(upper_bound.unwrap_or(lower_bound), alloc);
+        offsets.extend(items);
+        offsets
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        let offset_capacity = capacity.checked_add(1).ok_or(AllocError)?;
+        let data = T::try_with_capacity_in(capacity, alloc.clone())?;
+        let mut offsets = Storage::For::<OffsetItem>::try_with_capacity_in(offset_capacity, alloc)?;
+        offsets.try_extend(iter::once(OffsetItem::default()))?;
+        Ok(Self {
+            data,
+            offsets,
+            _collection: PhantomData,
+        })
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        let items = iter.into_iter();
+        let (lower_bound, upper_bound) = items.size_hint();
+        let mut offsets = Self::try_with_capacity_in(upper_bound.unwrap_or(lower_bound), alloc)?;
+        offsets.try_extend(items)?;
+        Ok(offsets)
     }
 }
 

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -296,19 +296,6 @@ impl<
 }
 
 impl<
-    T: CollectionAlloc<Owned: Default> + CollectionRealloc,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionAlloc + CollectionRealloc<Alloc = T::Alloc>>,
-> CollectionAlloc for Validity<T, Storage>
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            collection: T::with_capacity(capacity),
-            bitmap: Bitmap::with_capacity(capacity),
-        }
-    }
-}
-
-impl<
     T: CollectionRealloc<Owned: Default>,
     Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc<Alloc = T::Alloc>>,
 > CollectionRealloc for Validity<T, Storage>

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -217,7 +217,7 @@ const VALIDITY_CHUNK: usize = 1024;
 impl<
     U: Default,
     T: CollectionRealloc<Owned = U>,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc<Alloc = T::Alloc>>,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>,
 > Extend<Option<U>> for Validity<T, Storage>
 {
     fn extend<I: IntoIterator<Item = Option<U>>>(&mut self, iter: I) {

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -9,7 +9,9 @@ use core::{
 use crate::{
     bitmap::Bitmap,
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionRealloc, view::AsView},
+    collection::{
+        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
+    },
     length::Length,
 };
 
@@ -245,6 +247,51 @@ impl<
                 break;
             }
         }
+    }
+}
+
+impl<
+    T: CollectionAllocIn + CollectionRealloc<Owned: Default>,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionAllocIn<Alloc = T::Alloc> + CollectionRealloc>,
+> CollectionAllocIn for Validity<T, Storage>
+{
+    type Alloc = T::Alloc;
+
+    fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self {
+        let collection = T::with_capacity_in(capacity, alloc.clone());
+        let bitmap = Bitmap::<Storage>::with_capacity_in(capacity, alloc);
+        Self { collection, bitmap }
+    }
+
+    fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self {
+        let items = iter.into_iter();
+        let (lower_bound, upper_bound) = items.size_hint();
+        let mut bitmap =
+            Bitmap::<Storage>::with_capacity_in(upper_bound.unwrap_or(lower_bound), alloc.clone());
+        let collection = T::from_iter_in(
+            items
+                .inspect(|item| bitmap.extend(iter::once(item.is_some())))
+                .map(Option::unwrap_or_default),
+            alloc,
+        );
+        Self { collection, bitmap }
+    }
+
+    fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError> {
+        let collection = T::try_with_capacity_in(capacity, alloc.clone())?;
+        let bitmap = Bitmap::<Storage>::try_with_capacity_in(capacity, alloc)?;
+        Ok(Self { collection, bitmap })
+    }
+
+    fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
+        iter: I,
+        alloc: Self::Alloc,
+    ) -> Result<Self, AllocError> {
+        let items = iter.into_iter();
+        let (lower_bound, upper_bound) = items.size_hint();
+        let mut validity = Self::try_with_capacity_in(upper_bound.unwrap_or(lower_bound), alloc)?;
+        validity.try_extend(items)?;
+        Ok(validity)
     }
 }
 

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -195,7 +195,7 @@ impl<T: Collection, Storage: Buffer> Collection for Validity<T, Storage> {
 impl<
     U: Default,
     T: CollectionAlloc<Owned = U>,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionAlloc + CollectionRealloc>,
 > FromIterator<Option<U>> for Validity<T, Storage>
 {
     fn from_iter<I: IntoIterator<Item = Option<U>>>(iter: I) -> Self {
@@ -217,7 +217,7 @@ const VALIDITY_CHUNK: usize = 1024;
 impl<
     U: Default,
     T: CollectionRealloc<Owned = U>,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc<Alloc = T::Alloc>>,
 > Extend<Option<U>> for Validity<T, Storage>
 {
     fn extend<I: IntoIterator<Item = Option<U>>>(&mut self, iter: I) {
@@ -251,8 +251,8 @@ impl<
 }
 
 impl<
-    T: CollectionAllocIn + CollectionRealloc<Owned: Default>,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionAllocIn<Alloc = T::Alloc> + CollectionRealloc>,
+    T: CollectionRealloc<Owned: Default>,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc<Alloc = T::Alloc>>,
 > CollectionAllocIn for Validity<T, Storage>
 {
     type Alloc = T::Alloc;
@@ -296,8 +296,8 @@ impl<
 }
 
 impl<
-    T: CollectionRealloc<Owned: Default>,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>,
+    T: CollectionAlloc<Owned: Default> + CollectionRealloc,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionAlloc + CollectionRealloc<Alloc = T::Alloc>>,
 > CollectionAlloc for Validity<T, Storage>
 {
     fn with_capacity(capacity: usize) -> Self {
@@ -310,7 +310,7 @@ impl<
 
 impl<
     T: CollectionRealloc<Owned: Default>,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>,
+    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc<Alloc = T::Alloc>>,
 > CollectionRealloc for Validity<T, Storage>
 {
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -9,7 +9,7 @@ use core::{
 use crate::{
     bitmap::Bitmap,
     buffer::{Buffer, VecBuffer},
-    collection::{Collection, CollectionAlloc, CollectionRealloc, view::AsView},
+    collection::{AllocError, Collection, CollectionAlloc, CollectionRealloc, view::AsView},
     length::Length,
 };
 
@@ -266,6 +266,45 @@ impl<
     Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc>,
 > CollectionRealloc for Validity<T, Storage>
 {
+    fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        self.collection.try_reserve(additional)?;
+        self.bitmap.try_reserve(additional)
+    }
+
+    fn try_extend<I: IntoIterator<Item = Self::Owned>>(
+        &mut self,
+        iter: I,
+    ) -> Result<(), AllocError> {
+        let len = self.len();
+        self.collection.truncate(len);
+
+        let mut items = iter.into_iter();
+        loop {
+            let mut validity = [false; VALIDITY_CHUNK];
+            let mut count: usize = 0;
+            let values = items
+                .by_ref()
+                .take(VALIDITY_CHUNK)
+                .inspect(|item| {
+                    validity[count] = item.is_some();
+                    count = count.strict_add(1);
+                })
+                .map(Option::unwrap_or_default);
+            if let Err(error) = self.collection.try_extend(values) {
+                self.truncate(len);
+                return Err(error);
+            }
+            if let Err(error) = self.bitmap.try_extend(validity.into_iter().take(count)) {
+                self.truncate(len);
+                return Err(error);
+            }
+            if count < VALIDITY_CHUNK {
+                break;
+            }
+        }
+        Ok(())
+    }
+
     fn reserve(&mut self, additional: usize) {
         self.bitmap.reserve(additional);
         self.collection.reserve(additional);


### PR DESCRIPTION
Make CollectionAllocIn the foundational allocation capability.

- Rebase CollectionRealloc on CollectionAllocIn so reallocatable collections expose their allocator type and do not require default construction.
- Make CollectionAlloc the default-allocator specialization of CollectionAllocIn.
- Blanket-implement CollectionAlloc when the allocator, collection default, and iterator construction are available.
- Remove redundant manual CollectionAlloc implementations.
- Require matching allocator types in composite reallocatable collections.

No runtime behavior change is intended. Transparent extension behavior remains in #550, and native allocation-failure documentation and tests remain in #551.