### PR TITLE
feat: expose backing memory

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -3,7 +3,7 @@
 use core::fmt::Debug;
 
 use crate::{
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::ArrayItem,
     length::Length,
@@ -20,17 +20,19 @@ impl<T: ArrayItem, Storage: Buffer> Array<T, Storage> {
     }
 
     /// Returns the backing memory layout of this [`Array`].
-    #[must_use]
-    pub fn buffer(&self) -> &T::Memory<Storage> {
-        &self.0
-    }
-
-    /// Returns the backing memory layout of this [`Array`].
     ///
     /// This is the inverse of [`Array::from_buffer`].
     #[must_use]
     pub fn into_buffer(self) -> T::Memory<Storage> {
         self.0
+    }
+}
+
+impl<T: ArrayItem, Storage: Buffer> BufferRef for Array<T, Storage> {
+    type Buffer = T::Memory<Storage>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.0
     }
 }
 

--- a/src/array.rs
+++ b/src/array.rs
@@ -20,6 +20,12 @@ impl<T: ArrayItem, Storage: Buffer> Array<T, Storage> {
     }
 
     /// Returns the backing memory layout of this [`Array`].
+    #[must_use]
+    pub fn buffer(&self) -> &T::Memory<Storage> {
+        &self.0
+    }
+
+    /// Returns the backing memory layout of this [`Array`].
     ///
     /// This is the inverse of [`Array::from_buffer`].
     #[must_use]

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -14,7 +14,7 @@ use packed::BitPackedExt;
 use unpacked::{BitUnpacked, BitUnpackedExt};
 
 use crate::{
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc},
     length::Length,
 };
@@ -78,6 +78,31 @@ pub struct Bitmap<Storage: Buffer = VecBuffer> {
     offset: usize,
 }
 
+/// Immutable access to a [`Bitmap`].
+pub trait BitmapRef {
+    /// Storage of the bitmap.
+    type Storage: Buffer;
+
+    /// Returns the bitmap.
+    fn bitmap_ref(&self) -> &Bitmap<Self::Storage>;
+}
+
+impl<Storage: Buffer> BitmapRef for Bitmap<Storage> {
+    type Storage = Storage;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Storage> {
+        self
+    }
+}
+
+impl<Storage: Buffer> BufferRef for Bitmap<Storage> {
+    type Buffer = Storage::For<u8>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.buffer
+    }
+}
+
 impl<Storage: Buffer<For<u8>: Debug>> Debug for Bitmap<Storage> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Bitmap")
@@ -115,12 +140,6 @@ impl<Storage: Buffer> Bitmap<Storage> {
                 bytes,
             }),
         }
-    }
-
-    /// Returns the backing byte buffer of this [`Bitmap`].
-    #[must_use]
-    pub fn buffer(&self) -> &Storage::For<u8> {
-        &self.buffer
     }
 
     /// Returns the bit offset into the backing byte buffer.

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -90,14 +90,6 @@ pub trait BitmapRef {
     fn bitmap_ref(&self) -> &Bitmap<Self::Storage>;
 }
 
