### PR TITLE
docs: add length examples

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -5,11 +5,35 @@ extern crate alloc;
 use alloc::{boxed::Box, collections::VecDeque, rc::Rc, sync::Arc, vec::Vec};
 
 /// The length (or number of units) of an item.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::length::Length;
+///
+/// assert_eq!(Length::len(&[1, 2, 3]), 3);
+/// ```
 pub trait Length {
     /// Returns the number of units in this item, also referred to as its length.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::length::Length;
+    ///
+    /// assert_eq!(Length::len(&[1, 2]), 2);
+    /// ```
     fn len(&self) -> usize;
 
     /// Returns `true` if there are no unit in this item.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::length::Length;
+    ///
+    /// assert!(Length::is_empty(&[] as &[u8]));
+    /// ```
     fn is_empty(&self) -> bool {
         self.len() == 0
     }


### PR DESCRIPTION
Adds concise, runnable examples for the `Length` API.

Tests: `cargo test --workspace --doc --all-features`