### PR TITLE
build: use rust-overlay for Nix toolchains

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784784641,
+        "narHash": "sha256-F8/6twaXdW5dOHgLt1sO62fygfA3aKiYlEmnnIxzpTU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "19a19f3921ae195f2fbd85f5dc57e6d1df63aa0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,41 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { nixpkgs, rust-overlay, ... }:
     let
-      system = builtins.currentSystem;
-      pkgs = import nixpkgs { inherit system; };
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
     in {
-      devShells.${system}.default = pkgs.mkShell {
-        packages = [ pkgs.rustc pkgs.cargo pkgs.clippy pkgs.rustfmt ];
-      };
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          stable = pkgs.mkShell {
+            packages = [ pkgs.rust-bin.stable.latest.default ];
+          };
+        in {
+          default = stable;
+          inherit stable;
+          nightly = pkgs.mkShell {
+            packages = [
+              (pkgs.rust-bin.selectLatestNightlyWith (toolchain:
+                toolchain.default.override {
+                  extensions = [ "miri" "rust-src" ];
+                }))
+            ];
+          };
+        });
     };
 }


### PR DESCRIPTION
## Summary

- add and pin oxalica/rust-overlay, following the existing nixpkgs input
- provide default and stable shells with the latest stable Rust default profile
- provide a nightly shell with Miri and rust-src
- expose pure dev-shell outputs for the platforms supported by the pinned nixpkgs

## Validation

- nix flake check --all-systems --no-build
- nix develop .#stable --command cargo check --workspace
- nix develop .#nightly --command cargo miri setup
- nix develop .#nightly --command cargo miri test