### PR TITLE
docs: explain fixed-size layout design

### DIFF
--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -10,8 +10,6 @@ use crate::{
 
 /// A collection of fixed-length lists.
 ///
-/// # Design
-///
 /// Arrow stores a fixed-size list as a flat child array; the width is schema
 /// metadata rather than an offset buffer. Encoding `N` in the Rust type keeps
 /// that schema fact attached to the memory layout:

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -10,6 +10,18 @@ use crate::{
 
 /// A collection of fixed-length lists.
 ///
+/// # Design
+///
+/// Arrow stores a fixed-size list as a flat child array; the width is schema
+/// metadata rather than an offset buffer. Encoding `N` in the Rust type keeps
+/// that schema fact attached to the memory layout:
+///
+/// ```text
+/// [[a, b], [c, d]] -> child [a, b, c, d] + width 2
+/// ```
+///
+/// Outer nullability composes around the flattened child independently.
+///
 /// # Examples
 ///
 /// ```

--- a/src/layout/fixed_size_list.rs
+++ b/src/layout/fixed_size_list.rs
@@ -8,6 +8,18 @@ use crate::{
     nullability::{NonNullable, Nullability},
 };
 
+/// A collection of fixed-length lists.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::{collection::Collection, layout::fixed_size_list::FixedSizeList, nullability::Nullable};
+///
+/// let values = [[1, 2], [3, 4]].into_iter().collect::<FixedSizeList<i32, 2>>();
+/// assert_eq!(values.owned(1), Some([3, 4]));
+/// let values = [Some([1, 2]), None].into_iter().collect::<FixedSizeList<i32, 2, Nullable>>();
+/// assert_eq!(values.owned(1), Some(None));
+/// ```
 pub struct FixedSizeList<
     T: ArrayItem,
     const N: usize,
@@ -24,6 +36,16 @@ impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer>
     FixedSizeList<T, N, Nulls, Storage>
 {
     /// Constructs a [`FixedSizeList`] from its backing collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{collection::Collection, layout::fixed_size_list::FixedSizeList};
+    ///
+    /// let original = [[1, 2]].into_iter().collect::<FixedSizeList<i32, 2>>();
+    /// let restored = FixedSizeList::<i32, 2>::from_buffer(original.into_buffer());
+    /// assert_eq!(restored.owned(0), Some([1, 2]));
+    /// ```
     #[must_use]
     pub fn from_buffer(buffer: Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage>) -> Self {
         Self(buffer)
@@ -32,6 +54,15 @@ impl<T: ArrayItem, const N: usize, Nulls: Nullability, Storage: Buffer>
     /// Returns the backing collection of this [`FixedSizeList`].
     ///
     /// This is the inverse of [`FixedSizeList::from_buffer`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{layout::fixed_size_list::FixedSizeList, length::Length};
+    ///
+    /// let values = [[1, 2]].into_iter().collect::<FixedSizeList<i32, 2>>();
+    /// assert_eq!(values.into_buffer().len(), 1);
+    /// ```
     #[must_use]
     pub fn into_buffer(self) -> Nulls::Collection<Flatten<T::Memory<Storage>, N>, Storage> {
         self.0

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -13,6 +13,12 @@ use crate::{
 ///
 /// <https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout>
 ///
+/// # Design
+///
+/// Fixed-width Arrow values map directly to one contiguous typed buffer.
+/// Nullability wraps that buffer with validity metadata while leaving the
+/// value bytes and scalar type unchanged.
+///
 /// # Examples
 ///
 /// ```

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -12,6 +12,17 @@ use crate::{
 /// A collection of `FixedSize` items.
 ///
 /// <https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout>
+///
+/// # Examples
+///
+/// ```
+/// use narrow::{collection::Collection, layout::fixed_size_primitive::FixedSizePrimitive, nullability::Nullable};
+///
+/// let values = [1, 2].into_iter().collect::<FixedSizePrimitive<i32>>();
+/// assert_eq!(values.owned(1), Some(2));
+/// let values = [Some(1), None].into_iter().collect::<FixedSizePrimitive<i32, Nullable>>();
+/// assert_eq!(values.owned(1), Some(None));
+/// ```
 pub struct FixedSizePrimitive<
     T: FixedSize,
     Nulls: Nullability = NonNullable,
@@ -25,6 +36,15 @@ impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> MemoryLayout
 
 impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> FixedSizePrimitive<T, Nulls, Storage> {
     /// Constructs a [`FixedSizePrimitive`] from its backing collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{collection::Collection, layout::fixed_size_primitive::FixedSizePrimitive};
+    ///
+    /// let values = FixedSizePrimitive::<i32>::from_buffer(vec![1, 2]);
+    /// assert_eq!(values.owned(0), Some(1));
+    /// ```
     #[must_use]
     pub fn from_buffer(buffer: Nulls::Collection<Storage::For<T>, Storage>) -> Self {
         Self(buffer)
@@ -33,6 +53,15 @@ impl<T: FixedSize, Nulls: Nullability, Storage: Buffer> FixedSizePrimitive<T, Nu
     /// Returns the backing collection of this [`FixedSizePrimitive`].
     ///
     /// This is the inverse of [`FixedSizePrimitive::from_buffer`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::layout::fixed_size_primitive::FixedSizePrimitive;
+    ///
+    /// let values = [1, 2].into_iter().collect::<FixedSizePrimitive<i32>>();
+    /// assert_eq!(values.into_buffer(), [1, 2]);
+    /// ```
     #[must_use]
     pub fn into_buffer(self) -> Nulls::Collection<Storage::For<T>, Storage> {
         self.0

--- a/src/layout/fixed_size_primitive.rs
+++ b/src/layout/fixed_size_primitive.rs
@@ -13,8 +13,6 @@ use crate::{
 ///
 /// <https://arrow.apache.org/docs/format/Columnar.html#fixed-size-primitive-layout>
 ///
-/// # Design
-///
 /// Fixed-width Arrow values map directly to one contiguous typed buffer.
 /// Nullability wraps that buffer with validity metadata while leaving the
 /// value bytes and scalar type unchanged.


### PR DESCRIPTION
Explains contiguous primitive buffers and flattened fixed-size lists.