### PR TITLE
refactor: blanket implement collection alloc

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::Layout,
     length::Length,
 };
@@ -130,15 +130,6 @@ where
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError> {
         T::Memory::<Storage>::try_from_iter_in(iter, alloc).map(Self)
-    }
-}
-
-impl<T: Layout, Storage: Buffer> CollectionAlloc for Array<T, Storage>
-where
-    T::Memory<Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(T::Memory::<Storage>::with_capacity(capacity))
     }
 }
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -326,16 +326,6 @@ impl<Storage: Buffer> Collection for Bitmap<Storage> {
     }
 }
 
-impl<Storage: Buffer<For<u8>: CollectionAlloc>> CollectionAlloc for Bitmap<Storage> {
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            buffer: Storage::For::<u8>::with_capacity(bytes_for_bits(capacity)),
-            bits: 0,
-            offset: 0,
-        }
-    }
-}
-
 impl<Storage: Buffer<For<u8>: CollectionAllocIn>> CollectionAllocIn for Bitmap<Storage> {
     type Alloc = <Storage::For<u8> as CollectionAllocIn>::Alloc;
 

--- a/src/collection/box.rs
+++ b/src/collection/box.rs
@@ -3,7 +3,7 @@ extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 use core::{iter::Map, slice};
 
-use crate::collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, view::AsView};
+use crate::collection::{AllocError, Collection, CollectionAllocIn, view::AsView};
 
 impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
     type View<'collection>
@@ -30,12 +30,6 @@ impl<T: for<'any> AsView<'any>> Collection for Box<[T]> {
 
     fn into_iter_owned(self) -> Self::IntoIter {
         <Box<[T]> as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: for<'any> AsView<'any>> CollectionAlloc for Box<[T]> {
-    fn with_capacity(capacity: usize) -> Self {
-        Vec::with_capacity(capacity).into_boxed_slice()
     }
 }
 

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -128,12 +128,6 @@ impl<C: Collection, const N: usize> Collection for Flatten<C, N> {
     }
 }
 
-impl<C: CollectionAlloc, const N: usize> CollectionAlloc for Flatten<C, N> {
-    fn with_capacity(capacity: usize) -> Self {
-        Self(C::with_capacity(capacity.strict_mul(N)))
-    }
-}
-
 impl<C: CollectionAllocIn, const N: usize> CollectionAllocIn for Flatten<C, N> {
     type Alloc = C::Alloc;
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -86,29 +86,64 @@ pub trait CollectionAllocIn: Collection + Sized {
     fn from_iter_in<I: IntoIterator<Item = Self::Owned>>(iter: I, alloc: Self::Alloc) -> Self;
 
     /// Tries to construct an empty collection with the requested capacity.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when the requested capacity cannot be
+    /// reserved.
     fn try_with_capacity_in(capacity: usize, alloc: Self::Alloc) -> Result<Self, AllocError>;
 
     /// Tries to construct a collection from `iter`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when storage for the items cannot be
+    /// reserved.
     fn try_from_iter_in<I: IntoIterator<Item = Self::Owned>>(
         iter: I,
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError>;
 }
 
-/// An allocatable collection of items.
-pub trait CollectionAlloc: Collection + Default + FromIterator<Self::Owned> {
+/// An allocatable collection of items using its default allocator.
+///
+/// This trait is implemented automatically for every [`CollectionAllocIn`]
+/// whose allocator implements [`Default`] and which can be constructed through
+/// [`Default`] and [`FromIterator`].
+pub trait CollectionAlloc:
+    CollectionAllocIn<Alloc: Default> + Default + FromIterator<Self::Owned>
+{
     /// Constructs a new, empty collection with at least the specified capacity.
-    fn with_capacity(capacity: usize) -> Self;
+    #[must_use]
+    fn with_capacity(capacity: usize) -> Self {
+        <Self as CollectionAllocIn>::with_capacity_in(capacity, Default::default())
+    }
+}
+
+impl<C> CollectionAlloc for C
+where
+    C: CollectionAllocIn + Default + FromIterator<C::Owned>,
+    C::Alloc: Default,
+{
 }
 
 /// A re-allocatable collection of items.
 pub trait CollectionRealloc: CollectionAllocIn + Extend<Self::Owned> {
     /// Tries to reserve capacity for at least `additional` more items.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when the requested capacity cannot be
+    /// reserved.
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError>;
 
     /// Tries to extend this collection with the contents of `iter`.
     ///
-    /// The collection's logical contents are unchanged when reservation fails.
+    /// # Errors
+    ///
+    /// Returns an [`AllocError`] when storage for the additional items cannot
+    /// be reserved. The collection's logical contents are unchanged when a
+    /// reservation fails.
     fn try_extend<I: IntoIterator<Item = Self::Owned>>(
         &mut self,
         iter: I,
@@ -138,6 +173,13 @@ pub(crate) mod tests {
     use crate::collection::view::AsView;
 
     use super::*;
+
+    fn assert_collection_alloc<C: CollectionAlloc>() {}
+
+    #[test]
+    fn collection_alloc_is_blanket_implemented() {
+        assert_collection_alloc::<Vec<u32>>();
+    }
 
     pub(crate) fn round_trip<
         C: for<'any> CollectionAlloc<Owned = T, View<'any>: Debug>,

--- a/src/collection/vec.rs
+++ b/src/collection/vec.rs
@@ -4,7 +4,7 @@ use alloc::vec::{self, Vec};
 use core::{iter::Map, slice};
 
 use crate::collection::{
-    AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
+    AllocError, Collection, CollectionAllocIn, CollectionRealloc, view::AsView,
 };
 
 impl<T: for<'any> AsView<'any>> Collection for Vec<T> {
@@ -32,12 +32,6 @@ impl<T: for<'any> AsView<'any>> Collection for Vec<T> {
 
     fn into_iter_owned(self) -> Self::IntoIter {
         <Self as IntoIterator>::into_iter(self)
-    }
-}
-
-impl<T: for<'any> AsView<'any>> CollectionAlloc for Vec<T> {
-    fn with_capacity(capacity: usize) -> Self {
-        Vec::with_capacity(capacity)
     }
 }
 
@@ -107,9 +101,13 @@ impl<T: for<'any> AsView<'any>> CollectionRealloc for Vec<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::collection::CollectionAlloc;
 
     #[test]
     fn alloc_in() {
+        let reserved = <Vec<u32> as CollectionAlloc>::with_capacity(4);
+        assert!(reserved.capacity() >= 4);
+
         let collection = <Vec<u32> as CollectionAllocIn>::try_from_iter_in([1, 2, 3, 4], ())
             .expect("allocation succeeds");
         assert_eq!(collection, [1, 2, 3, 4]);

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -3,7 +3,7 @@ use core::fmt::Debug;
 use crate::{
     bitmap::Bitmap,
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::MemoryLayout,
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -128,15 +128,6 @@ where
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError> {
         Nulls::Collection::try_from_iter_in(iter, alloc).map(Self)
-    }
-}
-
-impl<Nulls: Nullability, Storage: Buffer> CollectionAlloc for Boolean<Nulls, Storage>
-where
-    Nulls::Collection<Bitmap<Storage>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::with_capacity(capacity))
     }
 }
 

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -2,10 +2,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{
-        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
-        flatten::Flatten,
-    },
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc, flatten::Flatten},
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -169,16 +166,6 @@ where
     ) -> Result<Self, AllocError> {
         Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::try_from_iter_in(iter, alloc)
             .map(Self)
-    }
-}
-
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAlloc
-    for FixedSizeList<T, N, Nulls, Storage>
-where
-    Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::<Flatten<T::Memory<Storage>, N>, Storage>::with_capacity(capacity))
     }
 }
 

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     fixed_size::FixedSize,
     layout::MemoryLayout,
     length::Length,