-impl<Storage: Buffer> BitmapRef for Bitmap<Storage> {
-    type Storage = Storage;
-
-    fn bitmap_ref(&self) -> &Bitmap<Self::Storage> {
-        self
-    }
-}
-
 impl<Storage: Buffer> BufferRef for Bitmap<Storage> {
     type Buffer = Storage::For<u8>;
 

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -2,6 +2,9 @@
 
 mod packed;
 mod unpacked;
+mod validity;
+
+pub use validity::ValidityBitmap;
 
 use core::{
     borrow::{Borrow, BorrowMut},

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -117,6 +117,18 @@ impl<Storage: Buffer> Bitmap<Storage> {
         }
     }
 
+    /// Returns the backing byte buffer of this [`Bitmap`].
+    #[must_use]
+    pub fn buffer(&self) -> &Storage::For<u8> {
+        &self.buffer
+    }
+
+    /// Returns the bit offset into the backing byte buffer.
+    #[must_use]
+    pub fn bit_offset(&self) -> usize {
+        self.offset
+    }
+
     /// Returns the raw parts of this [`Bitmap`]: its byte buffer, the number of
     /// bits it stores, and the bit offset into the buffer.
     ///

--- a/src/bitmap/validity.rs
+++ b/src/bitmap/validity.rs
@@ -1,0 +1,57 @@
+//! Validity information stored in a bitmap.
+
+use super::{Bitmap, BitmapRef};
+use crate::{buffer::Buffer, collection::Collection};
+
+/// A bitmap storing the validity of elements in a collection.
+pub trait ValidityBitmap: BitmapRef {
+    /// Returns whether the element at `index` is null, or [`None`] when the
+    /// index is out of bounds.
+    fn is_null(&self, index: usize) -> Option<bool> {
+        self.is_valid(index).map(|valid| !valid)
+    }
+
+    /// Returns the number of null elements.
+    fn null_count(&self) -> usize {
+        self.bitmap_ref()
+            .iter_views()
+            .filter(|valid| !*valid)
+            .count()
+    }
+
+    /// Returns whether the element at `index` is valid, or [`None`] when the
+    /// index is out of bounds.
+    fn is_valid(&self, index: usize) -> Option<bool> {
+        self.bitmap_ref().view(index)
+    }
+
+    /// Returns the number of valid elements.
+    fn valid_count(&self) -> usize {
+        self.bitmap_ref()
+            .iter_views()
+            .filter(|valid| *valid)
+            .count()
+    }
+
+    /// Returns whether the collection contains at least one null element.
+    fn any_null(&self) -> bool {
+        self.bitmap_ref().iter_views().any(|valid| !valid)
+    }
+
+    /// Returns whether all elements in the collection are null.
+    fn all_null(&self) -> bool {
+        self.bitmap_ref().iter_views().all(|valid| !valid)
+    }
+
+    /// Returns whether the collection contains at least one valid element.
+    fn any_valid(&self) -> bool {
+        self.bitmap_ref().iter_views().any(|valid| valid)
+    }
+
+    /// Returns whether all elements in the collection are valid.
+    fn all_valid(&self) -> bool {
+        self.bitmap_ref().iter_views().all(|valid| valid)
+    }
+}
+
+impl<Storage: Buffer> ValidityBitmap for Bitmap<Storage> {}

--- a/src/bitmap/validity.rs
+++ b/src/bitmap/validity.rs
@@ -1,7 +1,7 @@
 //! Validity information stored in a bitmap.
 
-use super::{Bitmap, BitmapRef};
-use crate::{buffer::Buffer, collection::Collection};
+use super::BitmapRef;
+use crate::collection::Collection;
 
 /// A bitmap storing the validity of elements in a collection.
 pub trait ValidityBitmap: BitmapRef {
@@ -53,5 +53,3 @@ pub trait ValidityBitmap: BitmapRef {
         self.bitmap_ref().iter_views().all(|valid| valid)
     }
 }
-
-impl<Storage: Buffer> ValidityBitmap for Bitmap<Storage> {}

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -14,6 +14,15 @@ pub trait Buffer: Default {
     type For<T: FixedSize>: Borrow<[T]> + Collection<Owned = T>;
 }
 
+/// Immutable access to a backing buffer or collection.
+pub trait BufferRef {
+    /// Backing buffer or collection.
+    type Buffer: Collection;
+
+    /// Returns the backing buffer or collection.
+    fn buffer_ref(&self) -> &Self::Buffer;
+}
+
 #[derive(Clone, Copy, Default, Debug)]
 pub struct ArrayBuffer<const N: usize>;
 impl<const N: usize> Buffer for ArrayBuffer<N> {

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -8,7 +8,7 @@ use core::{
 
 use crate::{
     collection::{
-        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        AllocError, ChildRef, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
         owned::IntoOwned,
     },
     length::Length,
@@ -64,18 +64,20 @@ impl<C: Collection, const N: usize> Flatten<C, N> {
         }
     }
 
-    /// Returns the child collection.
-    #[must_use]
-    pub fn child(&self) -> &C {
-        &self.0
-    }
-
     /// Returns the child collection of this [`Flatten`].
     ///
     /// This is the inverse of [`Flatten::try_from_parts`].
     #[must_use]
     pub fn into_parts(self) -> C {
         self.0
+    }
+}
+
+impl<C: Collection, const N: usize> ChildRef for Flatten<C, N> {
+    type Child = C;
+
+    fn child_ref(&self) -> &Self::Child {
+        &self.0
     }
 }
 

--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -64,6 +64,12 @@ impl<C: Collection, const N: usize> Flatten<C, N> {
         }
     }
 
+    /// Returns the child collection.
+    #[must_use]
+    pub fn child(&self) -> &C {
+        &self.0
+    }
+
     /// Returns the child collection of this [`Flatten`].
     ///
     /// This is the inverse of [`Flatten::try_from_parts`].

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -51,6 +51,19 @@ pub trait Collection: Length {
     fn into_iter_owned(self) -> Self::IntoIter;
 }
 
+/// Immutable access to a physical child collection.
+///
+/// A physical child does not necessarily correspond to an Arrow schema child.
+/// For example, variable-size binary data is a physical child in Narrow but an
+/// Arrow data buffer.
+pub trait ChildRef {
+    /// Physical child collection.
+    type Child: Collection;
+
+    /// Returns the physical child collection.
+    fn child_ref(&self) -> &Self::Child;
+}
+
 /// Error returned when storage for a collection cannot be reserved.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AllocError;

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -28,6 +28,7 @@ impl FixedSize for f64 {}
 /// An array with `N` `FixedSize` items per item.
 ///
 /// Just using [T; N] causes overlapping impls.
+#[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FixedSizeArray<T: FixedSize, const N: usize>([T; N]);
 

--- a/src/fixed_size.rs
+++ b/src/fixed_size.rs
@@ -28,7 +28,6 @@ impl FixedSize for f64 {}
 /// An array with `N` `FixedSize` items per item.
 ///
 /// Just using [T; N] causes overlapping impls.
-#[repr(transparent)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FixedSizeArray<T: FixedSize, const N: usize>([T; N]);
 

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 
 use crate::{
     bitmap::Bitmap,
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::MemoryLayout,
     length::Length,
@@ -26,17 +26,19 @@ impl<Nulls: Nullability, Storage: Buffer> Boolean<Nulls, Storage> {
     }
 
     /// Returns the backing collection of this [`Boolean`].
-    #[must_use]
-    pub fn buffer(&self) -> &Nulls::Collection<Bitmap<Storage>, Storage> {
-        &self.0
-    }
-
-    /// Returns the backing collection of this [`Boolean`].
     ///
     /// This is the inverse of [`Boolean::from_buffer`].
     #[must_use]
     pub fn into_buffer(self) -> Nulls::Collection<Bitmap<Storage>, Storage> {
         self.0
+    }
+}
+
+impl<Nulls: Nullability, Storage: Buffer> BufferRef for Boolean<Nulls, Storage> {
+    type Buffer = Nulls::Collection<Bitmap<Storage>, Storage>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.0
     }
 }
 

