### PR TITLE
refactor!: split layout and array item

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -5,14 +5,14 @@ use core::fmt::Debug;
 use crate::{
     buffer::{Buffer, VecBuffer},
     collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
-    layout::Layout,
+    layout::ArrayItem,
     length::Length,
 };
 
-/// An array of items `T`, stored using their [`Layout`] memory.
-pub struct Array<T: Layout, Storage: Buffer = VecBuffer>(T::Memory<Storage>);
+/// An array of items `T`, stored using their [`ArrayItem`] memory.
+pub struct Array<T: ArrayItem, Storage: Buffer = VecBuffer>(T::Memory<Storage>);
 
-impl<T: Layout, Storage: Buffer> Array<T, Storage> {
+impl<T: ArrayItem, Storage: Buffer> Array<T, Storage> {
     /// Constructs an [`Array`] from its backing memory layout.
     #[must_use]
     pub fn from_buffer(memory: T::Memory<Storage>) -> Self {
@@ -28,7 +28,7 @@ impl<T: Layout, Storage: Buffer> Array<T, Storage> {
     }
 }
 
-impl<T: Layout, Storage: Buffer> Clone for Array<T, Storage>
+impl<T: ArrayItem, Storage: Buffer> Clone for Array<T, Storage>
 where
     T::Memory<Storage>: Clone,
 {
@@ -37,7 +37,7 @@ where
     }
 }
 
-impl<T: Layout, Storage: Buffer> Debug for Array<T, Storage>
+impl<T: ArrayItem, Storage: Buffer> Debug for Array<T, Storage>
 where
     T::Memory<Storage>: Debug,
 {
@@ -46,7 +46,7 @@ where
     }
 }
 
-impl<T: Layout, Storage: Buffer> Default for Array<T, Storage>
+impl<T: ArrayItem, Storage: Buffer> Default for Array<T, Storage>
 where
     T::Memory<Storage>: Default,
 {
@@ -55,7 +55,7 @@ where
     }
 }
 
-impl<T: Layout, U, Storage: Buffer> Extend<U> for Array<T, Storage>
+impl<T: ArrayItem, U, Storage: Buffer> Extend<U> for Array<T, Storage>
 where
     T::Memory<Storage>: Extend<U>,
 {
@@ -64,13 +64,13 @@ where
     }
 }
 
