### PR TITLE
docs: explain length design

### DIFF
--- a/src/length.rs
+++ b/src/length.rs
@@ -6,8 +6,6 @@ use alloc::{boxed::Box, collections::VecDeque, rc::Rc, sync::Arc, vec::Vec};
 
 /// The length (or number of units) of an item.
 ///
-/// # Design
-///
 /// `Length` is a small convenience trait for types with a meaningful number of
 /// units. It is also the minimal supertrait of
 /// [`Collection`](crate::collection::Collection), while remaining useful for

--- a/src/length.rs
+++ b/src/length.rs
@@ -6,6 +6,13 @@ use alloc::{boxed::Box, collections::VecDeque, rc::Rc, sync::Arc, vec::Vec};
 
 /// The length (or number of units) of an item.
 ///
+/// # Design
+///
+/// Arrow layouts are assembled from several physical collections that must
+/// agree on their logical length. This small trait lets those collections
+/// participate without requiring the full [`Collection`](crate::collection::Collection)
+/// interface.
+///
 /// # Examples
 ///
 /// ```

--- a/src/length.rs
+++ b/src/length.rs
@@ -8,10 +8,10 @@ use alloc::{boxed::Box, collections::VecDeque, rc::Rc, sync::Arc, vec::Vec};
 ///
 /// # Design
 ///
-/// Arrow layouts are assembled from several physical collections that must
-/// agree on their logical length. This small trait lets those collections
-/// participate without requiring the full [`Collection`](crate::collection::Collection)
-/// interface.
+/// `Length` is a small convenience trait for types with a meaningful number of
+/// units. It is also the minimal supertrait of
+/// [`Collection`](crate::collection::Collection), while remaining useful for
+/// types that do not provide collection access.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Explains why logical length is shared across Arrow physical collections.