--- a/src/layout/boolean.rs
+++ b/src/layout/boolean.rs
@@ -26,6 +26,12 @@ impl<Nulls: Nullability, Storage: Buffer> Boolean<Nulls, Storage> {
     }
 
     /// Returns the backing collection of this [`Boolean`].
+    #[must_use]
+    pub fn buffer(&self) -> &Nulls::Collection<Bitmap<Storage>, Storage> {
+        &self.0
+    }
+
+    /// Returns the backing collection of this [`Boolean`].
     ///
     /// This is the inverse of [`Boolean::from_buffer`].
     #[must_use]

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -30,6 +30,12 @@ impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer>
     }
 
     /// Returns the backing collection of this [`FixedSizeList`].
+    #[must_use]
+    pub fn buffer(&self) -> &Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage> {
+        &self.0
+    }
+
+    /// Returns the backing collection of this [`FixedSizeList`].
     ///
     /// This is the inverse of [`FixedSizeList::from_buffer`].
     #[must_use]

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use crate::{
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc, flatten::Flatten},
     layout::{ArrayItem, MemoryLayout},
     length::Length,
@@ -30,17 +30,21 @@ impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer>
     }
 
     /// Returns the backing collection of this [`FixedSizeList`].
-    #[must_use]
-    pub fn buffer(&self) -> &Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage> {
-        &self.0
-    }
-
-    /// Returns the backing collection of this [`FixedSizeList`].
     ///
     /// This is the inverse of [`FixedSizeList::from_buffer`].
     #[must_use]
     pub fn into_buffer(self) -> Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage> {
         self.0
+    }
+}
+
+impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer> BufferRef
+    for FixedSizeList<T, N, Nulls, Storage>
+{
+    type Buffer = Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.0
     }
 }
 

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 
 use crate::{
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     fixed_size::FixedSize,
     layout::MemoryLayout,
@@ -31,17 +31,21 @@ impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> FixedSizePrimitive<T, Nu
     }
 
     /// Returns the backing collection of this [`FixedSizePrimitive`].
