### PR TITLE
docs: add view conversion examples

### DIFF
--- a/src/collection/owned.rs
+++ b/src/collection/owned.rs
@@ -4,8 +4,25 @@ use crate::fixed_size::FixedSize;
 use alloc::vec::Vec;
 
 /// Convert into owned items.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::owned::IntoOwned;
+///
+/// let owned: Vec<_> = (&[1, 2][..]).into_owned();
+/// assert_eq!(owned, [1, 2]);
+/// ```
 pub trait IntoOwned<Owned> {
     /// Returns the owned instance of self.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::collection::owned::IntoOwned;
+    ///
+    /// assert_eq!((&[1, 2][..]).into_owned(), vec![1, 2]);
+    /// ```
     fn into_owned(self) -> Owned;
 }
 

--- a/src/collection/view.rs
+++ b/src/collection/view.rs
@@ -4,11 +4,30 @@ use crate::{collection::owned::IntoOwned, fixed_size::FixedSize};
 use alloc::vec::Vec;
 
 /// Convert items into views.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::view::AsView;
+///
+/// let values = vec![1, 2];
+/// let view: &[i32] = values.as_view();
+/// assert_eq!(view, [1, 2]);
+/// ```
 pub trait AsView<'collection>: Sized {
     /// The view type.
     type View: Copy + IntoOwned<Self> + 'collection;
 
     /// Returns a view of self.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::collection::view::AsView;
+    ///
+    /// let values = vec![1, 2];
+    /// assert_eq!(values.as_view(), &[1, 2]);
+    /// ```
     fn as_view(&'collection self) -> Self::View;
 }
 


### PR DESCRIPTION
Adds concise, runnable examples for owned and borrowed item conversion.

Tests: `cargo test --workspace --doc --all-features`