### PR TITLE
feat: borrow VariableSizeList arrays from Arrow C data

### DIFF
--- a/narrow-ffi/src/export/variable_size_list.rs
+++ b/narrow-ffi/src/export/variable_size_list.rs
@@ -3,7 +3,7 @@
 extern crate alloc;
 
 use alloc::boxed::Box;
-use core::{borrow::Borrow, ffi::CStr, ffi::c_void, ptr};
+use core::{borrow::Borrow, ffi::c_void, ptr};
 
 use narrow::{
     bitmap::{BitmapRef, ValidityBitmap},
@@ -11,26 +11,11 @@ use narrow::{
     collection::ChildRef,
     layout::{ArrayItem, variable_size_list::VariableSizeList},
     nullability::{NonNullable, Nullability, Nullable},
-    offset::Offset,
 };
 
-use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema};
+use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowListOffset, ArrowSchema};
 
 use super::{ArrowArrayLayout, ExportError, release_schema};
-
-/// An Arrow list offset with a C Data format string.
-trait ArrowListOffset: Offset {
-    /// Arrow C Data format for a list using this offset width.
-    const FORMAT: &'static CStr;
-}
-
-impl ArrowListOffset for i32 {
-    const FORMAT: &'static CStr = c"+l";
-}
-
-impl ArrowListOffset for i64 {
-    const FORMAT: &'static CStr = c"+L";
-}
 
 impl<T, OffsetItem, Storage> ArrowArrayLayout
     for VariableSizeList<T, NonNullable, OffsetItem, Storage>
@@ -145,12 +130,9 @@ mod tests {
         validity::Validity,
     };
 
-    use crate::ARROW_FLAG_NULLABLE;
+    use crate::{ARROW_FLAG_NULLABLE, ArrowListOffset};
 
