### PR TITLE
ci: scope build caches to effective jobs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
-        id: rust-toolchain
       - name: Cache cargo-docs-rs
         id: cargo_docs_rs
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,8 +21,6 @@ jobs:
       actions: write
       contents: read
     env:
-      SCCACHE_GHA_ENABLED: true
-      RUSTC_WRAPPER: sccache
       RUSTDOCFLAGS: -Dwarnings
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -38,7 +36,6 @@ jobs:
             ~/.cargo/git/db/
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Cache cargo-docs-rs
         id: cargo_docs_rs
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,14 +28,6 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4fd1da8b0805d2d2e936788875a7d65dbd677dc2 # nightly
         id: rust-toolchain
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - name: Cache cargo-docs-rs
         id: cargo_docs_rs
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,6 @@ on:
     branches:
       - main
 
-env:
-  SCCACHE_GHA_ENABLED: true
-  RUSTC_WRAPPER: sccache
-
 jobs:
   release:
     name: Release
@@ -40,7 +36,6 @@ jobs:
             ~/.cargo/git/db/
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release
@@ -52,6 +47,9 @@ jobs:
     name: PR
     runs-on: ubuntu-slim
     permissions: {}
+    env:
+      SCCACHE_GHA_ENABLED: true
+      RUSTC_WRAPPER: sccache
     concurrency:
       group: release-${{ github.ref }}
       cancel-in-progress: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,6 @@ jobs:
           token: ${{ steps.token.outputs.token }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:
           command: release
@@ -67,14 +59,6 @@ jobs:
           token: ${{ steps.token.outputs.token }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - uses: release-plz/action@2eb1d8bcb770b4c48ccfaad919734b38b51958c9 # v0.5.131
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,23 +17,12 @@ jobs:
   msrv:
     name: Minimum supported Rust version
     runs-on: ubuntu-26.04-arm
-    permissions:
-      actions: write
-      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91
         id: rust-toolchain
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - run: cargo check --workspace --all-targets --no-default-features
       - run: cargo check --workspace --all-targets --all-features
       - run: cargo test --workspace --all-features --lib --bins --examples --tests -- --skip expand
@@ -43,9 +32,6 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-26.04-arm
-    permissions:
-      actions: write
-      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -54,14 +40,6 @@ jobs:
         id: rust-toolchain
         with:
           components: clippy, rustfmt
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - name: Test
         run: cargo test --workspace --all-targets --all-features
       - name: Doctest
@@ -85,14 +63,6 @@ jobs:
         id: rust-toolchain
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
           path: ~/.cache/miri
           key: miri-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}
       - run: cargo miri setup
@@ -103,9 +73,6 @@ jobs:
     name: Coverage
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-26.04-arm
-    permissions:
-      actions: write
-      contents: read
     env:
       RUSTFLAGS: "-C instrument-coverage"
       RUSTDOCFLAGS: "-C instrument-coverage"
@@ -117,14 +84,6 @@ jobs:
         id: rust-toolchain
         with:
           components: llvm-tools-preview
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-
       - run: cargo test --workspace --all-targets --all-features
         env:
           LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91
-        id: rust-toolchain
       - run: cargo check --workspace --all-targets --no-default-features
       - run: cargo check --workspace --all-targets --all-features
       - run: cargo test --workspace --all-features --lib --bins --examples --tests -- --skip expand
@@ -37,7 +36,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        id: rust-toolchain
         with:
           components: clippy, rustfmt
       - name: Test
@@ -73,7 +71,6 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        id: rust-toolchain
         with:
           components: llvm-tools-preview
       - run: cargo test --workspace --all-targets --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,6 @@ jobs:
     permissions:
       actions: write
       contents: read
-    env:
-      SCCACHE_GHA_ENABLED: true
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -37,7 +34,6 @@ jobs:
             ~/.cargo/git/db/
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - run: cargo check --workspace --all-targets --no-default-features
       - run: cargo check --workspace --all-targets --all-features
       - run: cargo test --workspace --all-features --lib --bins --examples --tests -- --skip expand
@@ -50,9 +46,6 @@ jobs:
     permissions:
       actions: write
       contents: read
-    env:
-      SCCACHE_GHA_ENABLED: true
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -69,7 +62,6 @@ jobs:
             ~/.cargo/git/db/
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - name: Test
         run: cargo test --workspace --all-targets --all-features
       - name: Doctest
@@ -115,8 +107,6 @@ jobs:
       actions: write
       contents: read
     env:
-      SCCACHE_GHA_ENABLED: true
-      RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C instrument-coverage"
       RUSTDOCFLAGS: "-C instrument-coverage"
     steps:
@@ -135,7 +125,6 @@ jobs:
             ~/.cargo/git/db/
           key: cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: cargo-
-      - uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
       - run: cargo test --workspace --all-targets --all-features
         env:
           LLVM_PROFILE_FILE: "narrow-%p-%m.profraw"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,19 +52,11 @@ jobs:
   miri:
     name: Miri
     runs-on: ubuntu-26.04-arm
-    permissions:
-      actions: write
-      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@49a8ff4eadd9ad85042f0e2f761eaab3888d767a # miri
-        id: rust-toolchain
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cache/miri
-          key: miri-${{ runner.os }}-${{ runner.arch }}-${{ steps.rust-toolchain.outputs.cachekey }}
       - run: cargo miri setup
       - run: cargo miri test --no-default-features
       - run: cargo miri test --all-features


### PR DESCRIPTION
## Summary

- remove generic Cargo registry and git caches from all workflows
- remove sccache from the MSRV, check, coverage, docs, and release jobs
- retain sccache for release PR semver checks
- remove the Miri sysroot cache
- retain the dedicated cargo-docs-rs binary cache
- drop no-longer-needed actions: write permissions from uncached test jobs

## Rationale

The workspace has no external registry or git dependencies, but every job restored the same roughly 23 MB Cargo download cache at a cost of about 1–3 seconds. Regular compiler jobs also have very few cacheable calls, with some cache reads taking longer than compiling the crate.

The targeted caches remain where measurements show a recurring benefit. Release PR semver checks compile crate APIs repeatedly, and the docs binary cache avoids installing cargo-docs-rs.

The Miri cache is keyed by the resolved moving Miri toolchain. A correctly consumed cache reduced a repeated run from roughly 99.5 seconds to 82 seconds, but a cold run remained about 98 seconds and stored about 58 MB. In practice, hits are limited mainly to reruns and additional PR pushes before the resolved Miri nightly changes. Pinning a dated nightly just to extend cache lifetime would reduce the value of testing against current Miri and add an update chore, so this removes the cache instead. The final uncached run completed in 97 seconds.

## CI comparison

| Job | Recent median before | This PR | Change |
| --- | ---: | ---: | ---: |
| MSRV | 22 s | 18 s | -4 s |
| Check | 22 s | 17 s | -5 s |
| Rustdoc | 17.5 s | 15 s | -2.5 s |
| Miri (uncached) | 99.5 s | 97 s | -2.5 s |

The pre-change medians use the six most recent comparable runs. Individual hosted-runner timings vary, so the Miri difference should be treated as neutral.

## Validation

- parsed all changed workflow files as YAML
- ran git diff --check
- confirmed sccache only remains in the release PR job
- confirmed generic Cargo and Miri caches are removed
- confirmed only the dedicated cargo-docs-rs cache remains outside sccache
- confirmed the final no-cache CI run passes