-    #[must_use]
-    pub fn buffer(&self) -> &Nulls::Collection<Storage::For<T>, Storage> {
-        &self.0
-    }
-
-    /// Returns the backing collection of this [`FixedSizePrimitive`].
     ///
     /// This is the inverse of [`FixedSizePrimitive::from_buffer`].
     #[must_use]
     pub fn into_buffer(self) -> Nulls::Collection<Storage::For<T>, Storage> {
         self.0
+    }
+}
+
+impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> BufferRef
+    for FixedSizePrimitive<T, Nulls, Storage>
+{
+    type Buffer = Nulls::Collection<Storage::For<T>, Storage>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.0
     }
 }
 

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -31,6 +31,12 @@ impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> FixedSizePrimitive<T, Nu
     }
 
     /// Returns the backing collection of this [`FixedSizePrimitive`].
+    #[must_use]
+    pub fn buffer(&self) -> &Nulls::Collection<Storage::For<T>, Storage> {
+        &self.0
+    }
+
+    /// Returns the backing collection of this [`FixedSizePrimitive`].
     ///
     /// This is the inverse of [`FixedSizePrimitive::from_buffer`].
     #[must_use]

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -36,6 +36,14 @@ impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
     }
 
     /// Returns the backing collection of this [`VariableSizeList`].
+    #[must_use]
+    pub fn buffer(
+        &self,
+    ) -> &Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage> {
+        &self.0
+    }
+
+    /// Returns the backing collection of this [`VariableSizeList`].
     ///
     /// This is the inverse of [`VariableSizeList::from_buffer`].
     #[must_use]

--- a/src/layout/variable_size_list.rs
+++ b/src/layout/variable_size_list.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use crate::{
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{AllocError, Collection, CollectionAllocIn, CollectionRealloc},
     layout::{ArrayItem, MemoryLayout},
     length::Length,
@@ -36,14 +36,6 @@ impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
     }
 
     /// Returns the backing collection of this [`VariableSizeList`].
-    #[must_use]
-    pub fn buffer(
-        &self,
-    ) -> &Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage> {
-        &self.0
-    }
-
-    /// Returns the backing collection of this [`VariableSizeList`].
     ///
     /// This is the inverse of [`VariableSizeList::from_buffer`].
     #[must_use]
@@ -51,6 +43,16 @@ impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer>
         self,
     ) -> Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage> {
         self.0
+    }
+}
+
+impl<T: ArrayItem, Nulls: Nullability, OffsetItem: Offset, Storage: Buffer> BufferRef
+    for VariableSizeList<T, Nulls, OffsetItem, Storage>
+{
+    type Buffer = Nulls::Collection<Offsets<T::Memory<Storage>, OffsetItem, Storage>, Storage>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.0
     }
 }
 

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -15,9 +15,9 @@ use core::{
 };
 
 use crate::{
-    buffer::{Buffer, VecBuffer},
+    buffer::{Buffer, BufferRef, VecBuffer},
     collection::{
-        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        AllocError, ChildRef, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
         owned::IntoOwned,
     },
     fixed_size::FixedSize,
@@ -172,24 +172,32 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U> Offsets<T, OffsetIte
         })
     }
 