-    use super::{
-        super::{Export, ExportError},
-        ArrowListOffset,
-    };
+    use super::super::{Export, ExportError};
 
     #[test]
     fn list_format_strings_match_arrow() {

--- a/narrow-ffi/src/import/fixed_size_list.rs
+++ b/narrow-ffi/src/import/fixed_size_list.rs
@@ -1,6 +1,6 @@
 //! Borrowed import support for [`FixedSizeList`].
 
-use core::{ffi::CStr, slice};
+use core::ffi::CStr;
 
 use narrow::{
     buffer::SliceBuffer,
@@ -51,34 +51,10 @@ where
             return Err(ImportError::UnsupportedFixedSizeListSize { size: N });
         }
 
-        // SAFETY: Common validation guarantees a one-entry child pointer array.
-        let array_children = unsafe { slice::from_raw_parts(array.children, 1) };
-        let child_array_pointer = array_children[0];
-        if child_array_pointer.is_null() {
-            return Err(ImportError::MissingArrayChildren);
-        }
-        // SAFETY: The caller guarantees that the child array is retained by
-        // the parent for `'array`.
-        let child_array: &'array ArrowArray = unsafe { &*child_array_pointer };
-
-        // SAFETY: Common validation guarantees a one-entry child pointer array.
-        let schema_children = unsafe { slice::from_raw_parts(schema.children, 1) };
-        let child_schema_pointer = schema_children[0];
-        if child_schema_pointer.is_null() {
-            return Err(ImportError::MissingSchemaChildren);
-        }
-        // SAFETY: The caller guarantees that the child schema is valid while
-        // the parent schema is borrowed.
-        let child_schema = unsafe { &*child_schema_pointer };
-
-        // SAFETY: The child structures are covered by the caller's Arrow C
-        // Data guarantees and retained by their respective parents.
-        let child = unsafe {
-            <T::Memory<SliceBuffer<'array>> as ImportLayout>::import_layout(
-                child_array,
-                child_schema,
-            )
-        }?;
+        // SAFETY: Common parent fields are validated and the caller upholds
+        // the Arrow C Data requirements for the retained child structures.
+        let child =
+            unsafe { Self::import_child::<T::Memory<SliceBuffer<'array>>>(array, schema, 0) }?;
         let child_length = child.len();
         if length.checked_mul(N) != Some(child_length) {
             return Err(ImportError::FixedSizeListLengthMismatch {

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -1,8 +1,8 @@
 //! Borrow Arrow C Data Interface arrays as Narrow arrays.
 
-use core::{ffi::CStr, fmt};
+use core::{ffi::CStr, fmt, slice};
 
-use narrow::{array::Array, buffer::SliceBuffer, layout::ArrayItem};
+use narrow::{array::Array, buffer::SliceBuffer, layout::ArrayItem, offset::OffsetsError};
 
 use crate::{ArrowArray, ArrowSchema};
 
@@ -117,6 +117,50 @@ trait ImportLayout<'array>: Sized {
         // Arrow C Data pointer and buffer requirements.
         unsafe { Self::import_validated(array, schema, length) }
     }
+
+    /// Imports a child memory layout at `index`.
+    ///
+    /// # Safety
+    ///
+    /// Common parent fields must be validated, and the caller must uphold the
+    /// requirements of [`Import::import`] for the child structures.
+    unsafe fn import_child<Child>(
+        array: &'array ArrowArray,
+        schema: &ArrowSchema,
+        index: usize,
+    ) -> Result<Child, ImportError>
+    where
+        Child: ImportLayout<'array>,
+    {
+        let children = usize::try_from(Self::CHILDREN).expect("child count must fit in usize");
+        assert!(index < children, "child index is out of bounds");
+
+        // SAFETY: Common validation and the caller guarantee a valid child
+        // pointer array with `children` entries.
+        let array_children = unsafe { slice::from_raw_parts(array.children, children) };
+        let child_array_pointer = array_children[index];
+        if child_array_pointer.is_null() {
+            return Err(ImportError::MissingArrayChildren);
+        }
+        // SAFETY: The caller guarantees that the child array is retained by
+        // the parent for `'array`.
+        let child_array: &'array ArrowArray = unsafe { &*child_array_pointer };
+
+        // SAFETY: Common validation and the caller guarantee a valid child
+        // pointer array with `children` entries.
+        let schema_children = unsafe { slice::from_raw_parts(schema.children, children) };
+        let child_schema_pointer = schema_children[index];
+        if child_schema_pointer.is_null() {
+            return Err(ImportError::MissingSchemaChildren);
+        }
+        // SAFETY: The caller guarantees that the child schema is valid while
+        // the parent schema is borrowed.
+        let child_schema = unsafe { &*child_schema_pointer };
+
+        // SAFETY: The child structures are covered by the caller's Arrow C
+        // Data guarantees and retained by their respective parents.
+        unsafe { Child::import_layout(child_array, child_schema) }
+    }
 }
 
 impl<'array, T> Import<'array> for Array<T, SliceBuffer<'array>>
@@ -199,6 +243,18 @@ pub enum ImportError {
         /// Number of child items per parent item.
         size: usize,
     },
+    /// A non-empty offsets buffer is missing.
+    MissingOffsetsBuffer,
+    /// The offsets buffer is not aligned for its element type.
+    MisalignedOffsetsBuffer {
+        /// Required byte alignment of the offset type.
+        alignment: usize,
+    },
+    /// An offsets buffer does not satisfy the Arrow offset invariants.
+    InvalidOffsets {
+        /// Offset invariant that was violated.
+        error: OffsetsError,
+    },
     /// A non-empty array does not contain a value buffer.
     MissingValuesBuffer,
     /// The primitive value buffer is not aligned for its element type.
@@ -251,6 +307,12 @@ impl fmt::Display for ImportError {
                 f,
                 "fixed-size-list length ({length}) with width ({size}) does not match child length ({child_length})"
             ),
+            Self::MissingOffsetsBuffer => write!(f, "Arrow offsets buffer is missing"),
+            Self::MisalignedOffsetsBuffer { alignment } => write!(
+                f,
+                "Arrow offsets buffer does not have the required alignment ({alignment})"
+            ),
+            Self::InvalidOffsets { error } => write!(f, "invalid Arrow offsets: {error}"),
             Self::MissingValuesBuffer => write!(f, "Arrow value buffer is missing"),
             Self::MisalignedValuesBuffer { alignment } => write!(
                 f,
@@ -260,7 +322,14 @@ impl fmt::Display for ImportError {
     }
 }
 
-impl core::error::Error for ImportError {}
+impl core::error::Error for ImportError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match *self {
+            Self::InvalidOffsets { ref error } => Some(error),
+            _ => None,
+        }
+    }
+}
 
 /// Borrowed import support for Boolean arrays.
 mod boolean;
