### PR TITLE
feat: export `Boolean` arrays through Arrow C data

### DIFF
--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -79,14 +79,12 @@ pub trait Export {
 }
 
 /// A layout that describes its [`ArrowArray`] fields.
-trait ArrowArrayLayout: Sized {
+trait ArrowArrayLayout: Length + Sized {
     /// Buffer pointers exposed by the exported array.
     type Buffers: AsRef<[*const c_void]> + AsMut<[*const c_void]> + Default + 'static;
     /// Child pointers exposed by the exported array.
     type Children: AsRef<[*mut ArrowArray]> + AsMut<[*mut ArrowArray]> + Default + 'static;
 
-    /// Returns the number of items in the array.
-    fn length(&self) -> usize;
     /// Returns the number of null elements, or `-1` when unknown.
     fn null_count(&self) -> i64 {
         0
@@ -121,7 +119,7 @@ trait ArrowArrayLayout: Sized {
         private.children = private.layout.children();
 
         // Convert platform-sized layout metadata into the Arrow C ABI fields.
-        let length = i64::try_from(private.layout.length()).expect("array length exceeds i64");
+        let length = i64::try_from(private.layout.len()).expect("array length exceeds i64");
         let null_count = private.layout.null_count();
         let offset = i64::try_from(private.layout.offset()).expect("array offset exceeds i64");
         let n_buffers =
@@ -169,10 +167,6 @@ where
     type Buffers = [*const c_void; 2];
     type Children = [*mut ArrowArray; 0];
 
-    fn length(&self) -> usize {
-        self.buffer_ref().borrow().len()
-    }
-
     fn buffers(&self) -> Self::Buffers {
         let values: &[T] = self.buffer_ref().borrow();
         [ptr::null(), values.as_ptr().cast()]
@@ -182,10 +176,6 @@ where
 impl<Storage: Buffer> ArrowArrayLayout for Boolean<NonNullable, Storage> {
     type Buffers = [*const c_void; 2];
     type Children = [*mut ArrowArray; 0];
-
-    fn length(&self) -> usize {
-        self.len()
-    }
 
     fn offset(&self) -> usize {
         self.buffer_ref().bit_offset()

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -110,6 +110,57 @@ trait ArrowArrayLayout: Sized {
     fn dictionary(_data: &mut Self::Data) -> *mut ArrowArray {
         ptr::null_mut()
     }
+
+    /// Builds an [`ArrowArray`] and [`ArrowSchema`] from this layout.
+    fn export<T: ArrowType>(self) -> (ArrowArray, ArrowSchema) {
+        // Pin the retained data before asking the layout for pointers into it.
+        let mut private = Box::new(ArrayData::<Self> {
+            data: self.into_data(),
+            buffers: Self::Buffers::default(),
+            children: Self::Children::default(),
+        });
+        private.buffers = Self::buffers(&private.data);
+        private.children = Self::children(&mut private.data);
+
+        // Convert platform-sized layout metadata into the Arrow C ABI fields.
+        let length = i64::try_from(Self::length(&private.data)).expect("array length exceeds i64");
+        let null_count = Self::null_count(&private.data);
+        let offset = i64::try_from(Self::offset(&private.data)).expect("array offset exceeds i64");
+        let n_buffers =
+            i64::try_from(private.buffers.as_ref().len()).expect("buffer count exceeds i64");
+        let n_children =
+            i64::try_from(private.children.as_ref().len()).expect("child count exceeds i64");
+        let dictionary = Self::dictionary(&mut private.data);
+
+        // Keep the layout data and pointer collections alive until release.
+        let buffers = private.buffers.as_mut();
+        let buffers = if buffers.is_empty() {
+            ptr::null_mut()
+        } else {
+            buffers.as_mut_ptr()
+        };
+        let children = private.children.as_mut();
+        let children = if children.is_empty() {
+            ptr::null_mut()
+        } else {
+            children.as_mut_ptr()
+        };
+        let private_data = Box::into_raw(private).cast();
+        let array = ArrowArray {
+            length,
+            null_count,
+            offset,
+            n_buffers,
+            n_children,
+            buffers,
+            children,
+            dictionary,
+            release: Some(release_array::<ArrayData<Self>>),
+            private_data,
+        };
+
+        (array, ArrowSchema::flat::<T>())
+    }
 }
 
 impl<T, Storage> ArrowArrayLayout for FixedSizePrimitive<T, NonNullable, Storage>
@@ -180,62 +231,8 @@ where
     T::Memory<Storage>: ArrowArrayLayout,
 {
     fn export(self) -> (ArrowArray, ArrowSchema) {
-        export_array::<T, _>(self.into_buffer())
+        self.into_buffer().export::<T>()
     }
-}
-
-fn export_array<T, Layout>(layout: Layout) -> (ArrowArray, ArrowSchema)
-where
-    T: ArrowType,
-    Layout: ArrowArrayLayout,
-{
-    // Pin the retained data before asking the layout for pointers into it.
-    let mut private = Box::new(ArrayData::<Layout> {
-        data: layout.into_data(),
-        buffers: Layout::Buffers::default(),
-        children: Layout::Children::default(),
-    });
-    private.buffers = Layout::buffers(&private.data);
-    private.children = Layout::children(&mut private.data);
-
-    // Convert platform-sized layout metadata into the Arrow C ABI fields.
-    let length = i64::try_from(Layout::length(&private.data)).expect("array length exceeds i64");
-    let null_count = Layout::null_count(&private.data);
-    let offset = i64::try_from(Layout::offset(&private.data)).expect("array offset exceeds i64");
-    let n_buffers =
-        i64::try_from(private.buffers.as_ref().len()).expect("buffer count exceeds i64");
-    let n_children =
-        i64::try_from(private.children.as_ref().len()).expect("child count exceeds i64");
-    let dictionary = Layout::dictionary(&mut private.data);
-
-    // Keep the layout data and pointer collections alive until release.
-    let buffers = private.buffers.as_mut();
-    let buffers = if buffers.is_empty() {
-        ptr::null_mut()
-    } else {
-        buffers.as_mut_ptr()
-    };
-    let children = private.children.as_mut();
-    let children = if children.is_empty() {
-        ptr::null_mut()
-    } else {
-        children.as_mut_ptr()
-    };
-    let private_data = Box::into_raw(private).cast();
-    let array = ArrowArray {
-        length,
-        null_count,
-        offset,
-        n_buffers,
-        n_children,
-        buffers,
-        children,
-        dictionary,
-        release: Some(release_array::<ArrayData<Layout>>),
-        private_data,
-    };
-
-    (array, ArrowSchema::flat::<T>())
 }
 
 impl ArrowSchema {

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -125,7 +125,7 @@ where
 
         // Primitive format strings and the empty name are static, so the
         // schema release callback only needs to mark the schema as released.
-        (array, flat_schema(T::FORMAT))
+        (array, ArrowSchema::flat(T::FORMAT))
     }
 }
 
@@ -172,21 +172,23 @@ where
             private_data,
         };
 
-        (array, flat_schema(c"b"))
+        (array, ArrowSchema::flat(c"b"))
     }
 }
 
-fn flat_schema(format: &'static CStr) -> ArrowSchema {
-    ArrowSchema {
-        format: format.as_ptr(),
-        name: c"".as_ptr(),
-        metadata: ptr::null(),
-        flags: 0,
-        n_children: 0,
-        children: ptr::null_mut(),
-        dictionary: ptr::null_mut(),
-        release: Some(release_schema),
-        private_data: ptr::null_mut(),
+impl ArrowSchema {
+    fn flat(format: &'static CStr) -> Self {
+        Self {
+            format: format.as_ptr(),
+            name: c"".as_ptr(),
+            metadata: ptr::null(),
+            flags: 0,
+            n_children: 0,
+            children: ptr::null_mut(),
+            dictionary: ptr::null_mut(),
+            release: Some(release_schema),
+            private_data: ptr::null_mut(),
+        }
     }
 }
 

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -14,59 +14,77 @@ use narrow::{
     bitmap::Bitmap,
     buffer::Buffer,
     fixed_size::FixedSize,
-    layout::{boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
+    layout::{ArrayItem, boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
     nullability::NonNullable,
 };
 
 use crate::{ArrowArray, ArrowSchema};
 
-/// A [`FixedSize`] primitive with an [Arrow C Data format string].
+/// A type with an [Arrow C Data format string].
 ///
 /// [Arrow C Data format string]: https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
-pub trait ArrowPrimitive: FixedSize {
+pub trait ArrowType {
     /// Arrow C Data type format.
     const FORMAT: &'static CStr;
 }
 
-impl ArrowPrimitive for i8 {
+impl ArrowType for bool {
+    const FORMAT: &'static CStr = c"b";
+}
+
+impl ArrowType for i8 {
     const FORMAT: &'static CStr = c"c";
 }
 
-impl ArrowPrimitive for u8 {
+impl ArrowType for u8 {
     const FORMAT: &'static CStr = c"C";
 }
 
-impl ArrowPrimitive for i16 {
+impl ArrowType for i16 {
     const FORMAT: &'static CStr = c"s";
 }
 
-impl ArrowPrimitive for u16 {
+impl ArrowType for u16 {
     const FORMAT: &'static CStr = c"S";
 }
 
-impl ArrowPrimitive for i32 {
+impl ArrowType for i32 {
     const FORMAT: &'static CStr = c"i";
 }
 
-impl ArrowPrimitive for u32 {
+impl ArrowType for u32 {
     const FORMAT: &'static CStr = c"I";
 }
 
-impl ArrowPrimitive for i64 {
+impl ArrowType for i64 {
     const FORMAT: &'static CStr = c"l";
 }
 
-impl ArrowPrimitive for u64 {
+impl ArrowType for u64 {
     const FORMAT: &'static CStr = c"L";
 }
 
-impl ArrowPrimitive for f32 {
+impl ArrowType for f32 {
     const FORMAT: &'static CStr = c"f";
 }
 
-impl ArrowPrimitive for f64 {
+impl ArrowType for f64 {
     const FORMAT: &'static CStr = c"g";
 }
+
+/// A [`FixedSize`] primitive supported by the Arrow C Data Interface.
+pub trait ArrowPrimitive: FixedSize + ArrowType {}
+
+impl ArrowPrimitive for i8 {}
+impl ArrowPrimitive for u8 {}
+impl ArrowPrimitive for i16 {}
+impl ArrowPrimitive for u16 {}
+impl ArrowPrimitive for i32 {}
+impl ArrowPrimitive for u32 {}
+impl ArrowPrimitive for i64 {}
+impl ArrowPrimitive for u64 {}
+impl ArrowPrimitive for f32 {}
+impl ArrowPrimitive for f64 {}
 
 /// Export an [`Array`] through the Arrow C Data Interface.
 pub trait Export {
@@ -82,63 +100,56 @@ struct ArrayData<Values> {
     buffers: [*const c_void; 2],
 }
 
-impl<T, Storage> Export for Array<T, Storage>
+/// A flat, non-nullable layout backed by one value buffer.
+trait FlatArrayLayout {
+    /// Item stored in the value buffer.
+    type Value: FixedSize;
+    /// Owned value-buffer storage retained by the export.
+    type Values: Borrow<[Self::Value]> + 'static;
+
+    /// Returns the value storage, logical length, and logical offset.
+    fn into_parts(self) -> (Self::Values, usize, usize);
+}
+
+impl<T, Storage> FlatArrayLayout for FixedSizePrimitive<T, NonNullable, Storage>
 where
     T: ArrowPrimitive,
     Storage: Buffer,
     Storage::For<T>: 'static,
 {
-    fn export(self) -> (ArrowArray, ArrowSchema) {
-        // Remove the type-level wrappers while preserving the original storage.
-        let primitive: FixedSizePrimitive<T, NonNullable, Storage> = self.into_buffer();
-        let values = primitive.into_buffer();
+    type Value = T;
+    type Values = Storage::For<T>;
 
-        // Pin the storage before taking its address. This is required for
-        // inline buffers, whose values would otherwise move with the wrapper.
-        let mut private = Box::new(ArrayData {
-            values,
-            buffers: [ptr::null(); 2],
-        });
-        let values: &[T] = private.values.borrow();
-        let length = i64::try_from(values.len()).expect("array length exceeds i64");
-
-        // Primitive arrays have validity and value buffers. A non-nullable
-        // array may expose a null validity buffer because its null count is zero.
-        private.buffers[1] = values.as_ptr().cast();
-
-        // Transfer ownership of the pinned storage to `private_data`. The
-        // release callback reconstructs this Box with the concrete buffer type.
-        let buffers = private.buffers.as_mut_ptr();
-        let private_data = Box::into_raw(private).cast();
-        let array = ArrowArray {
-            length,
-            null_count: 0,
-            offset: 0,
-            n_buffers: 2,
-            n_children: 0,
-            buffers,
-            children: ptr::null_mut(),
-            dictionary: ptr::null_mut(),
-            release: Some(release_array::<ArrayData<Storage::For<T>>>),
-            private_data,
-        };
-
-        // Primitive format strings and the empty name are static, so the
-        // schema release callback only needs to mark the schema as released.
-        (array, ArrowSchema::flat(T::FORMAT))
+    fn into_parts(self) -> (Self::Values, usize, usize) {
+        let values = self.into_buffer();
+        let length = values.borrow().len();
+        (values, length, 0)
     }
 }
 
-impl<Storage> Export for Array<bool, Storage>
+impl<Storage> FlatArrayLayout for Boolean<NonNullable, Storage>
 where
     Storage: Buffer,
     Storage::For<u8>: 'static,
 {
+    type Value = u8;
+    type Values = Storage::For<u8>;
+
+    fn into_parts(self) -> (Self::Values, usize, usize) {
+        let bitmap: Bitmap<Storage> = self.into_buffer();
+        bitmap.into_parts()
+    }
+}
+
+impl<T, Storage> Export for Array<T, Storage>
+where
+    T: ArrayItem + ArrowType,
+    Storage: Buffer,
+    T::Memory<Storage>: FlatArrayLayout,
+{
     fn export(self) -> (ArrowArray, ArrowSchema) {
-        // Remove the Boolean and bitmap wrappers without copying their storage.
-        let boolean: Boolean<NonNullable, Storage> = self.into_buffer();
-        let bitmap: Bitmap<Storage> = boolean.into_buffer();
-        let (values, bits, offset) = bitmap.into_parts();
+        // Remove the layout wrappers without copying their storage.
+        let (values, length, offset) = self.into_buffer().into_parts();
 
         // Pin the storage before exposing its address so inline buffers remain
         // at a stable location for the lifetime of the export.
@@ -146,16 +157,14 @@ where
             values,
             buffers: [ptr::null(); 2],
         });
-        let values: &[u8] = private.values.borrow();
-        let length = i64::try_from(bits).expect("array length exceeds i64");
+        let length = i64::try_from(length).expect("array length exceeds i64");
         let offset = i64::try_from(offset).expect("array offset exceeds i64");
 
-        // Boolean arrays have validity and value bitmaps. The validity buffer
-        // is null for this non-nullable array; the bitmap offset is expressed
-        // through `ArrowArray::offset`.
-        private.buffers[1] = values.as_ptr().cast();
+        // Flat arrays have validity and value buffers. A non-nullable array may
+        // expose a null validity buffer because its null count is zero.
+        private.buffers[1] = private.values.borrow().as_ptr().cast();
 
-        // Keep the bitmap storage and its buffer pointer array alive until the
+        // Keep the value storage and its buffer pointer array alive until the
         // consumer invokes the release callback.
         let buffers = private.buffers.as_mut_ptr();
         let private_data = Box::into_raw(private).cast();
@@ -168,18 +177,20 @@ where
             buffers,
             children: ptr::null_mut(),
             dictionary: ptr::null_mut(),
-            release: Some(release_array::<ArrayData<Storage::For<u8>>>),
+            release: Some(
+                release_array::<ArrayData<<T::Memory<Storage> as FlatArrayLayout>::Values>>,
+            ),
             private_data,
         };
 
-        (array, ArrowSchema::flat(c"b"))
+        (array, ArrowSchema::flat::<T>())
     }
 }
 
 impl ArrowSchema {
-    fn flat(format: &'static CStr) -> Self {
+    fn flat<T: ArrowType>() -> Self {
         Self {
-            format: format.as_ptr(),
+            format: T::FORMAT.as_ptr(),
             name: c"".as_ptr(),
             metadata: ptr::null(),
             flags: 0,
@@ -226,20 +237,34 @@ mod tests {
         layout::{boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
     };
 
-    use super::{ArrowPrimitive, Export};
+    use super::{ArrowPrimitive, ArrowType, Export};
 
     #[test]
-    fn primitive_format_strings_match_arrow() {
-        assert_eq!(<i8 as ArrowPrimitive>::FORMAT, c"c");
-        assert_eq!(<u8 as ArrowPrimitive>::FORMAT, c"C");
-        assert_eq!(<i16 as ArrowPrimitive>::FORMAT, c"s");
-        assert_eq!(<u16 as ArrowPrimitive>::FORMAT, c"S");
-        assert_eq!(<i32 as ArrowPrimitive>::FORMAT, c"i");
-        assert_eq!(<u32 as ArrowPrimitive>::FORMAT, c"I");
-        assert_eq!(<i64 as ArrowPrimitive>::FORMAT, c"l");
-        assert_eq!(<u64 as ArrowPrimitive>::FORMAT, c"L");
-        assert_eq!(<f32 as ArrowPrimitive>::FORMAT, c"f");
-        assert_eq!(<f64 as ArrowPrimitive>::FORMAT, c"g");
+    fn type_format_strings_match_arrow() {
+        fn assert_primitive<T: ArrowPrimitive>() {}
+
+        assert_eq!(bool::FORMAT, c"b");
+        assert_eq!(i8::FORMAT, c"c");
+        assert_eq!(u8::FORMAT, c"C");
+        assert_eq!(i16::FORMAT, c"s");
+        assert_eq!(u16::FORMAT, c"S");
+        assert_eq!(i32::FORMAT, c"i");
+        assert_eq!(u32::FORMAT, c"I");
+        assert_eq!(i64::FORMAT, c"l");
+        assert_eq!(u64::FORMAT, c"L");
+        assert_eq!(f32::FORMAT, c"f");
+        assert_eq!(f64::FORMAT, c"g");
+
+        assert_primitive::<i8>();
+        assert_primitive::<u8>();
+        assert_primitive::<i16>();
+        assert_primitive::<u16>();
+        assert_primitive::<i32>();
+        assert_primitive::<u32>();
+        assert_primitive::<i64>();
+        assert_primitive::<u64>();
+        assert_primitive::<f32>();
+        assert_primitive::<f64>();
     }
 
     #[test]

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -89,13 +89,13 @@ trait ArrowArrayLayout: Sized {
 
     /// Converts the layout into its retained data.
     fn into_data(self) -> Self::Data;
-    /// Returns the logical array length.
+    /// Returns the number of items in the array.
     fn length(data: &Self::Data) -> usize;
     /// Returns the number of null elements, or `-1` when unknown.
     fn null_count(_data: &Self::Data) -> i64 {
         0
     }
-    /// Returns the logical element offset.
+    /// Returns the item offset into the buffers.
     fn offset(_data: &Self::Data) -> usize {
         0
     }
@@ -139,9 +139,9 @@ where
 struct BooleanData<Values> {
     /// Storage backing the value bitmap.
     values: Values,
-    /// Number of logical bits in the bitmap.
+    /// Number of array items represented by the bitmap.
     length: usize,
-    /// Logical bit offset into the bitmap.
+    /// Bit offset into the bitmap.
     offset: usize,
 }
 

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -10,8 +10,12 @@ use core::{
 };
 
 use narrow::{
-    array::Array, buffer::Buffer, fixed_size::FixedSize,
-    layout::fixed_size_primitive::FixedSizePrimitive, nullability::NonNullable,
+    array::Array,
+    bitmap::Bitmap,
+    buffer::Buffer,
+    fixed_size::FixedSize,
+    layout::{boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
+    nullability::NonNullable,
 };
 
 use crate::{ArrowArray, ArrowSchema};
@@ -70,9 +74,9 @@ pub trait Export {
     fn export(self) -> (ArrowArray, ArrowSchema);
 }
 
-/// Data retained by `ArrowArray::private_data` for a primitive array export.
-struct PrimitiveArrayData<Values> {
-    /// Values backing the exported data buffer.
+/// Data retained by `ArrowArray::private_data` for an array export.
+struct ArrayData<Values> {
+    /// Storage backing the exported value buffer.
     values: Values,
     /// Arrow C Data buffer pointers for validity and values.
     buffers: [*const c_void; 2],
@@ -91,7 +95,7 @@ where
 
         // Pin the storage before taking its address. This is required for
         // inline buffers, whose values would otherwise move with the wrapper.
-        let mut private = Box::new(PrimitiveArrayData {
+        let mut private = Box::new(ArrayData {
             values,
             buffers: [ptr::null(); 2],
         });
@@ -115,24 +119,74 @@ where
             buffers,
             children: ptr::null_mut(),
             dictionary: ptr::null_mut(),
-            release: Some(release_array::<PrimitiveArrayData<Storage::For<T>>>),
+            release: Some(release_array::<ArrayData<Storage::For<T>>>),
             private_data,
         };
 
         // Primitive format strings and the empty name are static, so the
         // schema release callback only needs to mark the schema as released.
-        let schema = ArrowSchema {
-            format: T::FORMAT.as_ptr(),
-            name: c"".as_ptr(),
-            metadata: ptr::null(),
-            flags: 0,
+        (array, flat_schema(T::FORMAT))
+    }
+}
+
+impl<Storage> Export for Array<bool, Storage>
+where
+    Storage: Buffer,
+    Storage::For<u8>: 'static,
+{
+    fn export(self) -> (ArrowArray, ArrowSchema) {
+        // Remove the Boolean and bitmap wrappers without copying their storage.
+        let boolean: Boolean<NonNullable, Storage> = self.into_buffer();
+        let bitmap: Bitmap<Storage> = boolean.into_buffer();
+        let (values, bits, offset) = bitmap.into_parts();
+
+        // Pin the storage before exposing its address so inline buffers remain
+        // at a stable location for the lifetime of the export.
+        let mut private = Box::new(ArrayData {
+            values,
+            buffers: [ptr::null(); 2],
+        });
+        let values: &[u8] = private.values.borrow();
+        let length = i64::try_from(bits).expect("array length exceeds i64");
+        let offset = i64::try_from(offset).expect("array offset exceeds i64");
+
+        // Boolean arrays have validity and value bitmaps. The validity buffer
+        // is null for this non-nullable array; the bitmap offset is expressed
+        // through `ArrowArray::offset`.
+        private.buffers[1] = values.as_ptr().cast();
+
+        // Keep the bitmap storage and its buffer pointer array alive until the
+        // consumer invokes the release callback.
+        let buffers = private.buffers.as_mut_ptr();
+        let private_data = Box::into_raw(private).cast();
+        let array = ArrowArray {
+            length,
+            null_count: 0,
+            offset,
+            n_buffers: 2,
             n_children: 0,
+            buffers,
             children: ptr::null_mut(),
             dictionary: ptr::null_mut(),
-            release: Some(release_schema),
-            private_data: ptr::null_mut(),
+            release: Some(release_array::<ArrayData<Storage::For<u8>>>),
+            private_data,
         };
-        (array, schema)
+
+        (array, flat_schema(c"b"))
+    }
+}
+
+fn flat_schema(format: &'static CStr) -> ArrowSchema {
+    ArrowSchema {
+        format: format.as_ptr(),
+        name: c"".as_ptr(),
+        metadata: ptr::null(),
+        flags: 0,
+        n_children: 0,
+        children: ptr::null_mut(),
+        dictionary: ptr::null_mut(),
+        release: Some(release_schema),
+        private_data: ptr::null_mut(),
     }
 }
 
@@ -165,8 +219,9 @@ mod tests {
 
     use narrow::{
         array::Array,
+        bitmap::Bitmap,
         buffer::{ArcBuffer, ArrayBuffer},
-        layout::fixed_size_primitive::FixedSizePrimitive,
+        layout::{boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
     };
 
     use super::{ArrowPrimitive, Export};
@@ -240,5 +295,57 @@ mod tests {
             unsafe { slice::from_raw_parts(buffers[1].cast::<i32>(), 3) },
             [1, 2, 3]
         );
+    }
+
+    #[test]
+    fn exports_boolean_bitmap_without_copying_values() {
+        let values = Arc::<[u8]>::from([0b0001_0100]);
+        let weak = Arc::downgrade(&values);
+        let data = values.as_ptr();
+        let bitmap = Bitmap::<ArcBuffer>::try_from_parts(values, 3, 2).expect("valid bitmap");
+        let array: Array<bool, ArcBuffer> = Array::from_buffer(Boolean::from_buffer(bitmap));
+
+        let (array, schema) = array.export();
+
+        assert_eq!(array.length, 3);
+        assert_eq!(array.null_count, 0);
+        assert_eq!(array.offset, 2);
+        assert_eq!(array.n_buffers, 2);
+        assert_eq!(array.n_children, 0);
+        assert!(array.children.is_null());
+        assert!(array.dictionary.is_null());
+        // SAFETY: The exported array owns a two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        assert!(buffers[0].is_null());
+        assert_eq!(buffers[1], data.cast());
+        // SAFETY: The value buffer points to the byte held by the export.
+        assert_eq!(unsafe { *buffers[1].cast::<u8>() }, 0b0001_0100);
+
+        // SAFETY: The exported schema has a live, null-terminated format string.
+        assert_eq!(unsafe { CStr::from_ptr(schema.format) }, c"b");
+        assert_eq!(schema.flags, 0);
+        assert_eq!(schema.n_children, 0);
+        assert!(schema.children.is_null());
+        assert!(schema.dictionary.is_null());
+        assert!(weak.upgrade().is_some());
+
+        drop(array);
+        assert!(weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn pins_inline_boolean_bitmap_for_export() {
+        let bitmap =
+            Bitmap::<ArrayBuffer<1>>::try_from_parts([0b0000_0101], 3, 0).expect("valid bitmap");
+        let array: Array<bool, ArrayBuffer<1>> = Array::from_buffer(Boolean::from_buffer(bitmap));
+
+        let (array, _schema) = array.export();
+
+        // SAFETY: The exported array owns a two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        // SAFETY: The value buffer points to the inline byte pinned in the
+        // export's private allocation.
+        assert_eq!(unsafe { *buffers[1].cast::<u8>() }, 0b0000_0101);
     }
 }

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -72,20 +72,6 @@ impl ArrowType for f64 {
     const FORMAT: &'static CStr = c"g";
 }
 
-/// A [`FixedSize`] primitive supported by the Arrow C Data Interface.
-pub trait ArrowPrimitive: FixedSize + ArrowType {}
-
-impl ArrowPrimitive for i8 {}
-impl ArrowPrimitive for u8 {}
-impl ArrowPrimitive for i16 {}
-impl ArrowPrimitive for u16 {}
-impl ArrowPrimitive for i32 {}
-impl ArrowPrimitive for u32 {}
-impl ArrowPrimitive for i64 {}
-impl ArrowPrimitive for u64 {}
-impl ArrowPrimitive for f32 {}
-impl ArrowPrimitive for f64 {}
-
 /// Export an [`Array`] through the Arrow C Data Interface.
 pub trait Export {
     /// Consumes `self` and returns an [`ArrowArray`] and [`ArrowSchema`].
@@ -113,7 +99,7 @@ trait FlatArrayLayout {
 
 impl<T, Storage> FlatArrayLayout for FixedSizePrimitive<T, NonNullable, Storage>
 where
-    T: ArrowPrimitive,
+    T: FixedSize + ArrowType,
     Storage: Buffer,
     Storage::For<T>: 'static,
 {
@@ -237,12 +223,10 @@ mod tests {
         layout::{boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
     };
 
-    use super::{ArrowPrimitive, ArrowType, Export};
+    use super::{ArrowType, Export};
 
     #[test]
     fn type_format_strings_match_arrow() {
-        fn assert_primitive<T: ArrowPrimitive>() {}
-
         assert_eq!(bool::FORMAT, c"b");
         assert_eq!(i8::FORMAT, c"c");
         assert_eq!(u8::FORMAT, c"C");
@@ -254,17 +238,6 @@ mod tests {
         assert_eq!(u64::FORMAT, c"L");
         assert_eq!(f32::FORMAT, c"f");
         assert_eq!(f64::FORMAT, c"g");
-
-        assert_primitive::<i8>();
-        assert_primitive::<u8>();
-        assert_primitive::<i16>();
-        assert_primitive::<u16>();
-        assert_primitive::<i32>();
-        assert_primitive::<u32>();
-        assert_primitive::<i64>();
-        assert_primitive::<u64>();
-        assert_primitive::<f32>();
-        assert_primitive::<f64>();
     }
 
     #[test]

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -11,7 +11,6 @@ use core::{
 
 use narrow::{
     array::Array,
-    bitmap::Bitmap,
     buffer::{Buffer, BufferRef},
     fixed_size::FixedSize,
     layout::{ArrayItem, boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
@@ -79,58 +78,57 @@ pub trait Export {
     fn export(self) -> (ArrowArray, ArrowSchema);
 }
 
-/// Layout-specific data required to build an [`ArrowArray`].
+/// A layout that describes its [`ArrowArray`] fields.
 trait ArrowArrayLayout: Sized {
-    /// Data retained for the lifetime of the export.
-    type Data: 'static;
     /// Buffer pointers exposed by the exported array.
     type Buffers: AsRef<[*const c_void]> + AsMut<[*const c_void]> + Default + 'static;
     /// Child pointers exposed by the exported array.
     type Children: AsRef<[*mut ArrowArray]> + AsMut<[*mut ArrowArray]> + Default + 'static;
 
-    /// Converts the layout into its retained data.
-    fn into_data(self) -> Self::Data;
     /// Returns the number of items in the array.
-    fn length(data: &Self::Data) -> usize;
+    fn length(&self) -> usize;
     /// Returns the number of null elements, or `-1` when unknown.
-    fn null_count(_data: &Self::Data) -> i64 {
+    fn null_count(&self) -> i64 {
         0
     }
     /// Returns the item offset into the buffers.
-    fn offset(_data: &Self::Data) -> usize {
+    fn offset(&self) -> usize {
         0
     }
     /// Returns the array's buffer pointers.
-    fn buffers(data: &Self::Data) -> Self::Buffers;
+    fn buffers(&self) -> Self::Buffers;
     /// Returns the array's child pointers.
-    fn children(_data: &mut Self::Data) -> Self::Children {
+    fn children(&mut self) -> Self::Children {
         Self::Children::default()
     }
     /// Returns the dictionary array pointer.
-    fn dictionary(_data: &mut Self::Data) -> *mut ArrowArray {
+    fn dictionary(&mut self) -> *mut ArrowArray {
         ptr::null_mut()
     }
 
     /// Builds an [`ArrowArray`] and [`ArrowSchema`] from this layout.
-    fn export<T: ArrowType>(self) -> (ArrowArray, ArrowSchema) {
-        // Pin the retained data before asking the layout for pointers into it.
+    fn export<T: ArrowType>(self) -> (ArrowArray, ArrowSchema)
+    where
+        Self: 'static,
+    {
+        // Pin the layout before asking it for pointers into its storage.
         let mut private = Box::new(ArrayData::<Self> {
-            data: self.into_data(),
+            layout: self,
             buffers: Self::Buffers::default(),
             children: Self::Children::default(),
         });
-        private.buffers = Self::buffers(&private.data);
-        private.children = Self::children(&mut private.data);
+        private.buffers = private.layout.buffers();
+        private.children = private.layout.children();
 
         // Convert platform-sized layout metadata into the Arrow C ABI fields.
-        let length = i64::try_from(Self::length(&private.data)).expect("array length exceeds i64");
-        let null_count = Self::null_count(&private.data);
-        let offset = i64::try_from(Self::offset(&private.data)).expect("array offset exceeds i64");
+        let length = i64::try_from(private.layout.length()).expect("array length exceeds i64");
+        let null_count = private.layout.null_count();
+        let offset = i64::try_from(private.layout.offset()).expect("array offset exceeds i64");
         let n_buffers =
             i64::try_from(private.buffers.as_ref().len()).expect("buffer count exceeds i64");
         let n_children =
             i64::try_from(private.children.as_ref().len()).expect("child count exceeds i64");
-        let dictionary = Self::dictionary(&mut private.data);
+        let dictionary = private.layout.dictionary();
 
         // Keep the layout data and pointer collections alive until release.
         let buffers = private.buffers.as_mut();
@@ -167,57 +165,42 @@ impl<T, Storage> ArrowArrayLayout for FixedSizePrimitive<T, NonNullable, Storage
 where
     T: FixedSize + ArrowType,
     Storage: Buffer,
-    Storage::For<T>: 'static,
 {
-    type Data = Storage::For<T>;
     type Buffers = [*const c_void; 2];
     type Children = [*mut ArrowArray; 0];
 
-    fn into_data(self) -> Self::Data {
-        self.into_buffer()
+    fn length(&self) -> usize {
+        self.buffer_ref().borrow().len()
     }
 
-    fn length(data: &Self::Data) -> usize {
-        data.borrow().len()
-    }
-
-    fn buffers(data: &Self::Data) -> Self::Buffers {
-        let values: &[T] = data.borrow();
+    fn buffers(&self) -> Self::Buffers {
+        let values: &[T] = self.buffer_ref().borrow();
         [ptr::null(), values.as_ptr().cast()]
     }
 }
 
-impl<Storage> ArrowArrayLayout for Boolean<NonNullable, Storage>
-where
-    Storage: Buffer,
-    Bitmap<Storage>: 'static,
-{
-    type Data = Bitmap<Storage>;
+impl<Storage: Buffer> ArrowArrayLayout for Boolean<NonNullable, Storage> {
     type Buffers = [*const c_void; 2];
     type Children = [*mut ArrowArray; 0];
 
-    fn into_data(self) -> Self::Data {
-        self.into_buffer()
+    fn length(&self) -> usize {
+        self.len()
     }
 
-    fn length(data: &Self::Data) -> usize {
-        data.len()
+    fn offset(&self) -> usize {
+        self.buffer_ref().bit_offset()
     }
 
-    fn offset(data: &Self::Data) -> usize {
-        data.bit_offset()
-    }
-
-    fn buffers(data: &Self::Data) -> Self::Buffers {
-        let values: &[u8] = data.buffer_ref().borrow();
+    fn buffers(&self) -> Self::Buffers {
+        let values: &[u8] = self.buffer_ref().buffer_ref().borrow();
         [ptr::null(), values.as_ptr().cast()]
     }
 }
 
 /// Data retained by `ArrowArray::private_data` for an array export.
 struct ArrayData<Layout: ArrowArrayLayout> {
-    /// Layout-specific owned data.
-    data: Layout::Data,
+    /// Layout backing the exported array.
+    layout: Layout,
     /// Arrow C Data buffer pointers.
     buffers: Layout::Buffers,
     /// Arrow C Data child pointers.
@@ -228,7 +211,7 @@ impl<T, Storage> Export for Array<T, Storage>
 where
     T: ArrayItem + ArrowType,
     Storage: Buffer,
-    T::Memory<Storage>: ArrowArrayLayout,
+    T::Memory<Storage>: ArrowArrayLayout + 'static,
 {
     fn export(self) -> (ArrowArray, ArrowSchema) {
         self.into_buffer().export::<T>()

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -12,9 +12,10 @@ use core::{
 use narrow::{
     array::Array,
     bitmap::Bitmap,
-    buffer::Buffer,
+    buffer::{Buffer, BufferRef},
     fixed_size::FixedSize,
     layout::{ArrayItem, boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
+    length::Length,
     nullability::NonNullable,
 };
 
@@ -135,45 +136,29 @@ where
     }
 }
 
-/// Data retained for a Boolean array export.
-struct BooleanData<Values> {
-    /// Storage backing the value bitmap.
-    values: Values,
-    /// Number of array items represented by the bitmap.
-    length: usize,
-    /// Bit offset into the bitmap.
-    offset: usize,
-}
-
 impl<Storage> ArrowArrayLayout for Boolean<NonNullable, Storage>
 where
     Storage: Buffer,
-    Storage::For<u8>: 'static,
+    Bitmap<Storage>: 'static,
 {
-    type Data = BooleanData<Storage::For<u8>>;
+    type Data = Bitmap<Storage>;
     type Buffers = [*const c_void; 2];
     type Children = [*mut ArrowArray; 0];
 
     fn into_data(self) -> Self::Data {
-        let bitmap: Bitmap<Storage> = self.into_buffer();
-        let (values, length, offset) = bitmap.into_parts();
-        BooleanData {
-            values,
-            length,
-            offset,
-        }
+        self.into_buffer()
     }
 
     fn length(data: &Self::Data) -> usize {
-        data.length
+        data.len()
     }
 
     fn offset(data: &Self::Data) -> usize {
-        data.offset
+        data.bit_offset()
     }
 
     fn buffers(data: &Self::Data) -> Self::Buffers {
-        let values: &[u8] = data.values.borrow();
+        let values: &[u8] = data.buffer_ref().borrow();
         [ptr::null(), values.as_ptr().cast()]
     }
 }

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -78,99 +78,179 @@ pub trait Export {
     fn export(self) -> (ArrowArray, ArrowSchema);
 }
 
-/// Data retained by `ArrowArray::private_data` for an array export.
-struct ArrayData<Values> {
-    /// Storage backing the exported value buffer.
-    values: Values,
-    /// Arrow C Data buffer pointers for validity and values.
-    buffers: [*const c_void; 2],
+/// Layout-specific data required to build an [`ArrowArray`].
+trait ArrowArrayLayout: Sized {
+    /// Data retained for the lifetime of the export.
+    type Data: 'static;
+    /// Buffer pointers exposed by the exported array.
+    type Buffers: AsRef<[*const c_void]> + AsMut<[*const c_void]> + Default + 'static;
+    /// Child pointers exposed by the exported array.
+    type Children: AsRef<[*mut ArrowArray]> + AsMut<[*mut ArrowArray]> + Default + 'static;
+
+    /// Converts the layout into its retained data.
+    fn into_data(self) -> Self::Data;
+    /// Returns the logical array length.
+    fn length(data: &Self::Data) -> usize;
+    /// Returns the number of null elements, or `-1` when unknown.
+    fn null_count(_data: &Self::Data) -> i64 {
+        0
+    }
+    /// Returns the logical element offset.
+    fn offset(_data: &Self::Data) -> usize {
+        0
+    }
+    /// Returns the array's buffer pointers.
+    fn buffers(data: &Self::Data) -> Self::Buffers;
+    /// Returns the array's child pointers.
+    fn children(_data: &mut Self::Data) -> Self::Children {
+        Self::Children::default()
+    }
+    /// Returns the dictionary array pointer.
+    fn dictionary(_data: &mut Self::Data) -> *mut ArrowArray {
+        ptr::null_mut()
+    }
 }
 
-/// A flat, non-nullable layout backed by one value buffer.
-trait FlatArrayLayout {
-    /// Item stored in the value buffer.
-    type Value: FixedSize;
-    /// Owned value-buffer storage retained by the export.
-    type Values: Borrow<[Self::Value]> + 'static;
-
-    /// Returns the value storage, logical length, and logical offset.
-    fn into_parts(self) -> (Self::Values, usize, usize);
-}
-
-impl<T, Storage> FlatArrayLayout for FixedSizePrimitive<T, NonNullable, Storage>
+impl<T, Storage> ArrowArrayLayout for FixedSizePrimitive<T, NonNullable, Storage>
 where
     T: FixedSize + ArrowType,
     Storage: Buffer,
     Storage::For<T>: 'static,
 {
-    type Value = T;
-    type Values = Storage::For<T>;
+    type Data = Storage::For<T>;
+    type Buffers = [*const c_void; 2];
+    type Children = [*mut ArrowArray; 0];
 
-    fn into_parts(self) -> (Self::Values, usize, usize) {
-        let values = self.into_buffer();
-        let length = values.borrow().len();
-        (values, length, 0)
+    fn into_data(self) -> Self::Data {
+        self.into_buffer()
+    }
+
+    fn length(data: &Self::Data) -> usize {
+        data.borrow().len()
+    }
+
+    fn buffers(data: &Self::Data) -> Self::Buffers {
+        let values: &[T] = data.borrow();
+        [ptr::null(), values.as_ptr().cast()]
     }
 }
 
-impl<Storage> FlatArrayLayout for Boolean<NonNullable, Storage>
+/// Data retained for a Boolean array export.
+struct BooleanData<Values> {
+    /// Storage backing the value bitmap.
+    values: Values,
+    /// Number of logical bits in the bitmap.
+    length: usize,
+    /// Logical bit offset into the bitmap.
+    offset: usize,
+}
+
+impl<Storage> ArrowArrayLayout for Boolean<NonNullable, Storage>
 where
     Storage: Buffer,
     Storage::For<u8>: 'static,
 {
-    type Value = u8;
-    type Values = Storage::For<u8>;
+    type Data = BooleanData<Storage::For<u8>>;
+    type Buffers = [*const c_void; 2];
+    type Children = [*mut ArrowArray; 0];
 
-    fn into_parts(self) -> (Self::Values, usize, usize) {
+    fn into_data(self) -> Self::Data {
         let bitmap: Bitmap<Storage> = self.into_buffer();
-        bitmap.into_parts()
+        let (values, length, offset) = bitmap.into_parts();
+        BooleanData {
+            values,
+            length,
+            offset,
+        }
     }
+
+    fn length(data: &Self::Data) -> usize {
+        data.length
+    }
+
+    fn offset(data: &Self::Data) -> usize {
+        data.offset
+    }
+
+    fn buffers(data: &Self::Data) -> Self::Buffers {
+        let values: &[u8] = data.values.borrow();
+        [ptr::null(), values.as_ptr().cast()]
+    }
+}
+
+/// Data retained by `ArrowArray::private_data` for an array export.
+struct ArrayData<Layout: ArrowArrayLayout> {
+    /// Layout-specific owned data.
+    data: Layout::Data,
+    /// Arrow C Data buffer pointers.
+    buffers: Layout::Buffers,
+    /// Arrow C Data child pointers.
+    children: Layout::Children,
 }
 
 impl<T, Storage> Export for Array<T, Storage>
 where
     T: ArrayItem + ArrowType,
     Storage: Buffer,
-    T::Memory<Storage>: FlatArrayLayout,
+    T::Memory<Storage>: ArrowArrayLayout,
 {
     fn export(self) -> (ArrowArray, ArrowSchema) {
-        // Remove the layout wrappers without copying their storage.
-        let (values, length, offset) = self.into_buffer().into_parts();
-
-        // Pin the storage before exposing its address so inline buffers remain
-        // at a stable location for the lifetime of the export.
-        let mut private = Box::new(ArrayData {
-            values,
-            buffers: [ptr::null(); 2],
-        });
-        let length = i64::try_from(length).expect("array length exceeds i64");
-        let offset = i64::try_from(offset).expect("array offset exceeds i64");
-
-        // Flat arrays have validity and value buffers. A non-nullable array may
-        // expose a null validity buffer because its null count is zero.
-        private.buffers[1] = private.values.borrow().as_ptr().cast();
-
-        // Keep the value storage and its buffer pointer array alive until the
-        // consumer invokes the release callback.
-        let buffers = private.buffers.as_mut_ptr();
-        let private_data = Box::into_raw(private).cast();
-        let array = ArrowArray {
-            length,
-            null_count: 0,
-            offset,
-            n_buffers: 2,
-            n_children: 0,
-            buffers,
-            children: ptr::null_mut(),
-            dictionary: ptr::null_mut(),
-            release: Some(
-                release_array::<ArrayData<<T::Memory<Storage> as FlatArrayLayout>::Values>>,
-            ),
-            private_data,
-        };
-
-        (array, ArrowSchema::flat::<T>())
+        export_array::<T, _>(self.into_buffer())
     }
+}
+
+fn export_array<T, Layout>(layout: Layout) -> (ArrowArray, ArrowSchema)
+where
+    T: ArrowType,
+    Layout: ArrowArrayLayout,
+{
+    // Pin the retained data before asking the layout for pointers into it.
+    let mut private = Box::new(ArrayData::<Layout> {
+        data: layout.into_data(),
+        buffers: Layout::Buffers::default(),
+        children: Layout::Children::default(),
+    });
+    private.buffers = Layout::buffers(&private.data);
+    private.children = Layout::children(&mut private.data);
+
+    // Convert platform-sized layout metadata into the Arrow C ABI fields.
+    let length = i64::try_from(Layout::length(&private.data)).expect("array length exceeds i64");
+    let null_count = Layout::null_count(&private.data);
+    let offset = i64::try_from(Layout::offset(&private.data)).expect("array offset exceeds i64");
+    let n_buffers =
+        i64::try_from(private.buffers.as_ref().len()).expect("buffer count exceeds i64");
+    let n_children =
+        i64::try_from(private.children.as_ref().len()).expect("child count exceeds i64");
+    let dictionary = Layout::dictionary(&mut private.data);
+
+    // Keep the layout data and pointer collections alive until release.
+    let buffers = private.buffers.as_mut();
+    let buffers = if buffers.is_empty() {
+        ptr::null_mut()
+    } else {
+        buffers.as_mut_ptr()
+    };
+    let children = private.children.as_mut();
+    let children = if children.is_empty() {
+        ptr::null_mut()
+    } else {
+        children.as_mut_ptr()
+    };
+    let private_data = Box::into_raw(private).cast();
+    let array = ArrowArray {
+        length,
+        null_count,
+        offset,
+        n_buffers,
+        n_children,
+        buffers,
+        children,
+        dictionary,
+        release: Some(release_array::<ArrayData<Layout>>),
+        private_data,
+    };
+
+    (array, ArrowSchema::flat::<T>())
 }
 
 impl ArrowSchema {
@@ -197,6 +277,8 @@ unsafe extern "C" fn release_array<PrivateData>(array: *mut ArrowArray) {
     array.release = None;
     array.private_data = ptr::null_mut();
     array.buffers = ptr::null_mut();
+    array.children = ptr::null_mut();
+    array.dictionary = ptr::null_mut();
 
     // SAFETY: `private_data` was created with `Box::into_raw` for this exact
     // `PrivateData` type and is released only once.

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -13,7 +13,7 @@ use core::{
 };
 
 mod export;
-pub use export::{ArrowPrimitive, Export};
+pub use export::{ArrowPrimitive, ArrowType, Export};
 
 /// Dictionary values are ordered.
 pub const ARROW_FLAG_DICTIONARY_ORDERED: i64 = 1;

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -86,11 +86,11 @@ impl Drop for ArrowSchema {
 #[repr(C)]
 #[derive(Debug)]
 pub struct ArrowArray {
-    /// Logical number of elements in the array.
+    /// Number of items in the array.
     length: i64,
     /// Number of null elements, or `-1` when unknown.
     null_count: i64,
-    /// Non-negative logical element offset into the physical buffers.
+    /// Non-negative item offset into the physical buffers.
     offset: i64,
     /// Number of physical buffers, excluding child buffers.
     n_buffers: i64,

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -13,7 +13,7 @@ use core::{
 };
 
 mod export;
-pub use export::{ArrowPrimitive, ArrowType, Export};
+pub use export::{ArrowType, Export};
 
 /// Dictionary values are ordered.
 pub const ARROW_FLAG_DICTIONARY_ORDERED: i64 = 1;


### PR DESCRIPTION
## Summary

- add `ArrowType` format metadata for primitives and Boolean
- describe layout-dependent `ArrowArray` fields through a private export adapter
- build primitive and Boolean exports through one generic ownership and release path