### PR TITLE
feat: export primitive arrays through Arrow C data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,3 +16,6 @@ version = "0.16.0"
 [[package]]
 name = "narrow-ffi"
 version = "0.16.0"
+dependencies = [
+ "narrow",
+]

--- a/narrow-ffi/Cargo.toml
+++ b/narrow-ffi/Cargo.toml
@@ -16,5 +16,6 @@ categories.workspace = true
 default = []
 
 [dependencies]
+narrow = { path = "..", version = "0.16.0" }
 
 [dev-dependencies]

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -1,4 +1,4 @@
-//! Export Narrow arrays through the Arrow C Data Interface.
+//! Export [`Array`] values through the Arrow C Data Interface.
 
 extern crate alloc;
 
@@ -16,42 +16,59 @@ use narrow::{
 
 use crate::{ArrowArray, ArrowSchema};
 
-/// A fixed-size primitive with an Arrow C Data format string.
+/// A [`FixedSize`] primitive with an Arrow C Data format string.
 pub trait ArrowPrimitive: FixedSize {
     /// Arrow C Data type format.
     const FORMAT: &'static CStr;
 }
 
-macro_rules! primitive {
-    ($($type:ty => $format:literal),+ $(,)?) => {
-        $(
-            impl ArrowPrimitive for $type {
-                const FORMAT: &'static CStr = $format;
-            }
-        )+
-    };
+impl ArrowPrimitive for i8 {
+    const FORMAT: &'static CStr = c"c";
 }
 
-primitive! {
-    i8 => c"c",
-    u8 => c"C",
-    i16 => c"s",
-    u16 => c"S",
-    i32 => c"i",
-    u32 => c"I",
-    i64 => c"l",
-    u64 => c"L",
-    f32 => c"f",
-    f64 => c"g",
+impl ArrowPrimitive for u8 {
+    const FORMAT: &'static CStr = c"C";
 }
 
-/// Export a Narrow array through the Arrow C Data Interface.
+impl ArrowPrimitive for i16 {
+    const FORMAT: &'static CStr = c"s";
+}
+
+impl ArrowPrimitive for u16 {
+    const FORMAT: &'static CStr = c"S";
+}
+
+impl ArrowPrimitive for i32 {
+    const FORMAT: &'static CStr = c"i";
+}
+
+impl ArrowPrimitive for u32 {
+    const FORMAT: &'static CStr = c"I";
+}
+
+impl ArrowPrimitive for i64 {
+    const FORMAT: &'static CStr = c"l";
+}
+
+impl ArrowPrimitive for u64 {
+    const FORMAT: &'static CStr = c"L";
+}
+
+impl ArrowPrimitive for f32 {
+    const FORMAT: &'static CStr = c"f";
+}
+
+impl ArrowPrimitive for f64 {
+    const FORMAT: &'static CStr = c"g";
+}
+
+/// Export an [`Array`] through the Arrow C Data Interface.
 pub trait Export {
-    /// Consumes the array and returns its Arrow C Data array and schema.
+    /// Consumes `self` and returns an [`ArrowArray`] and [`ArrowSchema`].
     fn export(self) -> (ArrowArray, ArrowSchema);
 }
 
-struct PrimitivePrivate<Values> {
+struct PrimitiveArrayData<Values> {
     _values: Values,
     buffers: [*const c_void; 2],
 }
@@ -65,7 +82,7 @@ where
     fn export(self) -> (ArrowArray, ArrowSchema) {
         let primitive: FixedSizePrimitive<T, NonNullable, Storage> = self.into_buffer();
         let values = primitive.into_buffer();
-        let mut private = Box::new(PrimitivePrivate {
+        let mut private = Box::new(PrimitiveArrayData {
             _values: values,
             buffers: [ptr::null(); 2],
         });
@@ -112,10 +129,10 @@ unsafe extern "C" fn release_primitive<Values>(array: *mut ArrowArray) {
     array.buffers = ptr::null_mut();
 
     // SAFETY: `private_data` was created with `Box::into_raw` for this exact
-    // `PrimitivePrivate<Values>` instantiation and is released only once.
+    // `PrimitiveArrayData<Values>` instantiation and is released only once.
     unsafe {
         drop(Box::from_raw(
-            private_data.cast::<PrimitivePrivate<Values>>(),
+            private_data.cast::<PrimitiveArrayData<Values>>(),
         ))
     };
 }

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -1,0 +1,214 @@
+//! Export Narrow arrays through the Arrow C Data Interface.
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use core::{
+    borrow::Borrow,
+    ffi::{CStr, c_void},
+    ptr,
+};
+
+use narrow::{
+    array::Array, buffer::Buffer, fixed_size::FixedSize,
+    layout::fixed_size_primitive::FixedSizePrimitive, nullability::NonNullable,
+};
+
+use crate::{ArrowArray, ArrowSchema};
+
+/// A fixed-size primitive with an Arrow C Data format string.
+pub trait ArrowPrimitive: FixedSize {
+    /// Arrow C Data type format.
+    const FORMAT: &'static CStr;
+}
+
+macro_rules! primitive {
+    ($($type:ty => $format:literal),+ $(,)?) => {
+        $(
+            impl ArrowPrimitive for $type {
+                const FORMAT: &'static CStr = $format;
+            }
+        )+
+    };
+}
+
+primitive! {
+    i8 => c"c",
+    u8 => c"C",
+    i16 => c"s",
+    u16 => c"S",
+    i32 => c"i",
+    u32 => c"I",
+    i64 => c"l",
+    u64 => c"L",
+    f32 => c"f",
+    f64 => c"g",
+}
+
+/// Export a Narrow array through the Arrow C Data Interface.
+pub trait Export {
+    /// Consumes the array and returns its Arrow C Data array and schema.
+    fn export(self) -> (ArrowArray, ArrowSchema);
+}
+
+struct PrimitivePrivate<Values> {
+    _values: Values,
+    buffers: [*const c_void; 2],
+}
+
+impl<T, Storage> Export for Array<T, Storage>
+where
+    T: ArrowPrimitive,
+    Storage: Buffer,
+    Storage::For<T>: 'static,
+{
+    fn export(self) -> (ArrowArray, ArrowSchema) {
+        let primitive: FixedSizePrimitive<T, NonNullable, Storage> = self.into_buffer();
+        let values = primitive.into_buffer();
+        let mut private = Box::new(PrimitivePrivate {
+            _values: values,
+            buffers: [ptr::null(); 2],
+        });
+        let values: &[T] = private._values.borrow();
+        let length = i64::try_from(values.len()).expect("array length exceeds i64");
+        private.buffers[1] = values.as_ptr().cast();
+
+        let buffers = private.buffers.as_mut_ptr();
+        let private_data = Box::into_raw(private).cast();
+        let array = ArrowArray {
+            length,
+            null_count: 0,
+            offset: 0,
+            n_buffers: 2,
+            n_children: 0,
+            buffers,
+            children: ptr::null_mut(),
+            dictionary: ptr::null_mut(),
+            release: Some(release_primitive::<Storage::For<T>>),
+            private_data,
+        };
+        let schema = ArrowSchema {
+            format: T::FORMAT.as_ptr(),
+            name: c"".as_ptr(),
+            metadata: ptr::null(),
+            flags: 0,
+            n_children: 0,
+            children: ptr::null_mut(),
+            dictionary: ptr::null_mut(),
+            release: Some(release_schema),
+            private_data: ptr::null_mut(),
+        };
+        (array, schema)
+    }
+}
+
+unsafe extern "C" fn release_primitive<Values>(array: *mut ArrowArray) {
+    // SAFETY: The Arrow C Data contract passes the live structure to its
+    // producer-provided callback.
+    let array = unsafe { &mut *array };
+    let private_data = array.private_data;
+    array.release = None;
+    array.private_data = ptr::null_mut();
+    array.buffers = ptr::null_mut();
+
+    // SAFETY: `private_data` was created with `Box::into_raw` for this exact
+    // `PrimitivePrivate<Values>` instantiation and is released only once.
+    unsafe {
+        drop(Box::from_raw(
+            private_data.cast::<PrimitivePrivate<Values>>(),
+        ))
+    };
+}
+
+unsafe extern "C" fn release_schema(schema: *mut ArrowSchema) {
+    // SAFETY: The Arrow C Data contract passes the live structure to its
+    // producer-provided callback.
+    unsafe { (*schema).release = None };
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::sync::Arc;
+    use core::{ffi::CStr, slice};
+
+    use narrow::{
+        array::Array,
+        buffer::{ArcBuffer, ArrayBuffer},
+        layout::fixed_size_primitive::FixedSizePrimitive,
+    };
+
+    use super::{ArrowPrimitive, Export};
+
+    #[test]
+    fn primitive_format_strings_match_arrow() {
+        assert_eq!(<i8 as ArrowPrimitive>::FORMAT, c"c");
+        assert_eq!(<u8 as ArrowPrimitive>::FORMAT, c"C");
+        assert_eq!(<i16 as ArrowPrimitive>::FORMAT, c"s");
+        assert_eq!(<u16 as ArrowPrimitive>::FORMAT, c"S");
+        assert_eq!(<i32 as ArrowPrimitive>::FORMAT, c"i");
+        assert_eq!(<u32 as ArrowPrimitive>::FORMAT, c"I");
+        assert_eq!(<i64 as ArrowPrimitive>::FORMAT, c"l");
+        assert_eq!(<u64 as ArrowPrimitive>::FORMAT, c"L");
+        assert_eq!(<f32 as ArrowPrimitive>::FORMAT, c"f");
+        assert_eq!(<f64 as ArrowPrimitive>::FORMAT, c"g");
+    }
+
+    #[test]
+    fn exports_primitive_array_without_copying_values() {
+        let values = Arc::<[i32]>::from([1, 2, 3]);
+        let weak = Arc::downgrade(&values);
+        let data = values.as_ptr();
+        let array: Array<i32, ArcBuffer> =
+            Array::from_buffer(FixedSizePrimitive::from_buffer(values));
+
+        let (array, schema) = array.export();
+
+        assert_eq!(array.length, 3);
+        assert_eq!(array.null_count, 0);
+        assert_eq!(array.offset, 0);
+        assert_eq!(array.n_buffers, 2);
+        assert_eq!(array.n_children, 0);
+        assert!(array.children.is_null());
+        assert!(array.dictionary.is_null());
+        // SAFETY: The exported array owns a two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        assert!(buffers[0].is_null());
+        assert_eq!(buffers[1], data.cast());
+        // SAFETY: The second buffer points to three i32 values held by the export.
+        assert_eq!(
+            unsafe { slice::from_raw_parts(buffers[1].cast::<i32>(), 3) },
+            [1, 2, 3]
+        );
+
+        // SAFETY: The exported schema has a live, null-terminated format string.
+        assert_eq!(unsafe { CStr::from_ptr(schema.format) }, c"i");
+        assert_eq!(schema.flags, 0);
+        assert_eq!(schema.n_children, 0);
+        assert!(schema.children.is_null());
+        assert!(schema.dictionary.is_null());
+        assert!(weak.upgrade().is_some());
+
+        drop(array);
+        assert!(weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn pins_inline_values_for_export() {
+        let array: Array<i32, ArrayBuffer<3>> =
+            Array::from_buffer(FixedSizePrimitive::from_buffer([1, 2, 3]));
+
+        let (array, _schema) = array.export();
+
+        // SAFETY: The exported array owns a two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        // SAFETY: The second buffer points to three inline i32 values pinned in
+        // the export's private allocation.
+        assert_eq!(
+            unsafe { slice::from_raw_parts(buffers[1].cast::<i32>(), 3) },
+            [1, 2, 3]
+        );
+    }
+}

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -70,8 +70,11 @@ pub trait Export {
     fn export(self) -> (ArrowArray, ArrowSchema);
 }
 
+/// Data retained by `ArrowArray::private_data` for a primitive array export.
 struct PrimitiveArrayData<Values> {
-    _values: Values,
+    /// Values backing the exported data buffer.
+    values: Values,
+    /// Arrow C Data buffer pointers for validity and values.
     buffers: [*const c_void; 2],
 }
 
@@ -82,16 +85,25 @@ where
     Storage::For<T>: 'static,
 {
     fn export(self) -> (ArrowArray, ArrowSchema) {
+        // Remove the type-level wrappers while preserving the original storage.
         let primitive: FixedSizePrimitive<T, NonNullable, Storage> = self.into_buffer();
         let values = primitive.into_buffer();
+
+        // Pin the storage before taking its address. This is required for
+        // inline buffers, whose values would otherwise move with the wrapper.
         let mut private = Box::new(PrimitiveArrayData {
-            _values: values,
+            values,
             buffers: [ptr::null(); 2],
         });
-        let values: &[T] = private._values.borrow();
+        let values: &[T] = private.values.borrow();
         let length = i64::try_from(values.len()).expect("array length exceeds i64");
+
+        // Primitive arrays have validity and value buffers. A non-nullable
+        // array may expose a null validity buffer because its null count is zero.
         private.buffers[1] = values.as_ptr().cast();
 
+        // Transfer ownership of the pinned storage to `private_data`. The
+        // release callback reconstructs this Box with the concrete buffer type.
         let buffers = private.buffers.as_mut_ptr();
         let private_data = Box::into_raw(private).cast();
         let array = ArrowArray {
@@ -103,9 +115,12 @@ where
             buffers,
             children: ptr::null_mut(),
             dictionary: ptr::null_mut(),
-            release: Some(release_primitive::<Storage::For<T>>),
+            release: Some(release_array::<PrimitiveArrayData<Storage::For<T>>>),
             private_data,
         };
+
+        // Primitive format strings and the empty name are static, so the
+        // schema release callback only needs to mark the schema as released.
         let schema = ArrowSchema {
             format: T::FORMAT.as_ptr(),
             name: c"".as_ptr(),
@@ -121,7 +136,7 @@ where
     }
 }
 
-unsafe extern "C" fn release_primitive<Values>(array: *mut ArrowArray) {
+unsafe extern "C" fn release_array<PrivateData>(array: *mut ArrowArray) {
     // SAFETY: The Arrow C Data contract passes the live structure to its
     // producer-provided callback.
     let array = unsafe { &mut *array };
@@ -131,12 +146,8 @@ unsafe extern "C" fn release_primitive<Values>(array: *mut ArrowArray) {
     array.buffers = ptr::null_mut();
 
     // SAFETY: `private_data` was created with `Box::into_raw` for this exact
-    // `PrimitiveArrayData<Values>` instantiation and is released only once.
-    unsafe {
-        drop(Box::from_raw(
-            private_data.cast::<PrimitiveArrayData<Values>>(),
-        ))
-    };
+    // `PrivateData` type and is released only once.
+    unsafe { drop(Box::from_raw(private_data.cast::<PrivateData>())) };
 }
 
 unsafe extern "C" fn release_schema(schema: *mut ArrowSchema) {

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -16,7 +16,9 @@ use narrow::{
 
 use crate::{ArrowArray, ArrowSchema};
 
-/// A [`FixedSize`] primitive with an Arrow C Data format string.
+/// A [`FixedSize`] primitive with an [Arrow C Data format string].
+///
+/// [Arrow C Data format string]: https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
 pub trait ArrowPrimitive: FixedSize {
     /// Arrow C Data type format.
     const FORMAT: &'static CStr;

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -12,6 +12,9 @@ use core::{
     ptr,
 };
 
+mod export;
+pub use export::{ArrowPrimitive, Export};
+
 /// Dictionary values are ordered.
 pub const ARROW_FLAG_DICTIONARY_ORDERED: i64 = 1;
 

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -1,4 +1,4 @@
-//! Arrow C Data Interface support for Narrow.
+//! Arrow C Data Interface support for [`Array`](narrow::array::Array).
 //!
 //! See [The Arrow C data interface] specification.
 //!


### PR DESCRIPTION
## Summary

- map supported fixed-size primitives to Arrow C Data format strings
- export non-nullable primitive arrays as ArrowArray and ArrowSchema
- retain owned and inline Narrow storage behind private_data without copying values
- release exported storage through the Arrow producer callback