### PR TITLE
feat: export FixedSizeList arrays

### DIFF
--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -329,6 +329,7 @@ struct ArrayData<Owner, Layout: ArrowArrayLayout> {
 }
 
 impl<Owner: 'static, Layout: ArrowArrayLayout + 'static> ArrayData<Owner, Layout> {
+    /// Creates pinned private data for an exported array.
     fn new(owner: Owner, buffers: Layout::Buffers, children: Layout::Children) -> Box<Self> {
         let mut data = Box::new(Self {
             buffers,
@@ -340,6 +341,7 @@ impl<Owner: 'static, Layout: ArrowArrayLayout + 'static> ArrayData<Owner, Layout
         data
     }
 
+    /// Updates child pointers after the child arrays are pinned.
     fn set_child_pointers(&mut self) {
         self.child_pointers = self
             .children
@@ -349,6 +351,7 @@ impl<Owner: 'static, Layout: ArrowArrayLayout + 'static> ArrayData<Owner, Layout
             .collect();
     }
 
+    /// Builds an [`ArrowArray`] backed by this private data.
     fn into_array(
         mut self: Box<Self>,
         length: i64,
@@ -399,6 +402,7 @@ where
 }
 
 impl ArrowSchema {
+    /// Builds a childless schema for an [`ArrowType`].
     fn flat<T: ArrowType>() -> Self {
         Self {
             format: T::FORMAT.as_ptr(),
@@ -413,6 +417,7 @@ impl ArrowSchema {
         }
     }
 
+    /// Builds a fixed-size-list schema and retains its child schema.
     fn fixed_size_list<const N: usize>(child: Self) -> Self {
         let format = CString::new(format!("+w:{N}")).expect("valid fixed-size list format");
         let mut private = Box::new(FixedSizeListSchemaData {
@@ -449,6 +454,7 @@ struct FixedSizeListSchemaData {
     child_pointers: [*mut ArrowSchema; 1],
 }
 
+/// Releases private data retained by an [`ArrowArray`].
 unsafe extern "C" fn release_array<PrivateData>(array: *mut ArrowArray) {
     // SAFETY: The Arrow C Data contract passes the live structure to its
     // producer-provided callback.
@@ -465,12 +471,14 @@ unsafe extern "C" fn release_array<PrivateData>(array: *mut ArrowArray) {
     unsafe { drop(Box::from_raw(private_data.cast::<PrivateData>())) };
 }
 
+/// Marks a schema backed only by static data as released.
 unsafe extern "C" fn release_flat_schema(schema: *mut ArrowSchema) {
     // SAFETY: The Arrow C Data contract passes the live structure to its
     // producer-provided callback.
     unsafe { (*schema).release = None };
 }
 
+/// Releases private data retained by an [`ArrowSchema`].
 unsafe extern "C" fn release_schema<PrivateData>(schema: *mut ArrowSchema) {
     // SAFETY: The Arrow C Data contract passes the live structure to its
     // producer-provided callback.

--- a/narrow-ffi/src/export.rs
+++ b/narrow-ffi/src/export.rs
@@ -2,7 +2,7 @@
 
 extern crate alloc;
 
-use alloc::boxed::Box;
+use alloc::{boxed::Box, ffi::CString, format, vec::Vec};
 use core::{
     borrow::Borrow,
     ffi::{CStr, c_void},
@@ -15,7 +15,10 @@ use narrow::{
     buffer::{Buffer, BufferRef},
     collection::ChildRef,
     fixed_size::FixedSize,
-    layout::{ArrayItem, boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
+    layout::{
+        ArrayItem, boolean::Boolean, fixed_size_list::FixedSizeList,
+        fixed_size_primitive::FixedSizePrimitive,
+    },
     length::Length,
     nullability::{NonNullable, Nullable},
 };
@@ -121,8 +124,11 @@ pub trait Export {
 trait ArrowArrayLayout: Length + Sized {
     /// Buffer pointers exposed by the exported array.
     type Buffers: AsRef<[*const c_void]> + AsMut<[*const c_void]> + Default + 'static;
-    /// Child pointers exposed by the exported array.
-    type Children: AsRef<[*mut ArrowArray]> + AsMut<[*mut ArrowArray]> + Default + 'static;
+    /// Child arrays exposed by the exported array.
+    type Children: AsRef<[ArrowArray]> + AsMut<[ArrowArray]> + Default + 'static;
+
+    /// Builds the Arrow schema for this layout.
+    fn schema() -> ArrowSchema;
 
     /// Returns the number of null elements, or `-1` when unknown.
     fn null_count(&self) -> i64 {
@@ -135,16 +141,34 @@ trait ArrowArrayLayout: Length + Sized {
     /// Returns the array's buffer pointers.
     fn buffers(&self) -> Self::Buffers;
     /// Returns the array's child pointers.
-    fn children(&mut self) -> Self::Children {
-        Self::Children::default()
+    fn children(&self) -> Result<Self::Children, ExportError> {
+        Ok(Self::Children::default())
     }
     /// Returns the dictionary array pointer.
-    fn dictionary(&mut self) -> *mut ArrowArray {
+    fn dictionary(&self) -> *mut ArrowArray {
         ptr::null_mut()
     }
 
+    /// Builds a child [`ArrowArray`] borrowing storage retained by its parent.
+    fn child_array(&self) -> Result<ArrowArray, ExportError>
+    where
+        Self: 'static,
+    {
+        let offset = self.offset();
+        if offset != 0 {
+            return Err(ExportError::NonZeroOffset { offset });
+        }
+
+        let length = i64::try_from(self.len()).expect("array length exceeds i64");
+        let null_count = self.null_count();
+        let dictionary = self.dictionary();
+        let private = ArrayData::<(), Self>::new((), self.buffers(), self.children()?);
+
+        Ok(private.into_array(length, null_count, dictionary))
+    }
+
     /// Builds an [`ArrowArray`] and [`ArrowSchema`] from this layout.
-    fn export<T: ArrowType>(self) -> Result<(ArrowArray, ArrowSchema), ExportError>
+    fn export(self) -> Result<(ArrowArray, ArrowSchema), ExportError>
     where
         Self: 'static,
     {
@@ -154,51 +178,23 @@ trait ArrowArrayLayout: Length + Sized {
         }
 
         // Pin the layout before asking it for pointers into its storage.
-        let mut private = Box::new(ArrayData::<Self> {
-            layout: self,
+        let mut private = Box::new(ArrayData::<Self, Self> {
             buffers: Self::Buffers::default(),
             children: Self::Children::default(),
+            child_pointers: Vec::new(),
+            owner: self,
         });
-        private.buffers = private.layout.buffers();
-        private.children = private.layout.children();
+        private.buffers = private.owner.buffers();
+        private.children = private.owner.children()?;
+        private.set_child_pointers();
 
         // Convert platform-sized layout metadata into the Arrow C ABI fields.
-        let length = i64::try_from(private.layout.len()).expect("array length exceeds i64");
-        let null_count = private.layout.null_count();
-        let n_buffers =
-            i64::try_from(private.buffers.as_ref().len()).expect("buffer count exceeds i64");
-        let n_children =
-            i64::try_from(private.children.as_ref().len()).expect("child count exceeds i64");
-        let dictionary = private.layout.dictionary();
+        let length = i64::try_from(private.owner.len()).expect("array length exceeds i64");
+        let null_count = private.owner.null_count();
+        let dictionary = private.owner.dictionary();
+        let array = private.into_array(length, null_count, dictionary);
 
-        // Keep the layout data and pointer collections alive until release.
-        let buffers = private.buffers.as_mut();
-        let buffers = if buffers.is_empty() {
-            ptr::null_mut()
-        } else {
-            buffers.as_mut_ptr()
-        };
-        let children = private.children.as_mut();
-        let children = if children.is_empty() {
-            ptr::null_mut()
-        } else {
-            children.as_mut_ptr()
-        };
-        let private_data = Box::into_raw(private).cast();
-        let array = ArrowArray {
-            length,
-            null_count,
-            offset: 0,
-            n_buffers,
-            n_children,
-            buffers,
-            children,
-            dictionary,
-            release: Some(release_array::<ArrayData<Self>>),
-            private_data,
-        };
-
-        Ok((array, ArrowSchema::flat::<T>()))
+        Ok((array, Self::schema()))
     }
 }
 
@@ -208,7 +204,11 @@ where
     Storage: Buffer,
 {
     type Buffers = [*const c_void; 2];
-    type Children = [*mut ArrowArray; 0];
+    type Children = [ArrowArray; 0];
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::flat::<T>()
+    }
 
     fn buffers(&self) -> Self::Buffers {
         let values: &[T] = self.buffer_ref().borrow();
@@ -222,7 +222,11 @@ where
     Storage: Buffer,
 {
     type Buffers = [*const c_void; 2];
-    type Children = [*mut ArrowArray; 0];
+    type Children = [ArrowArray; 0];
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::flat::<Option<T>>()
+    }
 
     fn null_count(&self) -> i64 {
         i64::try_from(ValidityBitmap::null_count(self.buffer_ref()))
@@ -243,7 +247,11 @@ where
 
 impl<Storage: Buffer> ArrowArrayLayout for Boolean<NonNullable, Storage> {
     type Buffers = [*const c_void; 2];
-    type Children = [*mut ArrowArray; 0];
+    type Children = [ArrowArray; 0];
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::flat::<bool>()
+    }
 
     fn offset(&self) -> usize {
         self.buffer_ref().bit_offset()
@@ -257,7 +265,11 @@ impl<Storage: Buffer> ArrowArrayLayout for Boolean<NonNullable, Storage> {
 
 impl<Storage: Buffer> ArrowArrayLayout for Boolean<Nullable, Storage> {
     type Buffers = [*const c_void; 2];
-    type Children = [*mut ArrowArray; 0];
+    type Children = [ArrowArray; 0];
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::flat::<Option<bool>>()
+    }
 
     fn null_count(&self) -> i64 {
         i64::try_from(ValidityBitmap::null_count(self.buffer_ref()))
@@ -282,24 +294,107 @@ impl<Storage: Buffer> ArrowArrayLayout for Boolean<Nullable, Storage> {
     }
 }
 
+impl<T, const N: usize, Storage> ArrowArrayLayout for FixedSizeList<T, N, NonNullable, Storage>
+where
+    T: ArrayItem,
+    Storage: Buffer,
+    T::Memory<Storage>: ArrowArrayLayout + 'static,
+{
+    type Buffers = [*const c_void; 1];
+    type Children = [ArrowArray; 1];
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::fixed_size_list::<N>(<T::Memory<Storage>>::schema())
+    }
+
+    fn buffers(&self) -> Self::Buffers {
+        [ptr::null()]
+    }
+
+    fn children(&self) -> Result<Self::Children, ExportError> {
+        Ok([self.buffer_ref().child_ref().child_array()?])
+    }
+}
+
 /// Data retained by `ArrowArray::private_data` for an array export.
-struct ArrayData<Layout: ArrowArrayLayout> {
-    /// Layout backing the exported array.
-    layout: Layout,
+struct ArrayData<Owner, Layout: ArrowArrayLayout> {
     /// Arrow C Data buffer pointers.
     buffers: Layout::Buffers,
-    /// Arrow C Data child pointers.
+    /// Child arrays owned by the export.
     children: Layout::Children,
+    /// Arrow C Data child pointers.
+    child_pointers: Vec<*mut ArrowArray>,
+    /// Owner retained until the array is released.
+    owner: Owner,
+}
+
+impl<Owner: 'static, Layout: ArrowArrayLayout + 'static> ArrayData<Owner, Layout> {
+    fn new(owner: Owner, buffers: Layout::Buffers, children: Layout::Children) -> Box<Self> {
+        let mut data = Box::new(Self {
+            buffers,
+            children,
+            child_pointers: Vec::new(),
+            owner,
+        });
+        data.set_child_pointers();
+        data
+    }
+
+    fn set_child_pointers(&mut self) {
+        self.child_pointers = self
+            .children
+            .as_mut()
+            .iter_mut()
+            .map(ptr::from_mut)
+            .collect();
+    }
+
+    fn into_array(
+        mut self: Box<Self>,
+        length: i64,
+        null_count: i64,
+        dictionary: *mut ArrowArray,
+    ) -> ArrowArray {
+        let n_buffers =
+            i64::try_from(self.buffers.as_ref().len()).expect("buffer count exceeds i64");
+        let n_children = i64::try_from(self.child_pointers.len()).expect("child count exceeds i64");
+
+        let buffers = self.buffers.as_mut();
+        let buffers = if buffers.is_empty() {
+            ptr::null_mut()
+        } else {
+            buffers.as_mut_ptr()
+        };
+        let children = if self.child_pointers.is_empty() {
+            ptr::null_mut()
+        } else {
+            self.child_pointers.as_mut_ptr()
+        };
+        let private_data = Box::into_raw(self).cast();
+
+        ArrowArray {
+            length,
+            null_count,
+            offset: 0,
+            n_buffers,
+            n_children,
+            buffers,
+            children,
+            dictionary,
+            release: Some(release_array::<Self>),
+            private_data,
+        }
+    }
 }
 
 impl<T, Storage> Export for Array<T, Storage>
 where
-    T: ArrayItem + ArrowType,
+    T: ArrayItem,
     Storage: Buffer,
     T::Memory<Storage>: ArrowArrayLayout + 'static,
 {
     fn export(self) -> Result<(ArrowArray, ArrowSchema), ExportError> {
-        self.into_buffer().export::<T>()
+        self.into_buffer().export()
     }
 }
 
@@ -313,10 +408,45 @@ impl ArrowSchema {
             n_children: 0,
             children: ptr::null_mut(),
             dictionary: ptr::null_mut(),
-            release: Some(release_schema),
+            release: Some(release_flat_schema),
             private_data: ptr::null_mut(),
         }
     }
+
+    fn fixed_size_list<const N: usize>(child: Self) -> Self {
+        let format = CString::new(format!("+w:{N}")).expect("valid fixed-size list format");
+        let mut private = Box::new(FixedSizeListSchemaData {
+            format,
+            children: [child],
+            child_pointers: [ptr::null_mut()],
+        });
+        private.child_pointers[0] = ptr::from_mut(&mut private.children[0]);
+
+        let format = private.format.as_ptr();
+        let children = private.child_pointers.as_mut_ptr();
+        let private_data = Box::into_raw(private).cast();
+        Self {
+            format,
+            name: c"".as_ptr(),
+            metadata: ptr::null(),
+            flags: 0,
+            n_children: 1,
+            children,
+            dictionary: ptr::null_mut(),
+            release: Some(release_schema::<FixedSizeListSchemaData>),
+            private_data,
+        }
+    }
+}
+
+/// Data retained by `ArrowSchema::private_data` for a fixed-size list.
+struct FixedSizeListSchemaData {
+    /// Arrow C Data type format.
+    format: CString,
+    /// Child schemas owned by the export.
+    children: [ArrowSchema; 1],
+    /// Arrow C Data child pointers.
+    child_pointers: [*mut ArrowSchema; 1],
 }
 
 unsafe extern "C" fn release_array<PrivateData>(array: *mut ArrowArray) {
@@ -335,10 +465,25 @@ unsafe extern "C" fn release_array<PrivateData>(array: *mut ArrowArray) {
     unsafe { drop(Box::from_raw(private_data.cast::<PrivateData>())) };
 }
 
-unsafe extern "C" fn release_schema(schema: *mut ArrowSchema) {
+unsafe extern "C" fn release_flat_schema(schema: *mut ArrowSchema) {
     // SAFETY: The Arrow C Data contract passes the live structure to its
     // producer-provided callback.
     unsafe { (*schema).release = None };
+}
+
+unsafe extern "C" fn release_schema<PrivateData>(schema: *mut ArrowSchema) {
+    // SAFETY: The Arrow C Data contract passes the live structure to its
+    // producer-provided callback.
+    let schema = unsafe { &mut *schema };
+    let private_data = schema.private_data;
+    schema.release = None;
+    schema.private_data = ptr::null_mut();
+    schema.children = ptr::null_mut();
+    schema.dictionary = ptr::null_mut();
+
+    // SAFETY: `private_data` was created with `Box::into_raw` for this exact
+    // `PrivateData` type and is released only once.
+    unsafe { drop(Box::from_raw(private_data.cast::<PrivateData>())) };
 }
 
 #[cfg(test)]
@@ -354,7 +499,11 @@ mod tests {
         array::Array,
         bitmap::Bitmap,
         buffer::{ArcBuffer, ArrayBuffer},
-        layout::{boolean::Boolean, fixed_size_primitive::FixedSizePrimitive},
+        collection::flatten::Flatten,
+        layout::{
+            boolean::Boolean, fixed_size_list::FixedSizeList,
+            fixed_size_primitive::FixedSizePrimitive,
+        },
         validity::Validity,
     };
 
@@ -597,6 +746,77 @@ mod tests {
             array.export().expect_err("non-zero validity offset"),
             ExportError::NonZeroOffset { offset: 2 }
         );
+    }
+
+    #[test]
+    fn exports_fixed_size_list_child_without_copying_values() {
+        let values = Arc::<[i32]>::from([1, 2, 3, 4]);
+        let weak = Arc::downgrade(&values);
+        let data = values.as_ptr();
+        let values = FixedSizePrimitive::from_buffer(values);
+        let values = Flatten::try_from_parts(values).expect("valid fixed-size list");
+        let array: Array<[i32; 2], ArcBuffer> =
+            Array::from_buffer(FixedSizeList::from_buffer(values));
+
+        let (array, schema) = array.export().expect("export array");
+
+        assert_eq!(array.length, 2);
+        assert_eq!(array.null_count, 0);
+        assert_eq!(array.offset, 0);
+        assert_eq!(array.n_buffers, 1);
+        assert_eq!(array.n_children, 1);
+        // SAFETY: The exported array owns a one-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 1) };
+        assert!(buffers[0].is_null());
+        // SAFETY: The exported array owns a one-entry child pointer array.
+        let children = unsafe { slice::from_raw_parts(array.children, 1) };
+        // SAFETY: The child pointer refers to an array retained by the parent.
+        let child = unsafe { &*children[0] };
+        assert_eq!(child.length, 4);
+        assert_eq!(child.n_buffers, 2);
+        assert_eq!(child.n_children, 0);
+        // SAFETY: The child owns a two-entry buffer pointer array.
+        let child_buffers = unsafe { slice::from_raw_parts(child.buffers, 2) };
+        assert!(child_buffers[0].is_null());
+        assert_eq!(child_buffers[1], data.cast());
+        // SAFETY: The value buffer points to four values retained by the parent.
+        assert_eq!(
+            unsafe { slice::from_raw_parts(child_buffers[1].cast::<i32>(), 4) },
+            [1, 2, 3, 4]
+        );
+
+        // SAFETY: The exported schema has a live, null-terminated format string.
+        assert_eq!(unsafe { CStr::from_ptr(schema.format) }, c"+w:2");
+        assert_eq!(schema.flags, 0);
+        assert_eq!(schema.n_children, 1);
+        // SAFETY: The schema owns a one-entry child pointer array.
+        let children = unsafe { slice::from_raw_parts(schema.children, 1) };
+        // SAFETY: The child pointer refers to a schema retained by the parent.
+        let child = unsafe { &*children[0] };
+        // SAFETY: The child schema has a live, null-terminated format string.
+        assert_eq!(unsafe { CStr::from_ptr(child.format) }, c"i");
+        assert_eq!(child.flags, 0);
+        assert_eq!(child.n_children, 0);
+        assert!(weak.upgrade().is_some());
+
+        drop(array);
+        assert!(weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn rejects_non_zero_fixed_size_list_child_offset() {
+        let bitmap = Bitmap::<ArrayBuffer<4>>::try_from_parts([0b0011_1100, 0, 0, 0], 4, 2)
+            .expect("valid bitmap");
+        let validity = Validity::try_from_parts([1, 2, 3, 4], bitmap).expect("valid parts");
+        let values = FixedSizePrimitive::from_buffer(validity);
+        let values = Flatten::try_from_parts(values).expect("valid fixed-size list");
+        let array: Array<[Option<i32>; 2], ArrayBuffer<4>> =
+            Array::from_buffer(FixedSizeList::from_buffer(values));
+
+        let error = array.export().expect_err("non-zero child offset");
+
+        assert_eq!(error, ExportError::NonZeroOffset { offset: 2 });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- export non-nullable `FixedSizeList` arrays through one child array
- build `+w:N` schemas with owned child schemas
- retain child data without copying and reject non-zero child offsets