### PR TITLE
feat: borrow nullable primitive arrays

### DIFF
--- a/narrow-ffi/src/import/fixed_size_primitive.rs
+++ b/narrow-ffi/src/import/fixed_size_primitive.rs
@@ -3,60 +3,19 @@
 use core::{ffi::CStr, mem, slice};
 
 use narrow::{
-    buffer::SliceBuffer,
-    fixed_size::FixedSize,
-    layout::fixed_size_primitive::FixedSizePrimitive,
-    nullability::{NonNullable, Nullable},
+    buffer::SliceBuffer, fixed_size::FixedSize, layout::fixed_size_primitive::FixedSizePrimitive,
 };
 
-use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema, ArrowType};
+use crate::{ArrowArray, ArrowSchema, ArrowType};
 
-use super::{ImportError, ImportLayout};
+use super::{ImportError, ImportLayout, ImportNullability};
 
-impl<'array, T> ImportLayout<'array> for FixedSizePrimitive<T, NonNullable, SliceBuffer<'array>>
+impl<'array, T, Nulls> ImportLayout<'array> for FixedSizePrimitive<T, Nulls, SliceBuffer<'array>>
 where
     T: FixedSize + ArrowType,
+    Nulls: ImportNullability<'array>,
 {
-    const BUFFERS: i64 = 2;
-    const CHILDREN: i64 = 0;
-
-    fn matches_format(format: &CStr) -> bool {
-        format == T::FORMAT
-    }
-
-    unsafe fn import_validated(
-        array: &'array ArrowArray,
-        _schema: &ArrowSchema,
-        length: usize,
-    ) -> Result<Self, ImportError> {
-        // SAFETY: The caller guarantees a valid two-entry buffer pointer array.
-        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
-        let values = if length == 0 {
-            &[]
-        } else {
-            let values = buffers[1].cast::<T>();
-            if values.is_null() {
-                return Err(ImportError::MissingValuesBuffer);
-            }
-            if !values.is_aligned() {
-                return Err(ImportError::MisalignedValuesBuffer {
-                    alignment: mem::align_of::<T>(),
-                });
-            }
-            // SAFETY: The caller guarantees the value buffer contains `length`
-            // properly aligned values that remain immutable for `'array`.
-            unsafe { slice::from_raw_parts(values, length) }
-        };
-
-        Ok(Self::from_buffer(values))
-    }
-}
-
-impl<'array, T> ImportLayout<'array> for FixedSizePrimitive<T, Nullable, SliceBuffer<'array>>
-where
-    T: FixedSize + ArrowType,
-{
-    const FLAGS: i64 = ARROW_FLAG_NULLABLE;
+    const FLAGS: i64 = Nulls::FLAGS;
     const BUFFERS: i64 = 2;
     const CHILDREN: i64 = 0;
 
@@ -90,8 +49,8 @@ where
 
         // SAFETY: Common validation and the caller guarantee a valid optional
         // validity buffer for the imported values.
-        let validity = unsafe { Self::import_validity(array, values) }?;
-        Ok(Self::from_buffer(validity))
+        let collection = unsafe { Nulls::wrap(array, values) }?;
+        Ok(Self::from_buffer(collection))
     }
 }
 

--- a/narrow-ffi/src/import/fixed_size_primitive.rs
+++ b/narrow-ffi/src/import/fixed_size_primitive.rs
@@ -3,11 +3,13 @@
 use core::{ffi::CStr, mem, slice};
 
 use narrow::{
-    buffer::SliceBuffer, fixed_size::FixedSize, layout::fixed_size_primitive::FixedSizePrimitive,
-    nullability::NonNullable,
+    buffer::SliceBuffer,
+    fixed_size::FixedSize,
+    layout::fixed_size_primitive::FixedSizePrimitive,
+    nullability::{NonNullable, Nullable},
 };
 
-use crate::{ArrowArray, ArrowSchema, ArrowType};
+use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema, ArrowType};
 
 use super::{ImportError, ImportLayout};
 
@@ -50,18 +52,64 @@ where
     }
 }
 
