### PR TITLE
ci: restore ARM runners for release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-26.04-arm
     permissions: {}
     environment:
       name: crates-io
@@ -37,7 +37,7 @@ jobs:
 
   pr:
     name: PR
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-26.04-arm
     permissions: {}
     env:
       SCCACHE_GHA_ENABLED: true


### PR DESCRIPTION
## Summary

- move the `Release` job from `ubuntu-slim` back to `ubuntu-26.04-arm`
- move the release `PR` job from `ubuntu-slim` back to `ubuntu-26.04-arm`

## Rationale

The ARM runners are materially faster for this workflow. Across successful runs since the ARM runner was introduced:

- ARM: 16 runs, 48.5 s median, 49.2 s mean
- slim: 61 runs, 87 s median, 89.5 s mean

This restores the runner configuration used before #520 while leaving the release steps unchanged.

## Validation

- parsed the workflow as YAML
- ran `git diff --check`
- confirmed the diff changes only the two release runner labels
