### PR TITLE
refactor!: remove obsolete crate features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91
-      - run: cargo check --workspace --all-targets --no-default-features
-      - run: cargo check --workspace --all-targets --all-features
-      - run: cargo test --workspace --all-features --lib --bins --examples --tests -- --skip expand
-      - run: cargo test --workspace --all-features --benches
-      - run: cargo test --workspace --doc --all-features
+      - run: cargo check --workspace --all-targets
+      - run: cargo test --workspace --lib --bins --examples --tests -- --skip expand
+      - run: cargo test --workspace --benches
+      - run: cargo test --workspace --doc
 
   check:
     name: Check
@@ -39,11 +38,11 @@ jobs:
         with:
           components: clippy, rustfmt
       - name: Test
-        run: cargo test --workspace --all-targets --all-features
+        run: cargo test --workspace --all-targets
       - name: Doctest
-        run: cargo test --workspace --doc --all-features
+        run: cargo test --workspace --doc
       - name: Clippy
-        run: cargo clippy --workspace --all-targets --all-features -- -Dwarnings
+        run: cargo clippy --workspace --all-targets -- -Dwarnings
       - name: Rustfmt
         run: cargo fmt --all -- --check
 
@@ -56,8 +55,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@49a8ff4eadd9ad85042f0e2f761eaab3888d767a # miri
       - run: cargo miri setup
-      - run: cargo miri test --no-default-features
-      - run: cargo miri test --all-features
+      - run: cargo miri test
 
   coverage:
     name: Coverage
@@ -77,7 +75,7 @@ jobs:
           tool: cargo-llvm-cov@0.8.7
           fallback: none
       - name: Generate coverage
-        run: cargo llvm-cov --workspace --all-targets --all-features --codecov --output-path codecov.json
+        run: cargo llvm-cov --workspace --all-targets --codecov --output-path codecov.json
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           use_oidc: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@ab40b01f54fe82bdf65693ea090a1e4942c136e7 # 1.91
       - run: cargo check --workspace --all-targets
-      - run: cargo test --workspace --lib --bins --examples --tests -- --skip expand
+      - run: cargo test --workspace --lib --bins --examples --tests
       - run: cargo test --workspace --benches
       - run: cargo test --workspace --doc
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,9 +5,6 @@ version = 4
 [[package]]
 name = "narrow"
 version = "0.16.0"
-dependencies = [
- "narrow-derive",
-]
 
 [[package]]
 name = "narrow-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,18 +28,6 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
-[package.metadata.docs.rs]
-all-features = true
-
-[features]
-default = []
-derive = ["dep:narrow-derive"]
-
-[dependencies]
-narrow-derive = { path = "narrow-derive", version = "0.16.0", optional = true }
-
-[dev-dependencies]
-
 [profile.bench]
 lto = true
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+
 [profile.bench]
 lto = true
 codegen-units = 1

--- a/narrow-derive/Cargo.toml
+++ b/narrow-derive/Cargo.toml
@@ -12,12 +12,5 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
-[features]
-default = []
-
 [lib]
 proc-macro = true
-
-[dependencies]
-
-[dev-dependencies]

--- a/narrow-ffi/Cargo.toml
+++ b/narrow-ffi/Cargo.toml
@@ -12,10 +12,5 @@ license.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
-[features]
-default = []
-
 [dependencies]
 narrow = { path = "..", version = "0.16.0" }
-
-[dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
-#![cfg_attr(not(feature = "derive"), doc = "# Narrow")]
-#![cfg_attr(feature = "derive", doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md")))]
+#![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/README.md"))]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/mbrobbel/narrow/main/narrow.svg",
     html_favicon_url = "https://raw.githubusercontent.com/mbrobbel/narrow/main/narrow.svg"


### PR DESCRIPTION
## Summary

- remove the non-functional `derive` feature and `narrow-derive` dependency from `narrow`
- remove empty default feature declarations from all workspace crates
- make the existing README-based crate documentation unconditional
- collapse CI onto one feature-independent build, test, Miri, and coverage configuration

## Breaking change

`narrow` no longer defines a `derive` Cargo feature. The feature compiled an empty proc-macro crate but did not re-export or enable any API.

The `narrow-derive` and `narrow-ffi` packages remain workspace members. A future derive feature can be introduced when it has a concrete macro re-export; FFI remains a separate integration crate to avoid a cyclic dependency.

## CI impact

The Miri job previously ran the same test suite twice for 33 seconds per feature mode. It now runs once. The redundant MSRV feature-mode check is also removed.

## Validation

- Cargo metadata reports empty feature maps for all three packages and no dependencies for `narrow`
- `cargo check --workspace --all-targets`
- `cargo test --workspace --all-targets` (98 tests)
- `cargo test --workspace --doc` (100 doctests)
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- `cargo fmt --all -- --check`
- `cargo llvm-cov --workspace --all-targets --codecov` (98 tests and report generation)