+impl<'array, T> ImportLayout<'array> for FixedSizePrimitive<T, Nullable, SliceBuffer<'array>>
+where
+    T: FixedSize + ArrowType,
+{
+    const FLAGS: i64 = ARROW_FLAG_NULLABLE;
+    const BUFFERS: i64 = 2;
+    const CHILDREN: i64 = 0;
+
+    fn matches_format(format: &CStr) -> bool {
+        format == T::FORMAT
+    }
+
+    unsafe fn import_validated(
+        array: &'array ArrowArray,
+        _schema: &ArrowSchema,
+        length: usize,
+    ) -> Result<Self, ImportError> {
+        // SAFETY: The caller guarantees a valid two-entry buffer pointer array.
+        let buffers = unsafe { slice::from_raw_parts(array.buffers, 2) };
+        let values = if length == 0 {
+            &[]
+        } else {
+            let values = buffers[1].cast::<T>();
+            if values.is_null() {
+                return Err(ImportError::MissingValuesBuffer);
+            }
+            if !values.is_aligned() {
+                return Err(ImportError::MisalignedValuesBuffer {
+                    alignment: mem::align_of::<T>(),
+                });
+            }
+            // SAFETY: The caller guarantees the value buffer contains `length`
+            // properly aligned values that remain immutable for `'array`.
+            unsafe { slice::from_raw_parts(values, length) }
+        };
+
+        // SAFETY: Common validation and the caller guarantee a valid optional
+        // validity buffer for the imported values.
+        let validity = unsafe { Self::import_validity(array, values) }?;
+        Ok(Self::from_buffer(validity))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate alloc;
 
     use alloc::sync::Arc;
-    use core::borrow::Borrow;
+    use core::{borrow::Borrow, ptr};
 
     use narrow::{
         array::Array,
+        bitmap::{Bitmap, ValidityBitmap},
         buffer::{ArcBuffer, BufferRef, SliceBuffer},
+        collection::{ChildRef, Collection},
         layout::fixed_size_primitive::FixedSizePrimitive,
         length::Length,
+        validity::Validity,
     };
 
     use crate::{
@@ -207,5 +255,102 @@ mod tests {
                 .expect_err("known null does not match")
         };
         assert_eq!(error, ImportError::UnexpectedNullCount { null_count: 1 });
+    }
+
+    #[test]
+    fn imports_nullable_primitive_values_without_copying() {
+        let values = Arc::<[i32]>::from([1, 0, 3]);
+        let validity_values = Arc::<[u8]>::from([0b0000_0101]);
+        let values_data = values.as_ptr();
+        let validity_data = validity_values.as_ptr();
+        let bitmap =
+            Bitmap::<ArcBuffer>::try_from_parts(validity_values, 3, 0).expect("valid bitmap");
+        let validity = Validity::try_from_parts(values, bitmap).expect("valid parts");
+        let source: Array<Option<i32>, ArcBuffer> =
+            Array::from_buffer(FixedSizePrimitive::from_buffer(validity));
+        let (mut array, schema) = source.export().expect("export array");
+        array.null_count = -1;
+
+        // SAFETY: The exported structures retain valid value and validity
+        // buffers for the lifetime of the imported array.
+        let imported: Array<Option<i32>, SliceBuffer<'_>> =
+            unsafe { Import::import(&array, &schema) }.expect("import array");
+
+        let imported_validity = imported.buffer_ref().buffer_ref();
+        let imported_values: &[i32] = imported_validity.child_ref().borrow();
+        let imported_bitmap = imported_validity.bitmap_ref().expect("explicit validity");
+        let imported_validity_values: &[u8] = imported_bitmap.buffer_ref().borrow();
+        assert_eq!(imported_values.as_ptr(), values_data);
+        assert_eq!(imported_validity_values.as_ptr(), validity_data);
+        assert_eq!(
+            imported.iter_views().collect::<alloc::vec::Vec<_>>(),
+            [Some(1), None, Some(3)]
+        );
+    }
+
+    #[test]
+    fn imports_nullable_primitive_values_with_implicit_validity() {
+        let values = Arc::<[i32]>::from([1, 2, 3]);
+        let data = values.as_ptr();
+        let validity = Validity::<_, ArcBuffer>::from_collection(values);
+        let source: Array<Option<i32>, ArcBuffer> =
+            Array::from_buffer(FixedSizePrimitive::from_buffer(validity));
+        let (array, schema) = source.export().expect("export array");
+
+        // SAFETY: The exported structures retain a valid value buffer for the
+        // lifetime of the imported array.
+        let imported: Array<Option<i32>, SliceBuffer<'_>> =
+            unsafe { Import::import(&array, &schema) }.expect("import array");
+
+        let imported_validity = imported.buffer_ref().buffer_ref();
+        let imported_values: &[i32] = imported_validity.child_ref().borrow();
+        assert_eq!(imported_values.as_ptr(), data);
+        assert!(imported_validity.bitmap_ref().is_none());
+        assert_eq!(
+            imported.iter_views().collect::<alloc::vec::Vec<_>>(),
+            [Some(1), Some(2), Some(3)]
+        );
+    }
+
+    #[test]
+    fn rejects_missing_nullable_primitive_validity() {
+        let source = [Some(1_i32), None]
+            .into_iter()
+            .collect::<Array<Option<i32>>>();
+        let (array, schema) = source.export().expect("export array");
+        // SAFETY: The exported array owns a writable two-entry buffer pointer
+        // array. Clearing its validity entry exercises import validation.
+        unsafe { *array.buffers = ptr::null() };
+
+        // SAFETY: The value buffer remains valid, and the missing validity
+        // buffer is the condition under test.
+        let error = unsafe {
+            <Array<Option<i32>, SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("missing validity")
+        };
+        assert_eq!(error, ImportError::MissingValidityBuffer);
+    }
+
+    #[test]
+    fn rejects_nullable_primitive_null_count_mismatch() {
+        let source = [Some(1_i32), None]
+            .into_iter()
+            .collect::<Array<Option<i32>>>();
+        let (mut array, schema) = source.export().expect("export array");
+        array.null_count = 0;
+
+        // SAFETY: The exported buffers remain valid; only the null count is
+        // changed to exercise validation.
+        let error = unsafe {
+            <Array<Option<i32>, SliceBuffer<'_>> as Import>::import(&array, &schema)
+                .expect_err("mismatched null count")
+        };
+        assert_eq!(
+            error,
+            ImportError::NullCountMismatch {
+                declared: 0,
+                actual: 1,
+            }
+        );
     }
 }

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -8,6 +8,7 @@ use narrow::{
     buffer::SliceBuffer,
     collection::Collection,
     layout::ArrayItem,
+    nullability::{NonNullable, Nullability, Nullable},
     offset::OffsetsError,
     validity::Validity,
 };
@@ -30,6 +31,88 @@ pub trait Import<'array>: Sized {
     /// and contain enough properly aligned elements for the declared array
     /// length. Scalar metadata is validated by the importer.
     unsafe fn import(array: &'array ArrowArray, schema: &ArrowSchema) -> Result<Self, ImportError>;
+}
+
+/// Arrow import behavior for a [`Nullability`] type constructor.
+trait ImportNullability<'array>: Nullability {
+    /// Arrow schema nullable flag for this nullability.
+    const FLAGS: i64;
+
+    /// Wraps an imported collection with this nullability.
+    ///
+    /// # Safety
+    ///
+    /// Common fields must be validated, and the caller must uphold the
+    /// requirements of [`Import::import`] for the validity buffer.
+    unsafe fn wrap<T>(
+        array: &'array ArrowArray,
+        collection: T,
+    ) -> Result<Self::Collection<T, SliceBuffer<'array>>, ImportError>
+    where
+        T: Collection;
+}
+
+impl<'array> ImportNullability<'array> for NonNullable {
+    const FLAGS: i64 = 0;
+
+    unsafe fn wrap<T>(
+        _array: &'array ArrowArray,
+        collection: T,
+    ) -> Result<Self::Collection<T, SliceBuffer<'array>>, ImportError>
+    where
+        T: Collection,
+    {
+        Ok(collection)
+    }
+}
+
+impl<'array> ImportNullability<'array> for Nullable {
+    const FLAGS: i64 = ARROW_FLAG_NULLABLE;
+
+    unsafe fn wrap<T>(
+        array: &'array ArrowArray,
+        collection: T,
+    ) -> Result<Self::Collection<T, SliceBuffer<'array>>, ImportError>
+    where
+        T: Collection,
+    {
+        // Common validation guarantees a non-null buffer pointer array.
+        let buffers = usize::try_from(array.n_buffers).expect("buffer count must fit in usize");
+        assert!(buffers != 0, "validity requires a buffer");
+
+        // SAFETY: Common validation and the caller guarantee a valid buffer
+        // pointer array with `buffers` entries.
+        let buffer_pointers = unsafe { slice::from_raw_parts(array.buffers, buffers) };
+        let validity_pointer = buffer_pointers[0].cast::<u8>();
+        let length = collection.len();
+        let validity = if validity_pointer.is_null() {
+            if array.null_count == 0 || length == 0 {
+                Validity::from_collection(collection)
+            } else {
+                return Err(ImportError::MissingValidityBuffer);
+            }
+        } else {
+            let byte_length = length.div_ceil(8);
+            // SAFETY: The caller guarantees the validity buffer contains
+            // `byte_length` bytes that remain immutable for `'array`.
+            let values = unsafe { slice::from_raw_parts(validity_pointer, byte_length) };
+            let bitmap = Bitmap::try_from_parts(values, length, 0)
+                .expect("imported validity buffer contains the declared number of bits");
+            Validity::try_from_parts(collection, bitmap).expect("validity lengths match")
+        };
+
+        if array.null_count >= 0 {
+            let actual = validity.null_count();
+            if usize::try_from(array.null_count) != Ok(actual) {
+                return Err(ImportError::NullCountMismatch {
+                    declared: array.null_count,
+                    actual,
+                });
+            }
+        }
+
+        Ok(validity)
+    }
 }
 
 /// A memory layout that can borrow an Arrow C Data array.