@@ -268,3 +337,5 @@ mod boolean;
 mod fixed_size_list;
 /// Borrowed import support for fixed-size primitive arrays.
 mod fixed_size_primitive;
+/// Borrowed import support for variable-size-list arrays.
+mod variable_size_list;

--- a/narrow-ffi/src/import/variable_size_list.rs
+++ b/narrow-ffi/src/import/variable_size_list.rs
@@ -1,0 +1,169 @@
+//! Borrowed import support for [`VariableSizeList`].
+
+use core::{ffi::CStr, mem, slice};
+
+use narrow::{
+    buffer::SliceBuffer,
+    layout::{ArrayItem, variable_size_list::VariableSizeList},
+    nullability::NonNullable,
+    offset::Offsets,
+};
+
+use crate::{ArrowArray, ArrowListOffset, ArrowSchema};
+
+use super::{ImportError, ImportLayout};
+
+impl<'array, T, OffsetItem> ImportLayout<'array>
+    for VariableSizeList<T, NonNullable, OffsetItem, SliceBuffer<'array>>
+where
+    T: ArrayItem,
+    OffsetItem: ArrowListOffset,
+    T::Memory<SliceBuffer<'array>>: ImportLayout<'array>,
+{
+    const BUFFERS: i64 = 2;
+    const CHILDREN: i64 = 1;
+
+    fn matches_format(format: &CStr) -> bool {
+        format == OffsetItem::FORMAT
+    }
+
+    unsafe fn import_validated(
+        array: &'array ArrowArray,
+        schema: &ArrowSchema,
+        length: usize,
+    ) -> Result<Self, ImportError> {
+        let offsets_length = length.checked_add(1).ok_or(ImportError::InvalidLength {
+            length: array.length,
+        })?;
+        // SAFETY: Common validation guarantees a two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        let offsets_pointer = buffers[1].cast::<OffsetItem>();
+        if offsets_pointer.is_null() {
+            return Err(ImportError::MissingOffsetsBuffer);
+        }
+        if !offsets_pointer.is_aligned() {
+            return Err(ImportError::MisalignedOffsetsBuffer {
+                alignment: mem::align_of::<OffsetItem>(),
+            });
+        }
+        // SAFETY: The caller guarantees the offsets buffer contains
+        // `offsets_length` aligned values that remain immutable for `'array`.
+        let offset_values = unsafe { slice::from_raw_parts(offsets_pointer, offsets_length) };
+
+        // SAFETY: Common parent fields are validated and the caller upholds
+        // the Arrow C Data requirements for the retained child structures.
+        let child =
+            unsafe { Self::import_child::<T::Memory<SliceBuffer<'array>>>(array, schema, 0) }?;
+        let offsets = Offsets::try_from_parts(child, offset_values)
+            .map_err(|error| ImportError::InvalidOffsets { error })?;
+
+        Ok(Self::from_buffer(offsets))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate alloc;
+
+    use alloc::{sync::Arc, vec, vec::Vec};
+    use core::borrow::Borrow;
+
+    use narrow::{
+        array::Array,
+        buffer::{ArcBuffer, BufferRef, SliceBuffer},
+        collection::{ChildRef, Collection},
+        layout::{fixed_size_primitive::FixedSizePrimitive, variable_size_list::VariableSizeList},
+        offset::{Offsets, OffsetsError},
+    };
+
+    use crate::{
+        export::Export,
+        import::{Import, ImportError},
+    };
+
+    #[test]
+    fn imports_variable_size_list_buffers_without_copying() {
+        let value_storage = Arc::<[i32]>::from([1, 2, 3]);
+        let offset_storage = Arc::<[i32]>::from([0, 2, 3]);
+        let values_weak = Arc::downgrade(&value_storage);
+        let offsets_weak = Arc::downgrade(&offset_storage);
+        let values_data = value_storage.as_ptr();
+        let offsets_data = offset_storage.as_ptr();
+        let values = FixedSizePrimitive::from_buffer(value_storage);
+        let offsets = Offsets::try_from_parts(values, offset_storage).expect("valid offsets");
+        let source: Array<Vec<i32>, ArcBuffer> =
+            Array::from_buffer(VariableSizeList::from_buffer(offsets));
+        let (array, schema) = source.export().expect("export array");
+
+        {
+            // SAFETY: The exported structures remain live and retain their
+            // offsets, child array, and values for the imported array's lifetime.
+            let imported: Array<Vec<i32>, SliceBuffer<'_>> =
+                unsafe { Import::import(&array, &schema) }.expect("import array");
+
+            let imported_offsets = imported.buffer_ref().buffer_ref();
+            let offset_values: &[i32] = imported_offsets.buffer_ref().borrow();
+            let imported_values: &[i32] = imported_offsets.child_ref().buffer_ref().borrow();
+            assert_eq!(offset_values, [0, 2, 3]);
+            assert_eq!(offset_values.as_ptr(), offsets_data);
+            assert_eq!(imported_values, [1, 2, 3]);
+            assert_eq!(imported_values.as_ptr(), values_data);
+            assert_eq!(imported.owned(0), Some(vec![1, 2]));
+            assert_eq!(imported.owned(1), Some(vec![3]));
+            assert!(values_weak.upgrade().is_some());
+            assert!(offsets_weak.upgrade().is_some());
+        };
+
+        assert!(values_weak.upgrade().is_some());
+        assert!(offsets_weak.upgrade().is_some());
+        drop(array);
+        assert!(values_weak.upgrade().is_none());
+        assert!(offsets_weak.upgrade().is_none());
+        drop(schema);
+    }
+
+    #[test]
+    fn rejects_mismatched_variable_size_list_format() {
+        let source = [vec![1_i32]].into_iter().collect::<Array<Vec<i32>>>();
+        let (array, mut schema) = source.export().expect("export array");
+        schema.format = c"+L".as_ptr();
+
+        // SAFETY: The exported structures and buffers remain valid; only the
+        // parent format is changed to exercise list format validation.
+        let error = unsafe {
+            <Array<Vec<i32>, SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("mismatched variable-size-list format")
+        };
+
+        assert_eq!(error, ImportError::UnexpectedFormat);
+    }
+
+    #[test]
+    fn rejects_non_monotonic_variable_size_list_offsets() {
+        let source = [vec![1_i32, 2], vec![3]]
+            .into_iter()
+            .collect::<Array<Vec<i32>>>();
+        let (array, schema) = source.export().expect("export array");
+        let invalid_offsets = [0_i32, 2, 1];
+        // SAFETY: The exported array owns a writable two-entry pointer array;
+        // the second entry is the offsets buffer.
+        let offsets_slot = unsafe { array.buffers.add(1) };
+        // SAFETY: The slot is live and writable, and the replacement buffer
+        // remains live through the import call.
+        unsafe { *offsets_slot = invalid_offsets.as_ptr().cast() };
+
+        // SAFETY: Every referenced pointer remains valid and sufficiently
+        // sized; the malformed offset values are validated by the importer.
+        let error = unsafe {
+            <Array<Vec<i32>, SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("non-monotonic offsets")
+        };
+
+        assert_eq!(
+            error,
+            ImportError::InvalidOffsets {
+                error: OffsetsError::NonMonotonic { index: 2 },
+            }
+        );
+    }
+}

--- a/narrow-ffi/src/lib.rs
+++ b/narrow-ffi/src/lib.rs
@@ -62,14 +62,30 @@
 )]
 
 use core::{
-    ffi::{c_char, c_void},
+    ffi::{CStr, c_char, c_void},
     ptr,
 };
+
+use narrow::offset::Offset;
 
 mod export;
 pub use export::{ArrowType, Export, ExportError};
 mod import;
 pub use import::{Import, ImportError};
+
+/// An Arrow list offset with a C Data format string.
+trait ArrowListOffset: Offset {
+    /// Arrow C Data format for a list using this offset width.
+    const FORMAT: &'static CStr;
+}
+
+impl ArrowListOffset for i32 {
+    const FORMAT: &'static CStr = c"+l";
+}
+
+impl ArrowListOffset for i64 {
+    const FORMAT: &'static CStr = c"+L";
+}
 
 /// Dictionary values are ordered.
 pub const ARROW_FLAG_DICTIONARY_ORDERED: i64 = 1;


### PR DESCRIPTION
## Summary

- borrow non-nullable `VariableSizeList` offsets and children through `SliceBuffer`
- validate list formats, offset alignment, and Arrow offset invariants
- share list offset formats and recursive child import handling