### PR TITLE
feat: export nullable FixedSizeList arrays

### DIFF
--- a/narrow-ffi/src/export/fixed_size_list.rs
+++ b/narrow-ffi/src/export/fixed_size_list.rs
@@ -3,16 +3,17 @@
 extern crate alloc;
 
 use alloc::{boxed::Box, ffi::CString, format};
-use core::{ffi::c_void, ptr};
+use core::{borrow::Borrow, ffi::c_void, ptr};
 
 use narrow::{
+    bitmap::{BitmapRef, ValidityBitmap},
     buffer::{Buffer, BufferRef},
     collection::ChildRef,
     layout::{ArrayItem, fixed_size_list::FixedSizeList},
-    nullability::NonNullable,
+    nullability::{NonNullable, Nullability, Nullable},
 };
 
-use crate::{ArrowArray, ArrowSchema};
+use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema};
 
 use super::{ArrowArrayLayout, ExportError, release_schema};
 
@@ -26,7 +27,7 @@ where
     type Children = [ArrowArray; 1];
 
     fn schema() -> ArrowSchema {
-        ArrowSchema::fixed_size_list::<N>(<T::Memory<Storage>>::schema())
+        ArrowSchema::fixed_size_list::<N, NonNullable>(<T::Memory<Storage>>::schema())
     }
 
     fn buffers(&self) -> Self::Buffers {
@@ -38,9 +39,41 @@ where
     }
 }
 