@@ -130,60 +213,6 @@ trait ImportLayout<'array>: Sized {
         // SAFETY: Common fields have been validated and the caller upholds the
         // Arrow C Data pointer and buffer requirements.
         unsafe { Self::import_validated(array, schema, length) }
-    }
-
-    /// Imports the validity of a nullable layout around `collection`.
-    ///
-    /// # Safety
-    ///
-    /// Common fields must be validated, and the caller must uphold the
-    /// requirements of [`Import::import`] for the validity buffer.
-    unsafe fn import_validity<T>(
-        array: &'array ArrowArray,
-        collection: T,
-    ) -> Result<Validity<T, SliceBuffer<'array>>, ImportError>
-    where
-        T: Collection,
-    {
-        assert!(
-            Self::FLAGS & ARROW_FLAG_NULLABLE != 0,
-            "validity requires a nullable layout"
-        );
-        let buffers = usize::try_from(Self::BUFFERS).expect("buffer count must fit in usize");
-        assert!(buffers != 0, "validity requires a buffer");
-
-        // SAFETY: Common validation and the caller guarantee a valid buffer
-        // pointer array with `buffers` entries.
-        let buffer_pointers = unsafe { slice::from_raw_parts(array.buffers, buffers) };
-        let validity_pointer = buffer_pointers[0].cast::<u8>();
-        let length = collection.len();
-        let validity = if validity_pointer.is_null() {
-            if array.null_count == 0 || length == 0 {
-                Validity::from_collection(collection)
-            } else {
-                return Err(ImportError::MissingValidityBuffer);
-            }
-        } else {
-            let byte_length = length.div_ceil(8);
-            // SAFETY: The caller guarantees the validity buffer contains
-            // `byte_length` bytes that remain immutable for `'array`.
-            let values = unsafe { slice::from_raw_parts(validity_pointer, byte_length) };
-            let bitmap = Bitmap::try_from_parts(values, length, 0)
-                .expect("imported validity buffer contains the declared number of bits");
-            Validity::try_from_parts(collection, bitmap).expect("validity lengths match")
-        };
-
-        if array.null_count >= 0 {
-            let actual = validity.null_count();
-            if usize::try_from(array.null_count) != Ok(actual) {
-                return Err(ImportError::NullCountMismatch {
-                    declared: array.null_count,
-                    actual,
-                });
-            }
-        }
-
-        Ok(validity)
     }
 
     /// Imports a child memory layout at `index`.

