### PR TITLE
feat: borrow primitive arrays from Arrow C data

### DIFF
--- a/narrow-ffi/src/import/fixed_size_primitive.rs
+++ b/narrow-ffi/src/import/fixed_size_primitive.rs
@@ -1,0 +1,168 @@
+//! Borrowed import support for [`FixedSizePrimitive`].
+
+use core::{ffi::CStr, mem, slice};
+
+use narrow::{
+    array::Array, buffer::SliceBuffer, fixed_size::FixedSize,
+    layout::fixed_size_primitive::FixedSizePrimitive,
+};
+
+use crate::{ArrowArray, ArrowSchema, ArrowType};
+
+use super::{Import, ImportError};
+
+impl<'array, T> Import<'array> for Array<T, SliceBuffer<'array>>
+where
+    T: FixedSize + ArrowType,
+{
+    unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError> {
+        if array.is_released() {
+            return Err(ImportError::ReleasedArray);
+        }
+        if schema.is_released() {
+            return Err(ImportError::ReleasedSchema);
+        }
+        if schema.format.is_null() {
+            return Err(ImportError::MissingFormat);
+        }
+        // SAFETY: The caller guarantees a valid null-terminated schema format.
+        if unsafe { CStr::from_ptr(schema.format) } != T::FORMAT {
+            return Err(ImportError::UnexpectedFormat);
+        }
+        if schema.flags != 0 {
+            return Err(ImportError::UnexpectedFlags {
+                flags: schema.flags,
+            });
+        }
+
+        let length = usize::try_from(array.length).map_err(|_| ImportError::InvalidLength {
+            length: array.length,
+        })?;
+        if array.offset != 0 {
+            return Err(ImportError::NonZeroOffset {
+                offset: array.offset,
+            });
+        }
+        if array.null_count != 0 {
+            return Err(ImportError::UnexpectedNullCount {
+                null_count: array.null_count,
+            });
+        }
+        if array.n_buffers != 2 {
+            return Err(ImportError::UnexpectedBufferCount {
+                count: array.n_buffers,
+            });
+        }
+        if array.n_children != 0 || schema.n_children != 0 {
+            return Err(ImportError::UnexpectedChildCount {
+                array: array.n_children,
+                schema: schema.n_children,
+            });
+        }
+        if !array.dictionary.is_null() || !schema.dictionary.is_null() {
+            return Err(ImportError::UnexpectedDictionary);
+        }
+        if array.buffers.is_null() {
+            return Err(ImportError::MissingBufferPointers);
+        }
+
+        // SAFETY: The caller guarantees a valid two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        let values = if length == 0 {
+            &[]
+        } else {
+            let values = buffers[1].cast::<T>();
+            if values.is_null() {
+                return Err(ImportError::MissingValuesBuffer);
+            }
+            if !values.is_aligned() {
+                return Err(ImportError::MisalignedValuesBuffer {
+                    alignment: mem::align_of::<T>(),
+                });
+            }
+            // SAFETY: The caller guarantees the value buffer contains `length`
+            // properly aligned values that remain immutable for `'array`.
+            unsafe { slice::from_raw_parts(values, length) }
+        };
+
+        Ok(Array::from_buffer(FixedSizePrimitive::from_buffer(values)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::sync::Arc;
+    use core::borrow::Borrow;
+
+    use narrow::{
+        array::Array,
+        buffer::{ArcBuffer, BufferRef, SliceBuffer},
+        layout::fixed_size_primitive::FixedSizePrimitive,
+    };
+
+    use crate::{
+        export::Export,
+        import::{Import, ImportError},
+    };
+
+    #[test]
+    fn imports_primitive_values_without_copying() {
+        let storage = Arc::<[i32]>::from([1, 2, 3]);
+        let weak = Arc::downgrade(&storage);
+        let data = storage.as_ptr();
+        let source: Array<i32, ArcBuffer> =
+            Array::from_buffer(FixedSizePrimitive::from_buffer(storage));
+        let (array, schema) = source.export().expect("export array");
+
+        {
+            // SAFETY: The exported structures remain live and own a valid i32
+            // buffer for the lifetime of the imported array.
+            let imported: Array<i32, SliceBuffer<'_>> =
+                unsafe { Import::import(&array, &schema) }.expect("import array");
+
+            let imported_values: &[i32] = imported.buffer_ref().buffer_ref().borrow();
+            assert_eq!(imported_values, [1, 2, 3]);
+            assert_eq!(imported_values.as_ptr(), data);
+            assert!(weak.upgrade().is_some());
+        };
+
+        assert!(weak.upgrade().is_some());
+        drop(array);
+        assert!(weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn rejects_mismatched_primitive_format() {
+        let source = [1_i32].into_iter().collect::<Array<i32>>();
+        let (array, mut schema) = source.export().expect("export array");
+        schema.format = c"l".as_ptr();
+
+        // SAFETY: The exported structures and value buffer remain valid; only
+        // the schema format is changed to exercise validation.
+        let error = unsafe {
+            <Array<i32, SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("mismatched format")
+        };
+
+        assert_eq!(error, ImportError::UnexpectedFormat);
+    }
+
+    #[test]
+    fn rejects_non_zero_primitive_offset() {
+        let source = [1_i32].into_iter().collect::<Array<i32>>();
+        let (mut array, schema) = source.export().expect("export array");
+        array.offset = 1;
+
+        // SAFETY: The exported structures and value buffer remain valid; only
+        // the array offset is changed to exercise validation.
+        let error = unsafe {
+            <Array<i32, SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("non-zero offset")
+        };
+
+        assert_eq!(error, ImportError::NonZeroOffset { offset: 1 });
+    }
+}

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -1,0 +1,124 @@
+//! Borrow Arrow C Data Interface arrays as Narrow arrays.
+
+use core::fmt;
+
+use crate::{ArrowArray, ArrowSchema};
+
+/// Borrowed import support for an Arrow C Data array.
+pub trait Import<'array>: Sized {
+    /// Imports an [`ArrowArray`] and [`ArrowSchema`] without copying buffers.
+    ///
+    /// # Errors
+    ///
+    /// Returns an [`ImportError`] when the structures do not describe the
+    /// expected Narrow array representation.
+    ///
+    /// # Safety
+    ///
+    /// The Arrow structures and every referenced buffer must satisfy the Arrow
+    /// C Data Interface contract. Referenced buffers must remain immutable for
+    /// `'array` and contain enough properly aligned elements for the declared
+    /// array length.
+    unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError>;
+}
+
+/// Error returned when Arrow C Data cannot be borrowed as a Narrow array.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ImportError {
+    /// The Arrow array was already released.
+    ReleasedArray,
+    /// The Arrow schema was already released.
+    ReleasedSchema,
+    /// The Arrow schema does not contain a format string.
+    MissingFormat,
+    /// The Arrow format does not match the requested Narrow array type.
+    UnexpectedFormat,
+    /// The Arrow schema has unsupported flags.
+    UnexpectedFlags {
+        /// Schema flags supplied by the producer.
+        flags: i64,
+    },
+    /// The Arrow array length is negative or does not fit in [`usize`].
+    InvalidLength {
+        /// Invalid array length supplied by the producer.
+        length: i64,
+    },
+    /// The Arrow array has an unsupported offset.
+    NonZeroOffset {
+        /// Unsupported offset supplied by the producer.
+        offset: i64,
+    },
+    /// A non-nullable array reports a non-zero null count.
+    UnexpectedNullCount {
+        /// Null count supplied by the producer.
+        null_count: i64,
+    },
+    /// The Arrow array has an unexpected number of buffers.
+    UnexpectedBufferCount {
+        /// Buffer count supplied by the producer.
+        count: i64,
+    },
+    /// The Arrow array or schema has an unexpected number of children.
+    UnexpectedChildCount {
+        /// Array child count supplied by the producer.
+        array: i64,
+        /// Schema child count supplied by the producer.
+        schema: i64,
+    },
+    /// The Arrow array or schema contains an unexpected dictionary.
+    UnexpectedDictionary,
+    /// The Arrow array does not contain its buffer pointer array.
+    MissingBufferPointers,
+    /// A non-empty primitive array does not contain a value buffer.
+    MissingValuesBuffer,
+    /// The primitive value buffer is not aligned for its element type.
+    MisalignedValuesBuffer {
+        /// Required byte alignment of the requested element type.
+        alignment: usize,
+    },
+}
+
+impl fmt::Display for ImportError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::ReleasedArray => write!(f, "Arrow array is already released"),
+            Self::ReleasedSchema => write!(f, "Arrow schema is already released"),
+            Self::MissingFormat => write!(f, "Arrow schema format is missing"),
+            Self::UnexpectedFormat => write!(f, "Arrow schema format does not match"),
+            Self::UnexpectedFlags { flags } => {
+                write!(f, "Arrow schema flags ({flags}) are not supported")
+            }
+            Self::InvalidLength { length } => {
+                write!(f, "Arrow array length ({length}) is invalid")
+            }
+            Self::NonZeroOffset { offset } => {
+                write!(f, "Arrow array offset ({offset}) is not supported")
+            }
+            Self::UnexpectedNullCount { null_count } => {
+                write!(f, "non-nullable Arrow array has null count {null_count}")
+            }
+            Self::UnexpectedBufferCount { count } => {
+                write!(f, "Arrow array buffer count ({count}) does not match")
+            }
+            Self::UnexpectedChildCount { array, schema } => write!(
+                f,
+                "Arrow child counts do not match: array {array}, schema {schema}"
+            ),
+            Self::UnexpectedDictionary => {
+                write!(f, "Arrow dictionary is not supported for this array")
+            }
+            Self::MissingBufferPointers => write!(f, "Arrow buffer pointers are missing"),
+            Self::MissingValuesBuffer => write!(f, "Arrow value buffer is missing"),
+            Self::MisalignedValuesBuffer { alignment } => write!(
+                f,
+                "Arrow value buffer does not have the required alignment ({alignment})"
+            ),
+        }
+    }
+}
+
+impl core::error::Error for ImportError {}
+
+/// Borrowed import support for fixed-size primitive arrays.
+mod fixed_size_primitive;

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -68,6 +68,8 @@ use core::{
 
 mod export;
 pub use export::{ArrowType, Export, ExportError};
+mod import;
+pub use import::{Import, ImportError};
 
 /// Dictionary values are ordered.
 pub const ARROW_FLAG_DICTIONARY_ORDERED: i64 = 1;


### PR DESCRIPTION
## Summary

- borrow non-nullable fixed-size primitive buffers through `SliceBuffer`
- validate Arrow primitive schemas, array fields, and zero offsets
- tie borrowed arrays to the lifetime of the source `ArrowArray`