-impl<T: Layout, Storage: Buffer> Length for Array<T, Storage> {
+impl<T: ArrayItem, Storage: Buffer> Length for Array<T, Storage> {
     fn len(&self) -> usize {
         self.0.len()
     }
 }
 
-impl<T: Layout, U, Storage: Buffer> FromIterator<U> for Array<T, Storage>
+impl<T: ArrayItem, U, Storage: Buffer> FromIterator<U> for Array<T, Storage>
 where
     T::Memory<Storage>: FromIterator<U>,
 {
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<T: Layout, Storage: Buffer> Collection for Array<T, Storage> {
+impl<T: ArrayItem, Storage: Buffer> Collection for Array<T, Storage> {
     type View<'collection>
         = <T::Memory<Storage> as Collection>::View<'collection>
     where
@@ -107,7 +107,7 @@ impl<T: Layout, Storage: Buffer> Collection for Array<T, Storage> {
     }
 }
 
-impl<T: Layout, Storage: Buffer> CollectionAllocIn for Array<T, Storage>
+impl<T: ArrayItem, Storage: Buffer> CollectionAllocIn for Array<T, Storage>
 where
     T::Memory<Storage>: CollectionAllocIn,
 {
@@ -133,7 +133,7 @@ where
     }
 }
 
-impl<T: Layout, Storage: Buffer> CollectionAlloc for Array<T, Storage>
+impl<T: ArrayItem, Storage: Buffer> CollectionAlloc for Array<T, Storage>
 where
     T::Memory<Storage>: CollectionAlloc,
 {
@@ -142,7 +142,7 @@ where
     }
 }
 
-impl<T: Layout, Storage: Buffer> CollectionRealloc for Array<T, Storage>
+impl<T: ArrayItem, Storage: Buffer> CollectionRealloc for Array<T, Storage>
 where
     T::Memory<Storage>: CollectionRealloc,
 {

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -6,24 +6,24 @@ use crate::{
         AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
         flatten::Flatten,
     },
-    layout::{Layout, MemoryLayout},
+    layout::{ArrayItem, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
 };
 
 pub struct FixedSizeList<
-    T: Layout,
+    T: ArrayItem,
     const N: usize,
     Nulls: Nullability = NonNullable,
     Storage: Buffer = VecBuffer,
 >(Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>);
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> MemoryLayout
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> MemoryLayout
     for FixedSizeList<T, N, Nulls, Storage>
 {
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer>
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer>
     FixedSizeList<T, N, Nulls, Storage>
 {
     /// Constructs a [`FixedSizeList`] from its backing collection.
@@ -41,7 +41,7 @@ impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer>
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Debug
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> Debug
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: Debug,
@@ -51,7 +51,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Clone
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> Clone
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: Clone,
@@ -61,7 +61,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Default
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> Default
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: Default,
@@ -71,7 +71,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Extend<Nulls::Item<[T; N]>>
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> Extend<Nulls::Item<[T; N]>>
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: Extend<Nulls::Item<[T; N]>>,
@@ -81,7 +81,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer>
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer>
     FromIterator<Nulls::Item<[T; N]>> for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: FromIterator<Nulls::Item<[T; N]>>,
@@ -91,7 +91,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Length
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> Length
     for FixedSizeList<T, N, Nulls, Storage>
 {
     fn len(&self) -> usize {
@@ -99,7 +99,7 @@ impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Length
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Collection
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> Collection
     for FixedSizeList<T, N, Nulls, Storage>
 {
     type View<'collection>
@@ -134,7 +134,7 @@ impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> Collection
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAllocIn
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAllocIn
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionAllocIn,
@@ -172,7 +172,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAlloc
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionAlloc
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionAlloc,
@@ -182,7 +182,7 @@ where
     }
 }
 
-impl<T: Layout, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionRealloc
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> CollectionRealloc
     for FixedSizeList<T, N, Nulls, Storage>
 where
     Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>: CollectionRealloc,

--- a/src/layout/mod.rs
+++ b/src/layout/mod.rs
@@ -12,7 +12,7 @@ use crate::{
         boolean::Boolean, fixed_size_list::FixedSizeList, fixed_size_primitive::FixedSizePrimitive,
         variable_size_list::VariableSizeList,
     },
-    nullability::{NonNullable, Nullable},
+    nullability::{NonNullable, Nullability, Nullable},
 };
 
 pub mod boolean;
@@ -24,40 +24,79 @@ pub mod variable_size_list;
 /// A physical memory layout.
 pub trait MemoryLayout: Collection {}
 
-/// Mapping types to their physical memory layout.
-pub trait Layout {
+/// Mapping a base type to its physical memory layout.
+pub trait Layout: Sized {
     /// The Arrow physical memory layout of this type.
+    type Memory<Nulls: Nullability, Storage: Buffer>: MemoryLayout<Owned = Nulls::Item<Self>>;
+}
+
+/// Marker for base types whose layout supports Arrow validity bitmaps.
+pub trait NullableLayout: Layout {}
+
+/// Mapping an array item type to its complete physical memory layout.
+pub trait ArrayItem: Sized {
+    /// The Arrow physical memory layout of this array item type.
     type Memory<Storage: Buffer>: MemoryLayout<Owned = Self>;
 }
 
-impl Layout for bool {
-    type Memory<Storage: Buffer> = Boolean<NonNullable, Storage>;
+impl<T: Layout> ArrayItem for T {
+    type Memory<Storage: Buffer> = T::Memory<NonNullable, Storage>;
 }
 
-impl Layout for Option<bool> {
-    type Memory<Storage: Buffer> = Boolean<Nullable, Storage>;
+impl<T: NullableLayout> ArrayItem for Option<T> {
+    type Memory<Storage: Buffer> = T::Memory<Nullable, Storage>;
 }
+
+impl Layout for bool {
+    type Memory<Nulls: Nullability, Storage: Buffer> = Boolean<Nulls, Storage>;
+}
+
+impl NullableLayout for bool {}
 
 impl<T: FixedSize> Layout for T {
-    type Memory<Storage: Buffer> = FixedSizePrimitive<T, NonNullable, Storage>;
+    type Memory<Nulls: Nullability, Storage: Buffer> = FixedSizePrimitive<T, Nulls, Storage>;
 }
 
-impl<T: FixedSize> Layout for Option<T> {
-    type Memory<Storage: Buffer> = FixedSizePrimitive<T, Nullable, Storage>;
+impl<T: FixedSize> NullableLayout for T {}
+
+impl<T: ArrayItem, const N: usize> Layout for [T; N] {
+    type Memory<Nulls: Nullability, Storage: Buffer> = FixedSizeList<T, N, Nulls, Storage>;
 }
 
-impl<T: Layout, const N: usize> Layout for [T; N] {
-    type Memory<Storage: Buffer> = FixedSizeList<T, N, NonNullable, Storage>;
+impl<T: ArrayItem, const N: usize> NullableLayout for [T; N] {}
+
+impl<T: ArrayItem> Layout for Vec<T> {
+    type Memory<Nulls: Nullability, Storage: Buffer> = VariableSizeList<T, Nulls, i32, Storage>;
 }
 
-impl<T: Layout, const N: usize> Layout for Option<[T; N]> {
-    type Memory<Storage: Buffer> = FixedSizeList<T, N, Nullable, Storage>;
-}
+impl<T: ArrayItem> NullableLayout for Vec<T> {}
 
-impl<T: Layout> Layout for Vec<T> {
-    type Memory<Storage: Buffer> = VariableSizeList<T, NonNullable, i32, Storage>;
-}
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
 
-impl<T: Layout> Layout for Option<Vec<T>> {
-    type Memory<Storage: Buffer> = VariableSizeList<T, Nullable, i32, Storage>;
+    use alloc::vec::Vec;
+
+    use crate::{
+        buffer::VecBuffer,
+        layout::{
+            ArrayItem, boolean::Boolean, fixed_size_list::FixedSizeList,
+            fixed_size_primitive::FixedSizePrimitive, variable_size_list::VariableSizeList,
+        },
+        nullability::{NonNullable, Nullable},
+    };
+
+    fn assert_memory<T: ArrayItem<Memory<VecBuffer> = Memory>, Memory>() {}
+
+    #[test]
+    fn array_item_selects_nullability() {
+        assert_memory::<bool, Boolean<NonNullable, VecBuffer>>();
+        assert_memory::<Option<bool>, Boolean<Nullable, VecBuffer>>();
+        assert_memory::<i32, FixedSizePrimitive<i32, NonNullable, VecBuffer>>();
+        assert_memory::<Option<i32>, FixedSizePrimitive<i32, Nullable, VecBuffer>>();
+        assert_memory::<[Option<i32>; 2], FixedSizeList<Option<i32>, 2>>();
+        assert_memory::<Option<[Option<i32>; 2]>, FixedSizeList<Option<i32>, 2, Nullable>>();
+        assert_memory::<Vec<Option<i32>>, VariableSizeList<Option<i32>>>();
+        assert_memory::<Option<Vec<Option<i32>>>, VariableSizeList<Option<i32>, Nullable>>();
+    }
 }

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -6,25 +6,25 @@ use core::fmt::Debug;
 use crate::{
     buffer::{Buffer, VecBuffer},
     collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
-    layout::{Layout, MemoryLayout},
+    layout::{ArrayItem, MemoryLayout},
     length::Length,
     nullability::{NonNullable, Nullability},
     offset::{Offset, Offsets},
 };
 
 pub struct VariableSizeList<
-    T: Layout,
+    T: ArrayItem,
     Nulls: Nullability = NonNullable,
     OffsetItem: Offset = i32,
     Storage: Buffer = VecBuffer,
 >(Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>);
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> MemoryLayout
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> MemoryLayout
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 {
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
     VariableSizeList<T, Nulls, OffsetItem, Storage>
 {
     /// Constructs a [`VariableSizeList`] from its backing collection.
@@ -46,7 +46,7 @@ impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Debug
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Debug
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: Debug,
@@ -56,7 +56,7 @@ where
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Default
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Default
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: Default,
@@ -66,8 +66,8 @@ where
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Extend<Nulls::Item<Vec<T>>>
-    for VariableSizeList<T, Nulls, OffsetItem, Storage>
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
+    Extend<Nulls::Item<Vec<T>>> for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>:
         Extend<Nulls::Item<Vec<T>>>,
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
     FromIterator<Nulls::Item<Vec<T>>> for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>:
@@ -88,7 +88,7 @@ where
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Length
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Length
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 {
     fn len(&self) -> usize {
@@ -96,7 +96,7 @@ impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Length
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Collection
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Collection
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 {
     type View<'collection> = <Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage> as Collection>::View<'collection>
@@ -124,7 +124,7 @@ impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> Collect
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAllocIn
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAllocIn
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionAllocIn,
@@ -165,7 +165,7 @@ where
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAlloc
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionAlloc
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionAlloc,
@@ -178,7 +178,7 @@ where
     }
 }
 
-impl<T: Layout, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionRealloc
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> CollectionRealloc
     for VariableSizeList<T, Nulls, OffsetItem, Storage>
 where
     Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>: CollectionRealloc,


### PR DESCRIPTION
## Summary

- make `Layout` map base types across nullability
- add `ArrayItem` and `NullableLayout` to resolve complete array item layouts
- route fixed-size and variable-size list children through `ArrayItem`
- cover nullable and nested type selection

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo doc --workspace --all-features --no-deps`