--- a/narrow-ffi/src/import/mod.rs
+++ b/narrow-ffi/src/import/mod.rs
@@ -2,7 +2,15 @@
 
 use core::{ffi::CStr, fmt, slice};
 
-use narrow::{array::Array, buffer::SliceBuffer, layout::ArrayItem, offset::OffsetsError};
+use narrow::{
+    array::Array,
+    bitmap::{Bitmap, ValidityBitmap},
+    buffer::SliceBuffer,
+    collection::Collection,
+    layout::ArrayItem,
+    offset::OffsetsError,
+    validity::Validity,
+};
 
 use crate::{ARROW_FLAG_NULLABLE, ArrowArray, ArrowSchema};
 
@@ -124,6 +132,60 @@ trait ImportLayout<'array>: Sized {
         unsafe { Self::import_validated(array, schema, length) }
     }
 
+    /// Imports the validity of a nullable layout around `collection`.
+    ///
+    /// # Safety
+    ///
+    /// Common fields must be validated, and the caller must uphold the
+    /// requirements of [`Import::import`] for the validity buffer.
+    unsafe fn import_validity<T>(
+        array: &'array ArrowArray,
+        collection: T,
+    ) -> Result<Validity<T, SliceBuffer<'array>>, ImportError>
+    where
+        T: Collection,
+    {
+        assert!(
+            Self::FLAGS & ARROW_FLAG_NULLABLE != 0,
+            "validity requires a nullable layout"
+        );
+        let buffers = usize::try_from(Self::BUFFERS).expect("buffer count must fit in usize");
+        assert!(buffers != 0, "validity requires a buffer");
+
+        // SAFETY: Common validation and the caller guarantee a valid buffer
+        // pointer array with `buffers` entries.
+        let buffer_pointers = unsafe { slice::from_raw_parts(array.buffers, buffers) };
+        let validity_pointer = buffer_pointers[0].cast::<u8>();
+        let length = collection.len();
+        let validity = if validity_pointer.is_null() {
+            if array.null_count == 0 || length == 0 {
+                Validity::from_collection(collection)
+            } else {
+                return Err(ImportError::MissingValidityBuffer);
+            }
+        } else {
+            let byte_length = length.div_ceil(8);
+            // SAFETY: The caller guarantees the validity buffer contains
+            // `byte_length` bytes that remain immutable for `'array`.
+            let values = unsafe { slice::from_raw_parts(validity_pointer, byte_length) };
+            let bitmap = Bitmap::try_from_parts(values, length, 0)
+                .expect("imported validity buffer contains the declared number of bits");
+            Validity::try_from_parts(collection, bitmap).expect("validity lengths match")
+        };
+
+        if array.null_count >= 0 {
+            let actual = validity.null_count();
+            if usize::try_from(array.null_count) != Ok(actual) {
+                return Err(ImportError::NullCountMismatch {
+                    declared: array.null_count,
+                    actual,
+                });
+            }
+        }
+
+        Ok(validity)
+    }
+
     /// Imports a child memory layout at `index`.
     ///
     /// # Safety
