### PR TITLE
fix: clippy complexity warning about unused lifetime

### DIFF
--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -426,7 +426,7 @@ pub(crate) mod tests {
 
     pub(crate) fn round_trip<
         C: for<'any> CollectionAlloc<Owned = T, View<'any>: Debug>,
-        T: for<'this, 'other> AsView<'this, View: Debug> + Clone + Default + Debug + PartialEq,
+        T: for<'this> AsView<'this, View: Debug> + Clone + Default + Debug + PartialEq,
     >(
         items: impl IntoIterator<Item = T>,
     ) {


### PR DESCRIPTION
```
error: this lifetime isn't used in the type
   --> src/collection/mod.rs:429:23
    |
429 |         T: for<'this, 'other> AsView<'this, View: Debug> + Clone + Default + Debug + PartialEq,
    |                       ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#extra_unused_lifetimes
note: the lint level is defined here
   --> src/lib.rs:21:5
    |
 21 |     clippy::complexity,
    |     ^^^^^^^^^^^^^^^^^^
    = note: `#[deny(clippy::extra_unused_lifetimes)]` implied by `#[deny(clippy::complexity)]`
```