-    /// Returns the flat data collection.
-    #[must_use]
-    pub fn data(&self) -> &T {
-        &self.data
-    }
-
-    /// Returns the offsets buffer.
-    #[must_use]
-    pub fn offsets(&self) -> &Storage::For<OffsetItem> {
-        &self.offsets
-    }
-
     /// Returns the data collection and offsets buffer of these [`Offsets`].
     ///
     /// This is the inverse of [`Offsets::try_from_parts`].
     #[must_use]
     pub fn into_parts(self) -> (T, Storage::For<OffsetItem>) {
         (self.data, self.offsets)
+    }
+}
+
+impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U> BufferRef
+    for Offsets<T, OffsetItem, Storage, U>
+{
+    type Buffer = Storage::For<OffsetItem>;
+
+    fn buffer_ref(&self) -> &Self::Buffer {
+        &self.offsets
+    }
+}
+
+impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U> ChildRef
+    for Offsets<T, OffsetItem, Storage, U>
+{
+    type Child = T;
+
+    fn child_ref(&self) -> &Self::Child {
+        &self.data
     }
 }
 

--- a/src/offset.rs
+++ b/src/offset.rs
@@ -172,6 +172,18 @@ impl<T: Collection, OffsetItem: Offset, Storage: Buffer, U> Offsets<T, OffsetIte
         })
     }
 
+    /// Returns the flat data collection.
+    #[must_use]
+    pub fn data(&self) -> &T {
+        &self.data
+    }
+
+    /// Returns the offsets buffer.
+    #[must_use]
+    pub fn offsets(&self) -> &Storage::For<OffsetItem> {
+        &self.offsets
+    }
+
     /// Returns the data collection and offsets buffer of these [`Offsets`].
     ///
     /// This is the inverse of [`Offsets::try_from_parts`].

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use crate::{
-    bitmap::Bitmap,
+    bitmap::{Bitmap, BitmapRef},
     buffer::{Buffer, VecBuffer},
     collection::{
         AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
@@ -83,18 +83,20 @@ impl<T: Collection, Storage: Buffer> Validity<T, Storage> {
         &self.collection
     }
 
-    /// Returns the validity bitmap.
-    #[must_use]
-    pub fn bitmap(&self) -> &Bitmap<Storage> {
-        &self.bitmap
-    }
-
     /// Returns the collection and validity bitmap of this [`Validity`].
     ///
     /// This is the inverse of [`Validity::try_from_parts`].
     #[must_use]
     pub fn into_parts(self) -> (T, Bitmap<Storage>) {
         (self.collection, self.bitmap)
+    }
+}
+
+impl<T: Collection, Storage: Buffer> BitmapRef for Validity<T, Storage> {
+    type Storage = Storage;
+
+    fn bitmap_ref(&self) -> &Bitmap<Self::Storage> {
+        &self.bitmap
     }
 }
 

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -10,7 +10,8 @@ use crate::{
     bitmap::{Bitmap, BitmapRef},
     buffer::{Buffer, VecBuffer},
     collection::{
-        AllocError, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc, view::AsView,
+        AllocError, ChildRef, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
+        view::AsView,
     },
     length::Length,
 };
@@ -77,18 +78,20 @@ impl<T: Collection, Storage: Buffer> Validity<T, Storage> {
         }
     }
 
-    /// Returns the collection that may contain null elements.
-    #[must_use]
-    pub fn collection(&self) -> &T {
-        &self.collection
-    }
-
     /// Returns the collection and validity bitmap of this [`Validity`].
     ///
     /// This is the inverse of [`Validity::try_from_parts`].
     #[must_use]
     pub fn into_parts(self) -> (T, Bitmap<Storage>) {
         (self.collection, self.bitmap)
+    }
+}
+
+impl<T: Collection, Storage: Buffer> ChildRef for Validity<T, Storage> {
+    type Child = T;
+
+    fn child_ref(&self) -> &Self::Child {
+        &self.collection
     }
 }
 

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -77,6 +77,18 @@ impl<T: Collection, Storage: Buffer> Validity<T, Storage> {
         }
     }
 
