### PR TITLE
docs: add flatten collection examples

### DIFF
--- a/src/collection/flatten.rs
+++ b/src/collection/flatten.rs
@@ -16,10 +16,30 @@ use crate::{
 
 /// A collection that flattens an inner collection and exposes its items as
 /// arrays with N items.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::{Collection, flatten::Flatten};
+///
+/// let values = [[1, 2], [3, 4]].into_iter().collect::<Flatten<Vec<_>, 2>>();
+/// assert_eq!(values.owned(1), Some([3, 4]));
+/// ```
 #[derive(Clone, Copy, Debug, Default)]
 pub struct Flatten<C: Collection, const N: usize>(C);
 
 /// Error returned by [`Flatten::try_from_parts`].
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::flatten::{Flatten, FlattenError};
+///
+/// let error = Flatten::<Vec<_>, 2>::try_from_parts(vec![1]).unwrap_err();
+/// assert_eq!(error, FlattenError::NotMultiple { len: 1, n: 2 });
+/// let error = Flatten::<Vec<i32>, 0>::try_from_parts(vec![]).unwrap_err();
+/// assert_eq!(error, FlattenError::ZeroChunkSize);
+/// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FlattenError {
     /// The chunk size `N` is zero.
@@ -53,6 +73,15 @@ impl<C: Collection, const N: usize> Flatten<C, N> {
     ///
     /// Returns a [`FlattenError`] when `N` is zero or when the length of the
     /// child collection is not a multiple of `N`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::collection::{Collection, flatten::Flatten};
+    ///
+    /// let values = Flatten::<Vec<_>, 2>::try_from_parts(vec![1, 2]).unwrap();
+    /// assert_eq!(values.owned(0), Some([1, 2]));
+    /// ```
     pub fn try_from_parts(child: C) -> Result<Self, FlattenError> {
         match child.len().checked_rem(N) {
             None => Err(FlattenError::ZeroChunkSize),
@@ -67,6 +96,15 @@ impl<C: Collection, const N: usize> Flatten<C, N> {
     /// Returns the child collection of this [`Flatten`].
     ///
     /// This is the inverse of [`Flatten::try_from_parts`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::collection::flatten::Flatten;
+    ///
+    /// let values = Flatten::<Vec<_>, 2>::try_from_parts(vec![1, 2]).unwrap();
+    /// assert_eq!(values.into_parts(), [1, 2]);
+    /// ```
     #[must_use]
     pub fn into_parts(self) -> C {
         self.0
@@ -185,6 +223,16 @@ impl<C: CollectionRealloc, const N: usize> CollectionRealloc for Flatten<C, N> {
 }
 
 /// A view of `Flatten`. This is an array with N views of the inner collection.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::{Collection, flatten::{Flatten, FlattenView}};
+///
+/// let values = [[1, 2]].into_iter().collect::<Flatten<Vec<_>, 2>>();
+/// let view: FlattenView<'_, Vec<i32>, 2> = values.view(0).unwrap();
+/// assert_eq!(*view, [1, 2]);
+/// ```
 #[derive(Debug)]
 pub struct FlattenView<'collection, C: Collection + 'collection, const N: usize>(
     [C::View<'collection>; N],
@@ -220,6 +268,16 @@ impl<C: Collection, const N: usize> IntoOwned<[C::Owned; N]> for FlattenView<'_,
 }
 
 /// An iterator over N elements of the inner iterator at a time.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::{Collection, flatten::{ArrayChunks, Flatten}};
+///
+/// let values = [[1, 2]].into_iter().collect::<Flatten<Vec<_>, 2>>();
+/// let mut chunks: ArrayChunks<2, _> = values.into_iter_owned();
+/// assert_eq!(chunks.next(), Some([1, 2]));
+/// ```
 #[derive(Debug, Clone, Copy)]
 pub struct ArrayChunks<const N: usize, I: ExactSizeIterator>(I);
 

--- a/src/collection/slice.rs
+++ b/src/collection/slice.rs
@@ -30,7 +30,17 @@ impl<T: for<'any> AsView<'any>> Collection for &[T] {
     }
 }
 
-/// An iterator over a slice that turns views into owned instances
+/// An iterator over a slice that turns views into owned instances.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::collection::{Collection, slice::SliceIntoIter};
+///
+/// let values = [1, 2];
+/// let iter: SliceIntoIter<&[i32], i32> = values.as_slice().into_iter_owned();
+/// assert_eq!(iter.collect::<Vec<_>>(), [1, 2]);
+/// ```
 #[derive(Debug)]
 pub struct SliceIntoIter<T, U> {
     /// The item that can be borrowed as slice


### PR DESCRIPTION
Adds concise, runnable examples for flattened collections, views, and iterators.

Tests: `cargo test --workspace --doc --all-features`