### PR TITLE
feat: borrow FixedSizeList arrays from Arrow C data

### DIFF
--- a/narrow-ffi/src/import/boolean.rs
+++ b/narrow-ffi/src/import/boolean.rs
@@ -11,60 +11,18 @@ use crate::{ArrowArray, ArrowSchema, ArrowType};
 use super::{ImportError, ImportLayout};
 
 impl<'array> ImportLayout<'array> for Boolean<NonNullable, SliceBuffer<'array>> {
-    unsafe fn import_layout(
+    const N_BUFFERS: i64 = 2;
+    const N_CHILDREN: i64 = 0;
+
+    fn matches_format(format: &CStr) -> bool {
+        format == bool::FORMAT
+    }
+
+    unsafe fn import_validated(
         array: &'array ArrowArray,
-        schema: &ArrowSchema,
+        _schema: &ArrowSchema,
+        length: usize,
     ) -> Result<Self, ImportError> {
-        if array.is_released() {
-            return Err(ImportError::ReleasedArray);
-        }
-        if schema.is_released() {
-            return Err(ImportError::ReleasedSchema);
-        }
-        if schema.format.is_null() {
-            return Err(ImportError::MissingFormat);
-        }
-        // SAFETY: The caller guarantees a valid null-terminated schema format.
-        if unsafe { CStr::from_ptr(schema.format) } != bool::FORMAT {
-            return Err(ImportError::UnexpectedFormat);
-        }
-        if schema.flags != 0 {
-            return Err(ImportError::UnexpectedFlags {
-                flags: schema.flags,
-            });
-        }
-
-        let length = usize::try_from(array.length).map_err(|_| ImportError::InvalidLength {
-            length: array.length,
-        })?;
-        if array.offset != 0 {
-            return Err(ImportError::NonZeroOffset {
-                offset: array.offset,
-            });
-        }
-        if array.null_count != 0 {
-            return Err(ImportError::UnexpectedNullCount {
-                null_count: array.null_count,
-            });
-        }
-        if array.n_buffers != 2 {
-            return Err(ImportError::UnexpectedBufferCount {
-                count: array.n_buffers,
-            });
-        }
-        if array.n_children != 0 || schema.n_children != 0 {
-            return Err(ImportError::UnexpectedChildCount {
-                array: array.n_children,
-                schema: schema.n_children,
-            });
-        }
-        if !array.dictionary.is_null() || !schema.dictionary.is_null() {
-            return Err(ImportError::UnexpectedDictionary);
-        }
-        if array.buffers.is_null() {
-            return Err(ImportError::MissingBufferPointers);
-        }
-
         // SAFETY: The caller guarantees a valid two-entry buffer pointer array.
         let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
         let byte_length = length.div_ceil(8);

--- a/narrow-ffi/src/import/boolean.rs
+++ b/narrow-ffi/src/import/boolean.rs
@@ -11,8 +11,8 @@ use crate::{ArrowArray, ArrowSchema, ArrowType};
 use super::{ImportError, ImportLayout};
 
 impl<'array> ImportLayout<'array> for Boolean<NonNullable, SliceBuffer<'array>> {
-    const N_BUFFERS: i64 = 2;
-    const N_CHILDREN: i64 = 0;
+    const BUFFERS: i64 = 2;
+    const CHILDREN: i64 = 0;
 
     fn matches_format(format: &CStr) -> bool {
         format == bool::FORMAT

--- a/narrow-ffi/src/import/fixed_size_list.rs
+++ b/narrow-ffi/src/import/fixed_size_list.rs
@@ -31,6 +31,8 @@ where
             return false;
         }
 
+        // Parse the decimal width without allocating, rejecting non-digits
+        // and arithmetic overflow before comparing it with `N`.
         digits.iter().try_fold(0_usize, |size, byte| {
             let digit = (*byte).checked_sub(b'0')?;
             if digit > 9 {

--- a/narrow-ffi/src/import/fixed_size_list.rs
+++ b/narrow-ffi/src/import/fixed_size_list.rs
@@ -20,8 +20,8 @@ where
     T: ArrayItem,
     T::Memory<SliceBuffer<'array>>: ImportLayout<'array>,
 {
-    const N_BUFFERS: i64 = 1;
-    const N_CHILDREN: i64 = 1;
+    const BUFFERS: i64 = 1;
+    const CHILDREN: i64 = 1;
 
     fn matches_format(format: &CStr) -> bool {
         let Some(digits) = format.to_bytes().strip_prefix(b"+w:") else {

--- a/narrow-ffi/src/import/fixed_size_list.rs
+++ b/narrow-ffi/src/import/fixed_size_list.rs
@@ -1,0 +1,190 @@
+//! Borrowed import support for [`FixedSizeList`].
+
+use core::{ffi::CStr, slice};
+
+use narrow::{
+    buffer::SliceBuffer,
+    collection::flatten::Flatten,
+    layout::{ArrayItem, fixed_size_list::FixedSizeList},
+    length::Length,
+    nullability::NonNullable,
+};
+
+use crate::{ArrowArray, ArrowSchema};
+
+use super::{ImportError, ImportLayout};
+
+impl<'array, T, const N: usize> ImportLayout<'array>
+    for FixedSizeList<T, N, NonNullable, SliceBuffer<'array>>
+where
+    T: ArrayItem,
+    T::Memory<SliceBuffer<'array>>: ImportLayout<'array>,
+{
+    const N_BUFFERS: i64 = 1;
+    const N_CHILDREN: i64 = 1;
+
+    fn matches_format(format: &CStr) -> bool {
+        let Some(digits) = format.to_bytes().strip_prefix(b"+w:") else {
+            return false;
+        };
+        if digits.is_empty() {
+            return false;
+        }
+
+        digits.iter().try_fold(0_usize, |size, byte| {
+            let digit = (*byte).checked_sub(b'0')?;
+            if digit > 9 {
+                return None;
+            }
+            size.checked_mul(10)?.checked_add(usize::from(digit))
+        }) == Some(N)
+    }
+
+    unsafe fn import_validated(
+        array: &'array ArrowArray,
+        schema: &ArrowSchema,
+        length: usize,
+    ) -> Result<Self, ImportError> {
+        if N == 0 {
+            return Err(ImportError::UnsupportedFixedSizeListSize { size: N });
+        }
+
+        // SAFETY: Common validation guarantees a one-entry child pointer array.
+        let array_children = unsafe { slice::from_raw_parts(array.children, 1) };
+        let child_array_pointer = array_children[0];
+        if child_array_pointer.is_null() {
+            return Err(ImportError::MissingArrayChildren);
+        }
+        // SAFETY: The caller guarantees that the child array is retained by
+        // the parent for `'array`.
+        let child_array: &'array ArrowArray = unsafe { &*child_array_pointer };
+
+        // SAFETY: Common validation guarantees a one-entry child pointer array.
+        let schema_children = unsafe { slice::from_raw_parts(schema.children, 1) };
+        let child_schema_pointer = schema_children[0];
+        if child_schema_pointer.is_null() {
+            return Err(ImportError::MissingSchemaChildren);
+        }
+        // SAFETY: The caller guarantees that the child schema is valid while
+        // the parent schema is borrowed.
+        let child_schema = unsafe { &*child_schema_pointer };
+
+        // SAFETY: The child structures are covered by the caller's Arrow C
+        // Data guarantees and retained by their respective parents.
+        let child = unsafe {
+            <T::Memory<SliceBuffer<'array>> as ImportLayout>::import_layout(
+                child_array,
+                child_schema,
+            )
+        }?;
+        let child_length = child.len();
+        if length.checked_mul(N) != Some(child_length) {
+            return Err(ImportError::FixedSizeListLengthMismatch {
+                length,
+                child_length,
+                size: N,
+            });
+        }
+        let flattened = Flatten::try_from_parts(child)
+            .expect("validated fixed-size-list child length is a multiple of its width");
+
+        Ok(Self::from_buffer(flattened))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::sync::Arc;
+    use core::borrow::Borrow;
+
+    use narrow::{
+        array::Array,
+        buffer::{ArcBuffer, BufferRef, SliceBuffer},
+        collection::{ChildRef, Collection, flatten::Flatten},
+        layout::{fixed_size_list::FixedSizeList, fixed_size_primitive::FixedSizePrimitive},
+    };
+
+    use crate::{
+        export::Export,
+        import::{Import, ImportError},
+    };
+
+    #[test]
+    fn imports_fixed_size_list_child_without_copying() {
+        let storage = Arc::<[i32]>::from([1, 2, 3, 4]);
+        let weak = Arc::downgrade(&storage);
+        let data = storage.as_ptr();
+        let values = FixedSizePrimitive::from_buffer(storage);
+        let flattened = Flatten::try_from_parts(values).expect("valid fixed-size list");
+        let source: Array<[i32; 2], ArcBuffer> =
+            Array::from_buffer(FixedSizeList::from_buffer(flattened));
+        let (array, schema) = source.export().expect("export array");
+
+        {
+            // SAFETY: The exported structures remain live and retain their
+            // child array and value buffer for the imported array's lifetime.
+            let imported: Array<[i32; 2], SliceBuffer<'_>> =
+                unsafe { Import::import(&array, &schema) }.expect("import array");
+
+            let imported_values: &[i32] = imported
+                .buffer_ref()
+                .buffer_ref()
+                .child_ref()
+                .buffer_ref()
+                .borrow();
+            assert_eq!(imported_values, [1, 2, 3, 4]);
+            assert_eq!(imported_values.as_ptr(), data);
+            assert_eq!(imported.owned(0), Some([1, 2]));
+            assert_eq!(imported.owned(1), Some([3, 4]));
+            assert!(weak.upgrade().is_some());
+        };
+
+        assert!(weak.upgrade().is_some());
+        drop(array);
+        assert!(weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn rejects_mismatched_fixed_size_list_width() {
+        let source = [[1_i32, 2]].into_iter().collect::<Array<[i32; 2]>>();
+        let (array, mut schema) = source.export().expect("export array");
+        schema.format = c"+w:3".as_ptr();
+
+        // SAFETY: The exported structures and buffers remain valid; only the
+        // parent format is changed to exercise width validation.
+        let error = unsafe {
+            <Array<[i32; 2], SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("mismatched fixed-size-list width")
+        };
+
+        assert_eq!(error, ImportError::UnexpectedFormat);
+    }
+
+    #[test]
+    fn rejects_mismatched_fixed_size_list_child_length() {
+        let source = [[1_i32, 2], [3, 4]]
+            .into_iter()
+            .collect::<Array<[i32; 2]>>();
+        let (mut array, schema) = source.export().expect("export array");
+        array.length = 1;
+
+        // SAFETY: The exported structures and buffers remain valid; only the
+        // parent length is changed to exercise child length validation.
+        let error = unsafe {
+            <Array<[i32; 2], SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("mismatched fixed-size-list child length")
+        };
+
+        assert_eq!(
+            error,
+            ImportError::FixedSizeListLengthMismatch {
+                length: 1,
+                child_length: 4,
+                size: 2,
+            }
+        );
+    }
+}

--- a/narrow-ffi/src/import/fixed_size_primitive.rs
+++ b/narrow-ffi/src/import/fixed_size_primitive.rs
@@ -15,8 +15,8 @@ impl<'array, T> ImportLayout<'array> for FixedSizePrimitive<T, NonNullable, Slic
 where
     T: FixedSize + ArrowType,
 {
-    const N_BUFFERS: i64 = 2;
-    const N_CHILDREN: i64 = 0;
+    const BUFFERS: i64 = 2;
+    const CHILDREN: i64 = 0;
 
     fn matches_format(format: &CStr) -> bool {
         format == T::FORMAT

--- a/narrow-ffi/src/import/fixed_size_primitive.rs
+++ b/narrow-ffi/src/import/fixed_size_primitive.rs
@@ -15,60 +15,18 @@ impl<'array, T> ImportLayout<'array> for FixedSizePrimitive<T, NonNullable, Slic
 where
     T: FixedSize + ArrowType,
 {
-    unsafe fn import_layout(
+    const N_BUFFERS: i64 = 2;
+    const N_CHILDREN: i64 = 0;
+
+    fn matches_format(format: &CStr) -> bool {
+        format == T::FORMAT
+    }
+
+    unsafe fn import_validated(
         array: &'array ArrowArray,
-        schema: &ArrowSchema,
+        _schema: &ArrowSchema,
+        length: usize,
     ) -> Result<Self, ImportError> {
-        if array.is_released() {
-            return Err(ImportError::ReleasedArray);
-        }
-        if schema.is_released() {
-            return Err(ImportError::ReleasedSchema);
-        }
-        if schema.format.is_null() {
-            return Err(ImportError::MissingFormat);
-        }
-        // SAFETY: The caller guarantees a valid null-terminated schema format.
-        if unsafe { CStr::from_ptr(schema.format) } != T::FORMAT {
-            return Err(ImportError::UnexpectedFormat);
-        }
-        if schema.flags != 0 {
-            return Err(ImportError::UnexpectedFlags {
-                flags: schema.flags,
-            });
-        }
-
-        let length = usize::try_from(array.length).map_err(|_| ImportError::InvalidLength {
-            length: array.length,
-        })?;
-        if array.offset != 0 {
-            return Err(ImportError::NonZeroOffset {
-                offset: array.offset,
-            });
-        }
-        if array.null_count != 0 {
-            return Err(ImportError::UnexpectedNullCount {
-                null_count: array.null_count,
-            });
-        }
-        if array.n_buffers != 2 {
-            return Err(ImportError::UnexpectedBufferCount {
-                count: array.n_buffers,
-            });
-        }
-        if array.n_children != 0 || schema.n_children != 0 {
-            return Err(ImportError::UnexpectedChildCount {
-                array: array.n_children,
-                schema: schema.n_children,
-            });
-        }
-        if !array.dictionary.is_null() || !schema.dictionary.is_null() {
-            return Err(ImportError::UnexpectedDictionary);
-        }
-        if array.buffers.is_null() {
-            return Err(ImportError::MissingBufferPointers);
-        }
-
         // SAFETY: The caller guarantees a valid two-entry buffer pointer array.
         let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
         let values = if length == 0 {

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -1,6 +1,6 @@
 //! Borrow Arrow C Data Interface arrays as Narrow arrays.
 
-use core::fmt;
+use core::{ffi::CStr, fmt};
 
 use narrow::{array::Array, buffer::SliceBuffer, layout::ArrayItem};
 
@@ -17,16 +17,38 @@ pub trait Import<'array>: Sized {
     ///
     /// # Safety
     ///
-    /// The Arrow structures and every referenced buffer must satisfy the Arrow
-    /// C Data Interface contract. Referenced buffers must remain immutable for
-    /// `'array` and contain enough properly aligned elements for the declared
-    /// array length.
+    /// Every non-null pointer read by the importer must be valid for the
+    /// required reads. Referenced buffers must remain immutable for `'array`
+    /// and contain enough properly aligned elements for the declared array
+    /// length. Scalar metadata is validated by the importer.
     unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError>;
 }
 
 /// A memory layout that can borrow an Arrow C Data array.
 trait ImportLayout<'array>: Sized {
-    /// Imports the memory layout described by an Arrow array and schema.
+    /// Expected Arrow schema flags.
+    const FLAGS: i64 = 0;
+    /// Expected number of Arrow array buffers.
+    const N_BUFFERS: i64;
+    /// Expected number of Arrow array and schema children.
+    const N_CHILDREN: i64;
+
+    /// Returns whether an Arrow format matches this memory layout.
+    fn matches_format(format: &CStr) -> bool;
+
+    /// Constructs the memory layout after its common fields are validated.
+    ///
+    /// # Safety
+    ///
+    /// The caller must uphold the requirements of [`Import::import`].
+    unsafe fn import_validated(
+        array: &'array ArrowArray,
+        schema: &ArrowSchema,
+        length: usize,
+    ) -> Result<Self, ImportError>;
+
+    /// Validates and imports the memory layout described by an Arrow array and
+    /// schema.
     ///
     /// # Safety
     ///
@@ -34,7 +56,67 @@ trait ImportLayout<'array>: Sized {
     unsafe fn import_layout(
         array: &'array ArrowArray,
         schema: &ArrowSchema,
-    ) -> Result<Self, ImportError>;
+    ) -> Result<Self, ImportError> {
+        if array.is_released() {
+            return Err(ImportError::ReleasedArray);
+        }
+        if schema.is_released() {
+            return Err(ImportError::ReleasedSchema);
+        }
+        if schema.format.is_null() {
+            return Err(ImportError::MissingFormat);
+        }
+        // SAFETY: The caller guarantees a valid null-terminated schema format.
+        if !Self::matches_format(unsafe { CStr::from_ptr(schema.format) }) {
+            return Err(ImportError::UnexpectedFormat);
+        }
+        if schema.flags != Self::FLAGS {
+            return Err(ImportError::UnexpectedFlags {
+                flags: schema.flags,
+            });
+        }
+
+        let length = usize::try_from(array.length).map_err(|_| ImportError::InvalidLength {
+            length: array.length,
+        })?;
+        if array.offset != 0 {
+            return Err(ImportError::NonZeroOffset {
+                offset: array.offset,
+            });
+        }
+        if array.null_count != 0 {
+            return Err(ImportError::UnexpectedNullCount {
+                null_count: array.null_count,
+            });
+        }
+        if array.n_buffers != Self::N_BUFFERS {
+            return Err(ImportError::UnexpectedBufferCount {
+                count: array.n_buffers,
+            });
+        }
+        if array.n_children != Self::N_CHILDREN || schema.n_children != Self::N_CHILDREN {
+            return Err(ImportError::UnexpectedChildCount {
+                array: array.n_children,
+                schema: schema.n_children,
+            });
+        }
+        if !array.dictionary.is_null() || !schema.dictionary.is_null() {
+            return Err(ImportError::UnexpectedDictionary);
+        }
+        if Self::N_BUFFERS != 0 && array.buffers.is_null() {
+            return Err(ImportError::MissingBufferPointers);
+        }
+        if Self::N_CHILDREN != 0 && array.children.is_null() {
+            return Err(ImportError::MissingArrayChildren);
+        }
+        if Self::N_CHILDREN != 0 && schema.children.is_null() {
+            return Err(ImportError::MissingSchemaChildren);
+        }
+
+        // SAFETY: Common fields have been validated and the caller upholds the
+        // Arrow C Data pointer and buffer requirements.
+        unsafe { Self::import_validated(array, schema, length) }
+    }
 }
 
 impl<'array, T> Import<'array> for Array<T, SliceBuffer<'array>>
@@ -99,6 +181,24 @@ pub enum ImportError {
     UnexpectedDictionary,
     /// The Arrow array does not contain its buffer pointer array.
     MissingBufferPointers,
+    /// The Arrow array does not contain its child pointer array.
+    MissingArrayChildren,
+    /// The Arrow schema does not contain its child pointer array.
+    MissingSchemaChildren,
+    /// The fixed-size-list width is not supported.
+    UnsupportedFixedSizeListSize {
+        /// Unsupported fixed-size-list width.
+        size: usize,
+    },
+    /// A fixed-size-list child length does not match its parent.
+    FixedSizeListLengthMismatch {
+        /// Number of items in the parent array.
+        length: usize,
+        /// Number of items in the child array.
+        child_length: usize,
+        /// Number of child items per parent item.
+        size: usize,
+    },
     /// A non-empty array does not contain a value buffer.
     MissingValuesBuffer,
     /// The primitive value buffer is not aligned for its element type.
@@ -132,12 +232,25 @@ impl fmt::Display for ImportError {
             }
             Self::UnexpectedChildCount { array, schema } => write!(
                 f,
-                "Arrow child counts do not match: array {array}, schema {schema}"
+                "Arrow child counts do not match the imported layout: array {array}, schema {schema}"
             ),
             Self::UnexpectedDictionary => {
                 write!(f, "Arrow dictionary is not supported for this array")
             }
             Self::MissingBufferPointers => write!(f, "Arrow buffer pointers are missing"),
+            Self::MissingArrayChildren => write!(f, "Arrow array child pointers are missing"),
+            Self::MissingSchemaChildren => write!(f, "Arrow schema child pointers are missing"),
+            Self::UnsupportedFixedSizeListSize { size } => {
+                write!(f, "fixed-size-list width ({size}) is not supported")
+            }
+            Self::FixedSizeListLengthMismatch {
+                length,
+                child_length,
+                size,
+            } => write!(
+                f,
+                "fixed-size-list length ({length}) with width ({size}) does not match child length ({child_length})"
+            ),
             Self::MissingValuesBuffer => write!(f, "Arrow value buffer is missing"),
             Self::MisalignedValuesBuffer { alignment } => write!(
                 f,
@@ -151,5 +264,7 @@ impl core::error::Error for ImportError {}
 
 /// Borrowed import support for Boolean arrays.
 mod boolean;
+/// Borrowed import support for fixed-size-list arrays.
+mod fixed_size_list;
 /// Borrowed import support for fixed-size primitive arrays.
 mod fixed_size_primitive;

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -29,9 +29,9 @@ trait ImportLayout<'array>: Sized {
     /// Expected Arrow schema flags.
     const FLAGS: i64 = 0;
     /// Expected number of Arrow array buffers.
-    const N_BUFFERS: i64;
+    const BUFFERS: i64;
     /// Expected number of Arrow array and schema children.
-    const N_CHILDREN: i64;
+    const CHILDREN: i64;
 
     /// Returns whether an Arrow format matches this memory layout.
     fn matches_format(format: &CStr) -> bool;
@@ -89,12 +89,12 @@ trait ImportLayout<'array>: Sized {
                 null_count: array.null_count,
             });
         }
-        if array.n_buffers != Self::N_BUFFERS {
+        if array.n_buffers != Self::BUFFERS {
             return Err(ImportError::UnexpectedBufferCount {
                 count: array.n_buffers,
             });
         }
-        if array.n_children != Self::N_CHILDREN || schema.n_children != Self::N_CHILDREN {
+        if array.n_children != Self::CHILDREN || schema.n_children != Self::CHILDREN {
             return Err(ImportError::UnexpectedChildCount {
                 array: array.n_children,
                 schema: schema.n_children,
@@ -103,13 +103,13 @@ trait ImportLayout<'array>: Sized {
         if !array.dictionary.is_null() || !schema.dictionary.is_null() {
             return Err(ImportError::UnexpectedDictionary);
         }
-        if Self::N_BUFFERS != 0 && array.buffers.is_null() {
+        if Self::BUFFERS != 0 && array.buffers.is_null() {
             return Err(ImportError::MissingBufferPointers);
         }
-        if Self::N_CHILDREN != 0 && array.children.is_null() {
+        if Self::CHILDREN != 0 && array.children.is_null() {
             return Err(ImportError::MissingArrayChildren);
         }
-        if Self::N_CHILDREN != 0 && schema.children.is_null() {
+        if Self::CHILDREN != 0 && schema.children.is_null() {
             return Err(ImportError::MissingSchemaChildren);
         }
 


### PR DESCRIPTION
## Summary

- borrow non-nullable `FixedSizeList` children recursively through `SliceBuffer`
- validate fixed-size-list widths, child pointers, and parent-child lengths
- centralize common Arrow array and schema validation in `ImportLayout`