+    /// Returns the collection that may contain null elements.
+    #[must_use]
+    pub fn collection(&self) -> &T {
+        &self.collection
+    }
+
+    /// Returns the validity bitmap.
+    #[must_use]
+    pub fn bitmap(&self) -> &Bitmap<Storage> {
+        &self.bitmap
+    }
+
     /// Returns the collection and validity bitmap of this [`Validity`].
     ///
     /// This is the inverse of [`Validity::try_from_parts`].

--- a/src/validity.rs
+++ b/src/validity.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 use crate::{
-    bitmap::{Bitmap, BitmapRef},
+    bitmap::{Bitmap, BitmapRef, ValidityBitmap},
     buffer::{Buffer, VecBuffer},
     collection::{
         AllocError, ChildRef, Collection, CollectionAlloc, CollectionAllocIn, CollectionRealloc,
@@ -102,6 +102,8 @@ impl<T: Collection, Storage: Buffer> BitmapRef for Validity<T, Storage> {
         &self.bitmap
     }
 }
+
+impl<T: Collection, Storage: Buffer> ValidityBitmap for Validity<T, Storage> {}
 
 impl<T: Collection + Debug, Storage: Buffer> Debug for Validity<T, Storage>
 where

--- a/tests/borrowed_memory.rs
+++ b/tests/borrowed_memory.rs
@@ -16,7 +16,7 @@ fn borrows_nested_backing_memory() {
     );
     assert_eq!(list_validity.bitmap_ref().bit_offset(), 0);
 
-    let offsets = list_validity.collection();
+    let offsets = list_validity.child_ref();
     assert_eq!(offsets.buffer_ref().as_slice(), &[0, 2]);
 
     let items = offsets.child_ref();
@@ -26,7 +26,7 @@ fn borrows_nested_backing_memory() {
         &[0b0000_0001]
     );
 
-    let flattened = item_validity.collection();
+    let flattened = item_validity.child_ref();
     assert_eq!(flattened.child_ref().buffer_ref().as_slice(), &[1, 2, 0, 0]);
 }
 

--- a/tests/borrowed_memory.rs
+++ b/tests/borrowed_memory.rs
@@ -1,0 +1,42 @@
+use core::mem::{align_of, size_of};
+
+use narrow::{array::Array, fixed_size::FixedSizeArray};
+
+#[test]
+fn borrows_nested_backing_memory() {
+    type Nested = Option<Vec<Option<[i32; 2]>>>;
+
+    let array = [Some(vec![Some([1, 2]), None])]
+        .into_iter()
+        .collect::<Array<Nested>>();
+
+    let list = array.buffer();
+    let list_validity = list.buffer();
+    assert_eq!(list_validity.bitmap().buffer().as_slice(), &[0b0000_0001]);
+    assert_eq!(list_validity.bitmap().bit_offset(), 0);
+
+    let offsets = list_validity.collection();
+    assert_eq!(offsets.offsets().as_slice(), &[0, 2]);
+
+    let items = offsets.data();
+    let item_validity = items.buffer();
+    assert_eq!(item_validity.bitmap().buffer().as_slice(), &[0b0000_0001]);
+
+    let flattened = item_validity.collection();
+    assert_eq!(flattened.child().buffer().as_slice(), &[1, 2, 0, 0]);
+}
+
+#[test]
+fn borrows_boolean_backing_memory() {
+    let array = [true, false, true].into_iter().collect::<Array<bool>>();
+    let bitmap = array.buffer().buffer();
+
+    assert_eq!(bitmap.buffer().as_slice(), &[0b0000_0101]);
+    assert_eq!(bitmap.bit_offset(), 0);
+}
+
+#[test]
+fn fixed_size_array_is_transparent() {
+    assert_eq!(size_of::<FixedSizeArray<u16, 4>>(), size_of::<[u16; 4]>());
+    assert_eq!(align_of::<FixedSizeArray<u16, 4>>(), align_of::<[u16; 4]>());
+}

