### PR TITLE
feat: borrow Boolean arrays from Arrow C data

### DIFF
--- a/narrow-ffi/src/import/boolean.rs
+++ b/narrow-ffi/src/import/boolean.rs
@@ -1,20 +1,16 @@
-//! Borrowed import support for [`FixedSizePrimitive`].
+//! Borrowed import support for [`Boolean`].
 
-use core::{ffi::CStr, mem, slice};
+use core::{ffi::CStr, slice};
 
 use narrow::{
-    buffer::SliceBuffer, fixed_size::FixedSize, layout::fixed_size_primitive::FixedSizePrimitive,
-    nullability::NonNullable,
+    bitmap::Bitmap, buffer::SliceBuffer, layout::boolean::Boolean, nullability::NonNullable,
 };
 
 use crate::{ArrowArray, ArrowSchema, ArrowType};
 
 use super::{ArrowArrayImport, ImportError};
 
-impl<'array, T> ArrowArrayImport<'array> for FixedSizePrimitive<T, NonNullable, SliceBuffer<'array>>
-where
-    T: FixedSize + ArrowType,
-{
+impl<'array> ArrowArrayImport<'array> for Boolean<NonNullable, SliceBuffer<'array>> {
     unsafe fn import_layout(
         array: &'array ArrowArray,
         schema: &ArrowSchema,
@@ -29,7 +25,7 @@ where
             return Err(ImportError::MissingFormat);
         }
         // SAFETY: The caller guarantees a valid null-terminated schema format.
-        if unsafe { CStr::from_ptr(schema.format) } != T::FORMAT {
+        if unsafe { CStr::from_ptr(schema.format) } != bool::FORMAT {
             return Err(ImportError::UnexpectedFormat);
         }
         if schema.flags != 0 {
@@ -71,24 +67,22 @@ where
 
         // SAFETY: The caller guarantees a valid two-entry buffer pointer array.
         let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
-        let values = if length == 0 {
+        let byte_length = length.div_ceil(8);
+        let values = if byte_length == 0 {
             &[]
         } else {
-            let values = buffers[1].cast::<T>();
+            let values = buffers[1].cast::<u8>();
             if values.is_null() {
                 return Err(ImportError::MissingValuesBuffer);
             }
-            if !values.is_aligned() {
-                return Err(ImportError::MisalignedValuesBuffer {
-                    alignment: mem::align_of::<T>(),
-                });
-            }
-            // SAFETY: The caller guarantees the value buffer contains `length`
-            // properly aligned values that remain immutable for `'array`.
-            unsafe { slice::from_raw_parts(values, length) }
+            // SAFETY: The caller guarantees the value buffer contains
+            // `byte_length` bytes that remain immutable for `'array`.
+            unsafe { slice::from_raw_parts(values, byte_length) }
         };
+        let bitmap = Bitmap::try_from_parts(values, length, 0)
+            .expect("imported Boolean buffer contains the declared number of bits");
 
-        Ok(Self::from_buffer(values))
+        Ok(Self::from_buffer(bitmap))
     }
 }
 
@@ -101,33 +95,36 @@ mod tests {
 
     use narrow::{
         array::Array,
+        bitmap::Bitmap,
         buffer::{ArcBuffer, BufferRef, SliceBuffer},
-        layout::fixed_size_primitive::FixedSizePrimitive,
+        collection::Collection,
+        layout::boolean::Boolean,
     };
 
-    use crate::{
-        export::Export,
-        import::{Import, ImportError},
-    };
+    use crate::{export::Export, import::Import};
 
     #[test]
-    fn imports_primitive_values_without_copying() {
-        let storage = Arc::<[i32]>::from([1, 2, 3]);
+    fn imports_boolean_values_without_copying() {
+        let storage = Arc::<[u8]>::from([0b0000_0101]);
         let weak = Arc::downgrade(&storage);
         let data = storage.as_ptr();
-        let source: Array<i32, ArcBuffer> =
-            Array::from_buffer(FixedSizePrimitive::from_buffer(storage));
+        let bitmap = Bitmap::<ArcBuffer>::try_from_parts(storage, 3, 0).expect("valid bitmap");
+        let source: Array<bool, ArcBuffer> = Array::from_buffer(Boolean::from_buffer(bitmap));
         let (array, schema) = source.export().expect("export array");
 
         {
-            // SAFETY: The exported structures remain live and own a valid i32
-            // buffer for the lifetime of the imported array.
-            let imported: Array<i32, SliceBuffer<'_>> =
+            // SAFETY: The exported structures remain live and own a valid
+            // Boolean value bitmap for the lifetime of the imported array.
+            let imported: Array<bool, SliceBuffer<'_>> =
                 unsafe { Import::import(&array, &schema) }.expect("import array");
 
-            let imported_values: &[i32] = imported.buffer_ref().buffer_ref().borrow();
-            assert_eq!(imported_values, [1, 2, 3]);
+            let imported_values: &[u8] = imported.buffer_ref().buffer_ref().buffer_ref().borrow();
+            assert_eq!(imported_values, [0b0000_0101]);
             assert_eq!(imported_values.as_ptr(), data);
+            assert_eq!(
+                imported.iter_views().collect::<alloc::vec::Vec<_>>(),
+                [true, false, true,]
+            );
             assert!(weak.upgrade().is_some());
         };
 
@@ -135,37 +132,5 @@ mod tests {
         drop(array);
         assert!(weak.upgrade().is_none());
         drop(schema);
-    }
-
-    #[test]
-    fn rejects_mismatched_primitive_format() {
-        let source = [1_i32].into_iter().collect::<Array<i32>>();
-        let (array, mut schema) = source.export().expect("export array");
-        schema.format = c"l".as_ptr();
-
-        // SAFETY: The exported structures and value buffer remain valid; only
-        // the schema format is changed to exercise validation.
-        let error = unsafe {
-            <Array<i32, SliceBuffer<'_>> as Import>::import(&array, &schema)
-                .expect_err("mismatched format")
-        };
-
-        assert_eq!(error, ImportError::UnexpectedFormat);
-    }
-
-    #[test]
-    fn rejects_non_zero_primitive_offset() {
-        let source = [1_i32].into_iter().collect::<Array<i32>>();
-        let (mut array, schema) = source.export().expect("export array");
-        array.offset = 1;
-
-        // SAFETY: The exported structures and value buffer remain valid; only
-        // the array offset is changed to exercise validation.
-        let error = unsafe {
-            <Array<i32, SliceBuffer<'_>> as Import>::import(&array, &schema)
-                .expect_err("non-zero offset")
-        };
-
-        assert_eq!(error, ImportError::NonZeroOffset { offset: 1 });
     }
 }

--- a/narrow-ffi/src/import/boolean.rs
+++ b/narrow-ffi/src/import/boolean.rs
@@ -8,9 +8,9 @@ use narrow::{
 
 use crate::{ArrowArray, ArrowSchema, ArrowType};
 
-use super::{ArrowArrayImport, ImportError};
+use super::{ImportError, ImportLayout};
 
-impl<'array> ArrowArrayImport<'array> for Boolean<NonNullable, SliceBuffer<'array>> {
+impl<'array> ImportLayout<'array> for Boolean<NonNullable, SliceBuffer<'array>> {
     unsafe fn import_layout(
         array: &'array ArrowArray,
         schema: &ArrowSchema,

--- a/narrow-ffi/src/import/fixed_size_primitive.rs
+++ b/narrow-ffi/src/import/fixed_size_primitive.rs
@@ -9,9 +9,9 @@ use narrow::{
 
 use crate::{ArrowArray, ArrowSchema, ArrowType};
 
-use super::{ArrowArrayImport, ImportError};
+use super::{ImportError, ImportLayout};
 
-impl<'array, T> ArrowArrayImport<'array> for FixedSizePrimitive<T, NonNullable, SliceBuffer<'array>>
+impl<'array, T> ImportLayout<'array> for FixedSizePrimitive<T, NonNullable, SliceBuffer<'array>>
 where
     T: FixedSize + ArrowType,
 {

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -2,6 +2,8 @@
 
 use core::fmt;
 
+use narrow::{array::Array, buffer::SliceBuffer, layout::ArrayItem};
+
 use crate::{ArrowArray, ArrowSchema};
 
 /// Borrowed import support for an Arrow C Data array.
@@ -20,6 +22,33 @@ pub trait Import<'array>: Sized {
     /// `'array` and contain enough properly aligned elements for the declared
     /// array length.
     unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError>;
+}
+
+/// A memory layout that can borrow an Arrow C Data array.
+trait ArrowArrayImport<'array>: Sized {
+    /// Imports the memory layout described by an Arrow array and schema.
+    ///
+    /// # Safety
+    ///
+    /// The caller must uphold the requirements of [`Import::import`].
+    unsafe fn import_layout(
+        array: &'array ArrowArray,
+        schema: &ArrowSchema,
+    ) -> Result<Self, ImportError>;
+}
+
+impl<'array, T> Import<'array> for Array<T, SliceBuffer<'array>>
+where
+    T: ArrayItem,
+    T::Memory<SliceBuffer<'array>>: ArrowArrayImport<'array>,
+{
+    unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError> {
+        // SAFETY: The caller upholds the requirements of `Import::import`.
+        let memory = unsafe {
+            <T::Memory<SliceBuffer<'array>> as ArrowArrayImport>::import_layout(array, schema)
+        }?;
+        Ok(Self::from_buffer(memory))
+    }
 }
 
 /// Error returned when Arrow C Data cannot be borrowed as a Narrow array.
@@ -70,7 +99,7 @@ pub enum ImportError {
     UnexpectedDictionary,
     /// The Arrow array does not contain its buffer pointer array.
     MissingBufferPointers,
-    /// A non-empty primitive array does not contain a value buffer.
+    /// A non-empty array does not contain a value buffer.
     MissingValuesBuffer,
     /// The primitive value buffer is not aligned for its element type.
     MisalignedValuesBuffer {
@@ -120,5 +149,7 @@ impl fmt::Display for ImportError {
 
 impl core::error::Error for ImportError {}
 
+/// Borrowed import support for Boolean arrays.
+mod boolean;
 /// Borrowed import support for fixed-size primitive arrays.
 mod fixed_size_primitive;

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -25,7 +25,7 @@ pub trait Import<'array>: Sized {
 }
 
 /// A memory layout that can borrow an Arrow C Data array.
-trait ArrowArrayImport<'array>: Sized {
+trait ImportLayout<'array>: Sized {
     /// Imports the memory layout described by an Arrow array and schema.
     ///
     /// # Safety
@@ -40,12 +40,12 @@ trait ArrowArrayImport<'array>: Sized {
 impl<'array, T> Import<'array> for Array<T, SliceBuffer<'array>>
 where
     T: ArrayItem,
-    T::Memory<SliceBuffer<'array>>: ArrowArrayImport<'array>,
+    T::Memory<SliceBuffer<'array>>: ImportLayout<'array>,
 {
     unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError> {
         // SAFETY: The caller upholds the requirements of `Import::import`.
         let memory = unsafe {
-            <T::Memory<SliceBuffer<'array>> as ArrowArrayImport>::import_layout(array, schema)
+            <T::Memory<SliceBuffer<'array>> as ImportLayout>::import_layout(array, schema)
         }?;
         Ok(Self::from_buffer(memory))
     }


### PR DESCRIPTION
## Summary

- borrow packed Boolean value buffers through `SliceBuffer`
- construct zero-offset `Bitmap` storage without copying
- dispatch borrowed imports through their Narrow memory layouts