@@ -215,6 +277,15 @@ pub enum ImportError {
         /// Null count supplied by the producer.
         null_count: i64,
     },
+    /// A nullable non-empty array does not contain a required validity buffer.
+    MissingValidityBuffer,
+    /// A nullable array's null count does not match its validity bitmap.
+    NullCountMismatch {
+        /// Null count supplied by the producer.
+        declared: i64,
+        /// Number of nulls found in the validity bitmap.
+        actual: usize,
+    },
     /// The Arrow array has an unexpected number of buffers.
     UnexpectedBufferCount {
         /// Buffer count supplied by the producer.
@@ -295,6 +366,13 @@ impl fmt::Display for ImportError {
                     "Arrow array null count ({null_count}) does not match the imported layout"
                 )
             }
+            Self::MissingValidityBuffer => {
+                write!(f, "nullable Arrow array validity buffer is missing")
+            }
+            Self::NullCountMismatch { declared, actual } => write!(
+                f,
+                "Arrow array null count ({declared}) does not match validity bitmap ({actual})"
+            ),
             Self::UnexpectedBufferCount { count } => {
                 write!(f, "Arrow array buffer count ({count}) does not match")
             }


### PR DESCRIPTION
- borrow primitive value and validity buffers without copying
- select nullable wrapping through a type-level import abstraction
- preserve omitted validity and validate known null counts