--- a/tests/borrowed_memory.rs
+++ b/tests/borrowed_memory.rs
@@ -1,4 +1,9 @@
-use narrow::{array::Array, bitmap::BitmapRef, buffer::BufferRef, collection::ChildRef};
+use narrow::{
+    array::Array,
+    bitmap::{BitmapRef, ValidityBitmap},
+    buffer::BufferRef,
+    collection::ChildRef,
+};
 
 #[test]
 fn borrows_nested_backing_memory() {
@@ -15,6 +20,7 @@ fn borrows_nested_backing_memory() {
         &[0b0000_0001]
     );
     assert_eq!(list_validity.bitmap_ref().bit_offset(), 0);
+    assert_eq!(list_validity.null_count(), 0);
 
     let offsets = list_validity.child_ref();
     assert_eq!(offsets.buffer_ref().as_slice(), &[0, 2]);
@@ -25,6 +31,9 @@ fn borrows_nested_backing_memory() {
         item_validity.bitmap_ref().buffer_ref().as_slice(),
         &[0b0000_0001]
     );
+    assert_eq!(item_validity.null_count(), 1);
+    assert_eq!(item_validity.is_valid(0), Some(true));
+    assert_eq!(item_validity.is_null(1), Some(true));
 
     let flattened = item_validity.child_ref();
     assert_eq!(flattened.child_ref().buffer_ref().as_slice(), &[1, 2, 0, 0]);

--- a/tests/borrowed_memory.rs
+++ b/tests/borrowed_memory.rs
@@ -1,6 +1,4 @@
-use core::mem::{align_of, size_of};
-
-use narrow::{array::Array, fixed_size::FixedSizeArray};
+use narrow::{array::Array, bitmap::BitmapRef, buffer::BufferRef, collection::ChildRef};
 
 #[test]
 fn borrows_nested_backing_memory() {
@@ -10,33 +8,33 @@ fn borrows_nested_backing_memory() {
         .into_iter()
         .collect::<Array<Nested>>();
 
-    let list = array.buffer();
-    let list_validity = list.buffer();
-    assert_eq!(list_validity.bitmap().buffer().as_slice(), &[0b0000_0001]);
-    assert_eq!(list_validity.bitmap().bit_offset(), 0);
+    let list = array.buffer_ref();
+    let list_validity = list.buffer_ref();
+    assert_eq!(
+        list_validity.bitmap_ref().buffer_ref().as_slice(),
+        &[0b0000_0001]
+    );
+    assert_eq!(list_validity.bitmap_ref().bit_offset(), 0);
 
     let offsets = list_validity.collection();
-    assert_eq!(offsets.offsets().as_slice(), &[0, 2]);
+    assert_eq!(offsets.buffer_ref().as_slice(), &[0, 2]);
 
-    let items = offsets.data();
-    let item_validity = items.buffer();
-    assert_eq!(item_validity.bitmap().buffer().as_slice(), &[0b0000_0001]);
+    let items = offsets.child_ref();
+    let item_validity = items.buffer_ref();
+    assert_eq!(
+        item_validity.bitmap_ref().buffer_ref().as_slice(),
+        &[0b0000_0001]
+    );
 
     let flattened = item_validity.collection();
-    assert_eq!(flattened.child().buffer().as_slice(), &[1, 2, 0, 0]);
+    assert_eq!(flattened.child_ref().buffer_ref().as_slice(), &[1, 2, 0, 0]);
 }
 
 #[test]
 fn borrows_boolean_backing_memory() {
     let array = [true, false, true].into_iter().collect::<Array<bool>>();
-    let bitmap = array.buffer().buffer();
+    let bitmap = array.buffer_ref().buffer_ref();
 
-    assert_eq!(bitmap.buffer().as_slice(), &[0b0000_0101]);
+    assert_eq!(bitmap.buffer_ref().as_slice(), &[0b0000_0101]);
     assert_eq!(bitmap.bit_offset(), 0);
-}
-
-#[test]
-fn fixed_size_array_is_transparent() {
-    assert_eq!(size_of::<FixedSizeArray<u16, 4>>(), size_of::<[u16; 4]>());
-    assert_eq!(align_of::<FixedSizeArray<u16, 4>>(), align_of::<[u16; 4]>());
 }


### PR DESCRIPTION
## Summary

- add BufferRef, BitmapRef, ValidityBitmap, and ChildRef for read-only physical storage traversal
- expose null and valid queries through the semantic validity bitmap trait
- implement the traits across arrays, layouts, bitmaps, validity, offsets, and flattened children
- distinguish physical children from Arrow schema children