+impl<T, const N: usize, Storage> ArrowArrayLayout for FixedSizeList<T, N, Nullable, Storage>
+where
+    T: ArrayItem,
+    Storage: Buffer,
+    T::Memory<Storage>: ArrowArrayLayout + 'static,
+{
+    type Buffers = [*const c_void; 1];
+    type Children = [ArrowArray; 1];
+
+    fn schema() -> ArrowSchema {
+        ArrowSchema::fixed_size_list::<N, Nullable>(<T::Memory<Storage>>::schema())
+    }
+
+    fn null_count(&self) -> i64 {
+        i64::try_from(ValidityBitmap::null_count(self.buffer_ref()))
+            .expect("null count exceeds i64")
+    }
+
+    fn offset(&self) -> usize {
+        self.buffer_ref().bitmap_ref().bit_offset()
+    }
+
+    fn buffers(&self) -> Self::Buffers {
+        let validity_values: &[u8] = self.buffer_ref().bitmap_ref().buffer_ref().borrow();
+        [validity_values.as_ptr().cast()]
+    }
+
+    fn children(&self) -> Result<Self::Children, ExportError> {
+        Ok([self.buffer_ref().child_ref().child_ref().child_array()?])
+    }
+}
+
 impl ArrowSchema {
     /// Builds a fixed-size-list schema and retains its child schema.
-    fn fixed_size_list<const N: usize>(child: Self) -> Self {
+    fn fixed_size_list<const N: usize, Nulls: Nullability>(child: Self) -> Self {
         let format_string = CString::new(format!("+w:{N}")).expect("valid fixed-size list format");
         let mut private = Box::new(FixedSizeListSchemaData {
             format: format_string,
@@ -56,7 +89,11 @@ impl ArrowSchema {
             format: format_pointer,
             name: c"".as_ptr(),
             metadata: ptr::null(),
-            flags: 0,
+            flags: if Nulls::NULLABLE {
+                ARROW_FLAG_NULLABLE
+            } else {
+                0
+            },
             n_children: 1,
             children,
             dictionary: ptr::null_mut(),
@@ -91,6 +128,8 @@ mod tests {
         layout::{fixed_size_list::FixedSizeList, fixed_size_primitive::FixedSizePrimitive},
         validity::Validity,
     };
+
+    use crate::ARROW_FLAG_NULLABLE;
 
     use super::super::{Export, ExportError};
 
@@ -148,6 +187,73 @@ mod tests {
         drop(array);
         assert!(weak.upgrade().is_none());
         drop(schema);
+    }
+
+    #[test]
+    fn exports_nullable_fixed_size_list_without_copying_buffers() {
+        let value_storage = Arc::<[i32]>::from([1, 2, 3, 4]);
+        let validity_storage = Arc::<[u8]>::from([0b0000_0001]);
+        let values_weak = Arc::downgrade(&value_storage);
+        let validity_weak = Arc::downgrade(&validity_storage);
+        let values_data = value_storage.as_ptr();
+        let validity_data = validity_storage.as_ptr();
+        let values_layout = FixedSizePrimitive::from_buffer(value_storage);
+        let flattened = Flatten::try_from_parts(values_layout).expect("valid fixed-size list");
+        let bitmap =
+            Bitmap::<ArcBuffer>::try_from_parts(validity_storage, 2, 0).expect("valid bitmap");
+        let validity = Validity::try_from_parts(flattened, bitmap).expect("valid parts");
+        let narrow_array: Array<Option<[i32; 2]>, ArcBuffer> =
+            Array::from_buffer(FixedSizeList::from_buffer(validity));
+
+        let (array, schema) = narrow_array.export().expect("export array");
+
+        assert_eq!(array.length, 2);
+        assert_eq!(array.null_count, 1);
+        assert_eq!(array.offset, 0);
+        assert_eq!(array.n_buffers, 1);
+        assert_eq!(array.n_children, 1);
+        // SAFETY: The exported array owns a one-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 1) };
+        assert_eq!(buffers[0], validity_data.cast());
+        // SAFETY: The exported array owns a one-entry child pointer array.
+        let array_children = unsafe { slice::from_raw_parts(array.children, 1) };
+        // SAFETY: The child pointer refers to an array retained by the parent.
+        let child_array = unsafe { &*array_children[0] };
+        assert_eq!(child_array.length, 4);
+        // SAFETY: The child owns a two-entry buffer pointer array.
+        let child_buffers = unsafe { slice::from_raw_parts(child_array.buffers, 2) };
+        assert_eq!(child_buffers[1], values_data.cast());
+
+        // SAFETY: The exported schema has a live, null-terminated format string.
+        assert_eq!(unsafe { CStr::from_ptr(schema.format) }, c"+w:2");
+        assert_eq!(schema.flags, ARROW_FLAG_NULLABLE);
+        // SAFETY: The schema owns a one-entry child pointer array.
+        let schema_children = unsafe { slice::from_raw_parts(schema.children, 1) };
+        // SAFETY: The child pointer refers to a schema retained by the parent.
+        let child_schema = unsafe { &*schema_children[0] };
+        assert_eq!(child_schema.flags, 0);
+        assert!(values_weak.upgrade().is_some());
+        assert!(validity_weak.upgrade().is_some());
+
+        drop(array);
+        assert!(values_weak.upgrade().is_none());
+        assert!(validity_weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn rejects_non_zero_nullable_fixed_size_list_offset() {
+        let values_layout = FixedSizePrimitive::from_buffer([1, 2, 3, 4]);
+        let flattened = Flatten::try_from_parts(values_layout).expect("valid fixed-size list");
+        let bitmap = Bitmap::<ArrayBuffer<4>>::try_from_parts([0b0000_1100, 0, 0, 0], 2, 2)
+            .expect("valid bitmap");
+        let validity = Validity::try_from_parts(flattened, bitmap).expect("valid parts");
+        let array: Array<Option<[i32; 2]>, ArrayBuffer<4>> =
+            Array::from_buffer(FixedSizeList::from_buffer(validity));
+
+        let error = array.export().expect_err("non-zero offset");
+
+        assert_eq!(error, ExportError::NonZeroOffset { offset: 2 });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- export nullable `FixedSizeList` validity and child buffers without copying
- report parent null counts and nullable schema metadata
- reject non-zero parent validity offsets