### PR TITLE
docs: add bitmap reference examples

### DIFF
--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -82,11 +82,29 @@ pub struct Bitmap<Storage: Buffer = VecBuffer> {
 }
 
 /// Immutable access to a [`Bitmap`].
+///
+/// # Examples
+///
+/// ```
+/// use narrow::{bitmap::BitmapRef, length::Length, validity::Validity};
+///
+/// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+/// assert_eq!(values.bitmap_ref().len(), 2);
+/// ```
 pub trait BitmapRef {
     /// Storage of the bitmap.
     type Storage: Buffer;
 
     /// Returns the bitmap.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::BitmapRef, length::Length, validity::Validity};
+    ///
+    /// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert_eq!(values.bitmap_ref().len(), 2);
+    /// ```
     fn bitmap_ref(&self) -> &Bitmap<Self::Storage>;
 }
 
@@ -138,6 +156,15 @@ impl<Storage: Buffer> Bitmap<Storage> {
     }
 
     /// Returns the bit offset into the backing byte buffer.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::Bitmap, buffer::VecBuffer};
+    ///
+    /// let bitmap = Bitmap::<VecBuffer>::try_from_parts(vec![0], 2, 3).unwrap();
+    /// assert_eq!(bitmap.bit_offset(), 3);
+    /// ```
     #[must_use]
     pub fn bit_offset(&self) -> usize {
         self.offset

--- a/src/bitmap/validity.rs
+++ b/src/bitmap/validity.rs
@@ -4,14 +4,41 @@ use super::BitmapRef;
 use crate::collection::Collection;
 
 /// A bitmap storing the validity of elements in a collection.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+///
+/// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+/// assert_eq!((values.valid_count(), values.null_count()), (1, 1));
+/// ```
 pub trait ValidityBitmap: BitmapRef {
     /// Returns whether the element at `index` is null, or [`None`] when the
     /// index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert_eq!(values.is_null(1), Some(true));
+    /// ```
     fn is_null(&self, index: usize) -> Option<bool> {
         self.is_valid(index).map(|valid| !valid)
     }
 
     /// Returns the number of null elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert_eq!(values.null_count(), 1);
+    /// ```
     fn null_count(&self) -> usize {
         self.bitmap_ref()
             .iter_views()
@@ -21,11 +48,29 @@ pub trait ValidityBitmap: BitmapRef {
 
     /// Returns whether the element at `index` is valid, or [`None`] when the
     /// index is out of bounds.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert_eq!(values.is_valid(0), Some(true));
+    /// ```
     fn is_valid(&self, index: usize) -> Option<bool> {
         self.bitmap_ref().view(index)
     }
 
     /// Returns the number of valid elements.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert_eq!(values.valid_count(), 1);
+    /// ```
     fn valid_count(&self) -> usize {
         self.bitmap_ref()
             .iter_views()
@@ -34,21 +79,57 @@ pub trait ValidityBitmap: BitmapRef {
     }
 
     /// Returns whether the collection contains at least one null element.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [Some(1), None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert!(values.any_null());
+    /// ```
     fn any_null(&self) -> bool {
         self.bitmap_ref().iter_views().any(|valid| !valid)
     }
 
     /// Returns whether all elements in the collection are null.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [None, None].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert!(values.all_null());
+    /// ```
     fn all_null(&self) -> bool {
         self.bitmap_ref().iter_views().all(|valid| !valid)
     }
 
     /// Returns whether the collection contains at least one valid element.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [None, Some(1)].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert!(values.any_valid());
+    /// ```
     fn any_valid(&self) -> bool {
         self.bitmap_ref().iter_views().any(|valid| valid)
     }
 
     /// Returns whether all elements in the collection are valid.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{bitmap::ValidityBitmap, validity::Validity};
+    ///
+    /// let values = [Some(1), Some(2)].into_iter().collect::<Validity<Vec<i32>>>();
+    /// assert!(values.all_valid());
+    /// ```
     fn all_valid(&self) -> bool {
         self.bitmap_ref().iter_views().all(|valid| valid)
     }


### PR DESCRIPTION
Adds concise, runnable examples for bitmap references and validity queries.

Tests: `cargo test --workspace --doc --all-features`