@@ -141,16 +141,6 @@ where
         alloc: Self::Alloc,
     ) -> Result<Self, AllocError> {
         Nulls::Collection::try_from_iter_in(iter, alloc).map(Self)
-    }
-}
-
-impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> CollectionAlloc
-    for FixedSizePrimitive<T, Nulls, Storage>
-where
-    Nulls::Collection<Storage::For<T>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::with_capacity(capacity))
     }
 }
 

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -5,7 +5,7 @@ use core::fmt::Debug;
 
 use crate::{
     buffer::{Buffer, VecBuffer},
-    collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
+    collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::{Layout, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
@@ -162,19 +162,6 @@ where
             Storage,
         >::try_from_iter_in(iter, alloc)
         .map(Self)
-    }
-}
-
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAlloc
-    for VariableSizeList<T, Nulls, OffsetItem, Storage>
-where
-    Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionAlloc,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self(Nulls::Collection::<
-            Offsets<T::Memory<Storage>, OffsetItem, Storage>,
-            Storage,
-        >::with_capacity(capacity))
     }
 }
 

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -376,26 +376,6 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U: FromIterator<T::Owne
 }
 
 impl<
-    T: CollectionAlloc + CollectionRealloc,
-    OffsetItem: Offset,
-    Storage: Buffer,
-    U: CollectionAlloc<Owned = T::Owned> + FromIterator<T::Owned>,
-> CollectionAlloc for Offsets<T, OffsetItem, Storage, U>
-where
-    Storage::For<OffsetItem>: Extend<OffsetItem>
-        + CollectionAlloc<Owned = OffsetItem>
-        + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            data: T::with_capacity(capacity),
-            offsets: Storage::For::<OffsetItem>::with_capacity(capacity),
-            _collection: PhantomData,
-        }
-    }
-}
-
-impl<
     T: CollectionRealloc,
     OffsetItem: Offset,
     Storage: Buffer,
@@ -406,6 +386,7 @@ where
         Extend<OffsetItem> + CollectionRealloc<Owned = OffsetItem, Alloc = T::Alloc>,
 {
     fn try_reserve(&mut self, additional: usize) -> Result<(), AllocError> {
+        // This is only enough for collections with len 1
         self.data.try_reserve(additional)?;
         self.offsets.try_reserve(additional)
     }

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -296,19 +296,6 @@ impl<
 }
 
 impl<
-    T: CollectionAlloc<Owned: Default> + CollectionRealloc,
-    Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionAlloc + CollectionRealloc<Alloc = T::Alloc>>,
-> CollectionAlloc for Validity<T, Storage>
-{
-    fn with_capacity(capacity: usize) -> Self {
-        Self {
-            collection: T::with_capacity(capacity),
-            bitmap: Bitmap::with_capacity(capacity),
-        }
-    }
-}
-
-impl<
     T: CollectionRealloc<Owned: Default>,
     Storage: Buffer<For<u8>: BorrowMut<[u8]> + CollectionRealloc<Alloc = T::Alloc>>,
 > CollectionRealloc for Validity<T, Storage>


### PR DESCRIPTION
Blanket-implement CollectionAlloc for default-allocator collections and remove redundant explicit implementations.

Stacked on #551.