### PR TITLE
feat: borrow nullable fixed-size lists

### DIFF
--- a/narrow-ffi/src/import/fixed_size_list.rs
+++ b/narrow-ffi/src/import/fixed_size_list.rs
@@ -7,19 +7,20 @@ use narrow::{
     collection::flatten::Flatten,
     layout::{ArrayItem, fixed_size_list::FixedSizeList},
     length::Length,
-    nullability::NonNullable,
 };
 
 use crate::{ArrowArray, ArrowSchema};
 
-use super::{ImportError, ImportLayout};
+use super::{ImportError, ImportLayout, ImportNullability};
 
-impl<'array, T, const N: usize> ImportLayout<'array>
-    for FixedSizeList<T, N, NonNullable, SliceBuffer<'array>>
+impl<'array, T, const N: usize, Nulls> ImportLayout<'array>
+    for FixedSizeList<T, N, Nulls, SliceBuffer<'array>>
 where
     T: ArrayItem,
     T::Memory<SliceBuffer<'array>>: ImportLayout<'array>,
+    Nulls: ImportNullability<'array>,
 {
+    const FLAGS: i64 = Nulls::FLAGS;
     const BUFFERS: i64 = 1;
     const CHILDREN: i64 = 1;
 
@@ -66,7 +67,10 @@ where
         let flattened = Flatten::try_from_parts(child)
             .expect("validated fixed-size-list child length is a multiple of its width");
 
-        Ok(Self::from_buffer(flattened))
+        // SAFETY: Common validation and the caller guarantee a valid optional
+        // validity buffer for the imported lists.
+        let collection = unsafe { Nulls::wrap(array, flattened) }?;
+        Ok(Self::from_buffer(collection))
     }
 }
 
@@ -75,13 +79,15 @@ mod tests {
     extern crate alloc;
 
     use alloc::sync::Arc;
-    use core::borrow::Borrow;
+    use core::{borrow::Borrow, ptr};
 
     use narrow::{
         array::Array,
+        bitmap::{Bitmap, ValidityBitmap},
         buffer::{ArcBuffer, BufferRef, SliceBuffer},
         collection::{ChildRef, Collection, flatten::Flatten},
         layout::{fixed_size_list::FixedSizeList, fixed_size_primitive::FixedSizePrimitive},
+        validity::Validity,
     };
 
     use crate::{
@@ -123,6 +129,62 @@ mod tests {
         drop(array);
         assert!(weak.upgrade().is_none());
         drop(schema);
+    }
+
+    #[test]
+    fn imports_nullable_fixed_size_list_without_copying() {
+        let values = Arc::<[i32]>::from([1, 2, 3, 4]);
+        let validity_values = Arc::<[u8]>::from([0b0000_0001]);
+        let values_data = values.as_ptr();
+        let validity_data = validity_values.as_ptr();
+        let values_layout = FixedSizePrimitive::from_buffer(values);
+        let flattened = Flatten::try_from_parts(values_layout).expect("valid fixed-size list");
+        let bitmap =
+            Bitmap::<ArcBuffer>::try_from_parts(validity_values, 2, 0).expect("valid bitmap");
+        let validity = Validity::try_from_parts(flattened, bitmap).expect("valid parts");
+        let source: Array<Option<[i32; 2]>, ArcBuffer> =
+            Array::from_buffer(FixedSizeList::from_buffer(validity));
+        let (mut array, schema) = source.export().expect("export array");
+        array.null_count = -1;
+
+        // SAFETY: The exported structures retain the child values and validity
+        // buffer for the imported array's lifetime.
+        let imported: Array<Option<[i32; 2]>, SliceBuffer<'_>> =
+            unsafe { Import::import(&array, &schema) }.expect("import array");
+
+        let imported_layout = imported.buffer_ref();
+        let imported_validity = imported_layout.buffer_ref();
+        let imported_bitmap = imported_validity.bitmap_ref().expect("validity bitmap");
+        let imported_validity_values: &[u8] = imported_bitmap.buffer_ref().borrow();
+        let imported_values: &[i32] = imported_validity
+            .child_ref()
+            .child_ref()
+            .buffer_ref()
+            .borrow();
+        assert_eq!(imported.owned(0), Some(Some([1, 2])));
+        assert_eq!(imported.owned(1), Some(None));
+        assert_eq!(imported_validity_values.as_ptr(), validity_data);
+        assert_eq!(imported_values.as_ptr(), values_data);
+    }
+
+    #[test]
+    fn preserves_omitted_fixed_size_list_validity() {
+        let source = [Some([1_i32, 2]), Some([3, 4])]
+            .into_iter()
+            .collect::<Array<Option<[i32; 2]>>>();
+        let (mut array, schema) = source.export().expect("export array");
+        // SAFETY: The exported array owns a one-entry buffer pointer array.
+        unsafe { *array.buffers.cast_mut() = ptr::null() };
+        array.null_count = 0;
+
+        // SAFETY: The omitted validity buffer is permitted for an array with
+        // no null items, and the exported child remains live.
+        let imported: Array<Option<[i32; 2]>, SliceBuffer<'_>> =
+            unsafe { Import::import(&array, &schema) }.expect("import array");
+
+        assert!(imported.buffer_ref().buffer_ref().bitmap_ref().is_none());
+        assert_eq!(imported.owned(0), Some(Some([1, 2])));
+        assert_eq!(imported.owned(1), Some(Some([3, 4])));
     }
 
     #[test]


### PR DESCRIPTION
- generalize fixed-size-list import over the existing type-level nullability abstraction
- borrow parent validity and child value buffers without copying
- preserve omitted validity for arrays without null items