### PR TITLE
test: preserve native allocation failures

### DIFF
--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -69,12 +69,19 @@ pub trait CollectionAllocIn: Collection + Sized {
     type Alloc: Clone;
 
     /// Constructs a new, empty collection with at least the specified capacity
-    /// using `alloc` and its native infallible failure handling.
+    /// using `alloc`.
+    ///
+    /// Unlike [`CollectionAllocIn::try_with_capacity_in`], this method does not
+    /// return reservation failures. Implementations use their allocator's
+    /// native infallible failure handling.
     #[must_use]
     fn with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Self;
 
-    /// Constructs a collection from `iter` using `alloc` and its native
-    /// infallible failure handling.
+    /// Constructs a collection from `iter` using `alloc`.
+    ///
+    /// Unlike [`CollectionAllocIn::try_from_iter_in`], this method does not
+    /// return reservation failures. Implementations use their allocator's
+    /// native infallible failure handling.
     #[must_use]
     fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self;
 
@@ -108,6 +115,10 @@ pub trait CollectionRealloc: CollectionAllocIn + Extend<Self::Owned> {
     ) -> Result<(), AllocError>;
 
     /// Reserves capacity for at least `additional` more items to be inserted in this collection.
+    ///
+    /// Unlike [`CollectionRealloc::try_reserve`], this method does not return
+    /// reservation failures. Implementations use their allocator's native
+    /// infallible failure handling.
     fn reserve(&mut self, additional: usize);
 
     /// Shortens this collection to `len` items, dropping the rest.

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -131,4 +131,17 @@ mod tests {
         );
         assert_eq!(collection, [1, 2, 3, 4]);
     }
+
+    #[test]
+    #[should_panic(expected = "capacity overflow")]
+    fn alloc_in_capacity_overflow_panics() {
+        let _ = <Vec<u32> as CollectionAllocIn>::with_capacity_in(usize::MAX, ());
+    }
+
+    #[test]
+    #[should_panic(expected = "capacity overflow")]
+    fn reserve_capacity_overflow_panics() {
+        let mut collection = alloc::vec![1_u32, 2, 3, 4];
+        CollectionRealloc::reserve(&mut collection, usize::MAX);
+    }
 }


### PR DESCRIPTION
Document native infallible failure handling and verify Vec capacity overflow behavior.

Stacked on #550.