### PR TITLE
docs: explain Arrow export design

### DIFF
--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -26,6 +26,12 @@ use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema};
 ///
 /// [Arrow C Data format string]: https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
 ///
+/// # Design
+///
+/// Narrow's Rust item type already determines its Arrow layout. These
+/// associated constants carry the corresponding C schema description at the
+/// type level, including the nullable flag added by `Option<T>`.
+///
 /// # Examples
 ///
 /// ```
@@ -92,6 +98,12 @@ impl ArrowType for f64 {
 
 /// Error returned when an [`Array`] cannot be exported.
 ///
+/// # Design
+///
+/// Export rejects representation details it cannot preserve faithfully instead
+/// of silently changing their meaning. The enum is non-exhaustive so further
+/// unsupported Arrow conditions can be reported explicitly.
+///
 /// # Examples
 ///
 /// ```
@@ -127,6 +139,13 @@ impl core::error::Error for ExportError {}
 /// Export an [`Array`] through the Arrow C Data Interface.
 ///
 /// Only arrays with an offset of zero are currently supported.
+///
+/// # Design
+///
+/// Export consumes the array because the returned C handles must retain its
+/// storage after Rust leaves this call. That storage and the exposed pointer
+/// tables live in `private_data` until the foreign consumer invokes the Arrow
+/// release callback.
 ///
 /// # Examples
 ///

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -26,9 +26,9 @@ use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema};
 ///
 /// [Arrow C Data format string]: https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
 ///
-/// Narrow's Rust item type already determines its Arrow layout. These
-/// associated constants carry the corresponding C schema description at the
-/// type level, including the nullable flag added by `Option<T>`.
+/// The Rust item type already determines its Arrow layout. These associated
+/// constants carry the corresponding C schema description at the type level,
+/// including the nullable flag added by `Option<T>`.
 ///
 /// # Examples
 ///

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -26,8 +26,6 @@ use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema};
 ///
 /// [Arrow C Data format string]: https://arrow.apache.org/docs/format/CDataInterface.html#data-type-description-format-strings
 ///
-/// # Design
-///
 /// Narrow's Rust item type already determines its Arrow layout. These
 /// associated constants carry the corresponding C schema description at the
 /// type level, including the nullable flag added by `Option<T>`.
@@ -98,8 +96,6 @@ impl ArrowType for f64 {
 
 /// Error returned when an [`Array`] cannot be exported.
 ///
-/// # Design
-///
 /// Export rejects representation details it cannot preserve faithfully instead
 /// of silently changing their meaning. The enum is non-exhaustive so further
 /// unsupported Arrow conditions can be reported explicitly.
@@ -139,8 +135,6 @@ impl core::error::Error for ExportError {}
 /// Export an [`Array`] through the Arrow C Data Interface.
 ///
 /// Only arrays with an offset of zero are currently supported.
-///
-/// # Design
 ///
 /// Export consumes the array because the returned C handles must retain its
 /// storage after Rust leaves this call. That storage and the exposed pointer


### PR DESCRIPTION
Explains type-directed schemas and ownership-preserving Arrow export.