### PR TITLE
docs: explain physical child design

### DIFF
--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -56,11 +56,29 @@ pub trait Collection: Length {
 /// A physical child does not necessarily correspond to an Arrow schema child.
 /// For example, variable-size binary data is a physical child in Narrow but an
 /// Arrow data buffer.
+///
+/// # Examples
+///
+/// ```
+/// use narrow::{collection::ChildRef, offset::Offsets};
+///
+/// let values = [vec![1, 2]].into_iter().collect::<Offsets<Vec<i32>>>();
+/// assert_eq!(values.child_ref(), &[1, 2]);
+/// ```
 pub trait ChildRef {
     /// Physical child collection.
     type Child: Collection;
 
     /// Returns the physical child collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use narrow::{collection::ChildRef, offset::Offsets};
+    ///
+    /// let values = [vec![1, 2]].into_iter().collect::<Offsets<Vec<i32>>>();
+    /// assert_eq!(values.child_ref(), &[1, 2]);
+    /// ```
     fn child_ref(&self) -> &Self::Child;
 }
 

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -57,6 +57,13 @@ pub trait Collection: Length {
 /// For example, variable-size binary data is a physical child in Narrow but an
 /// Arrow data buffer.
 ///
+/// # Design
+///
+/// Nested layouts are wrappers around other physical collections. A shared
+/// child-access trait lets exporters and introspection code recurse through
+/// those wrappers without matching every concrete layout, while the name
+/// deliberately distinguishes physical children from schema children.
+///
 /// # Examples
 ///
 /// ```

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -57,8 +57,6 @@ pub trait Collection: Length {
 /// For example, variable-size binary data is a physical child in Narrow but an
 /// Arrow data buffer.
 ///
-/// # Design
-///
 /// Nested layouts are wrappers around other physical collections. A shared
 /// child-access trait lets exporters and introspection code recurse through
 /// those wrappers without matching every concrete layout, while the name


### PR DESCRIPTION
Explains why physical child access is distinct from Arrow schema children.